### PR TITLE
feat: add P14A2 bounded result export pages

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -503,21 +503,36 @@ snapshot_token, ranking_snapshot_token } }`.
   response text, supplementary information, option document metadata/URL,
   option citations and manual-assessment axes/notes/revisions. The
   `ranking_snapshot_token` is the exact token produced by the existing P12C1
-  ranking contract for the same complete dossier/baseline universe.
+  ranking contract for the same complete dossier/baseline universe. P14A2
+  sources that token directly from the shared private token helper; a ranking
+  page must not execute the public paged P12C1 RPC before computing its rows.
 - `technical_configuration_result_export_ranking_list` request extends the
   manifest scope with `p_page`, `p_page_size`. It delegates ranking semantics to
   the existing P12C1 contract and returns
   `{ data, dossier_id, baseline_version_id, snapshot_token,
-ranking_snapshot_token, total, page, page_size }`. Page size is 1-100.
+ranking_snapshot_token, total, page, page_size }`. Page size is 1-100. Each item
+  is exactly
+  `{ option_id, supplier_id, supplier_name, display_label, eligibility,
+incomplete_criterion_count, failed_count, insufficient_evidence_count,
+exceeds_count, rank }`. Ranking is computed over the complete P12C1
+  dossier/baseline universe before filtering to the validated option scope, so
+  selected exports preserve complete-universe rank and counters.
 - `technical_configuration_result_export_matrix_list` request extends the
   manifest scope with `p_page`, `p_page_size`. It returns flattened canonical
-  `(criterion, option)` cells ordered by group/criterion then canonical option,
+  `(criterion, option)` cells ordered by validated criterion ordinality then
+  validated option ordinality,
   with `total`, `page`, `page_size`, exact scope IDs and the same two tokens.
-  Page size is 1-1000. Each cell contains criterion/group context, option
-  identity, nullable response, supplementary information, exact option
-  document/citation links for that criterion, nullable manual-assessment axes
-  and notes, and the derived seven-status conclusion. Reference products and
-  baseline-only evidence are excluded from option columns.
+  Page size is 1-1000. Each cell is exactly
+  `{ group_id, group_name, group_order, criterion_id, criterion_code,
+criterion_title, requirement_text, criterion_order, option_id, supplier_id,
+supplier_name, display_label, model, manufacturer, option_name, response_text,
+supplementary_information, document_links, technical_axis, evidence_axis,
+assessment_notes, conclusion }`. Each `document_links` item is exactly
+  `{ document_id, document_name, document_url, citation_id, page_section,
+excerpt }`. Missing comparison sets, responses and assessments produce nullable
+  scalar values; missing criterion citations produce `document_links: []`.
+  `conclusion` is one of the exact P12C1-derived seven statuses. Reference
+  products and baseline-only evidence are excluded from option columns.
 - P14 export RPCs are side-effect-free. They never call comparison-set
   get-or-create, never create missing rows, never increment dossier/baseline/
   comparison/assessment revisions and never alter audit metadata. Missing

--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -532,7 +532,9 @@ assessment_notes, conclusion }`. Each `document_links` item is exactly
 excerpt }`. Missing comparison sets, responses and assessments produce nullable
   scalar values; missing criterion citations produce `document_links: []`.
   `conclusion` is one of the exact P12C1-derived seven statuses. Reference
-  products and baseline-only evidence are excluded from option columns.
+  products and baseline-only evidence are excluded from option columns. The
+  ranking and matrix surfaces use the same private immutable derived-status and
+  option-display-label helpers so their precedence and labels cannot drift.
 - P14 export RPCs are side-effect-free. They never call comparison-set
   get-or-create, never create missing rows, never increment dossier/baseline/
   comparison/assessment revisions and never alter audit metadata. Missing

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3005,8 +3005,12 @@ tokens without changing any revision, audit state or data row.
 
 ### Planned files
 
-- Create at execution time after migration-order inspection:
-  `supabase/migrations/<timestamp>_technical_configuration_result_export_pages.sql`
+- Create at execution time after migration-order and file-ceiling inspection:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_ranking_source.sql`
+- Create immediately after the ranking migration:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_snapshot_token_source.sql`
+- Create immediately after the snapshot-token migration:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_matrix_page.sql`
 - Create:
   `src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts`
 - Create:
@@ -3018,14 +3022,16 @@ tokens without changing any revision, audit state or data row.
 
 ### Tasks
 
-- [ ] Write RED SQL/source tests for exact ranking and flattened matrix payloads,
+- [x] Write RED SQL/source tests for exact ranking and flattened matrix payloads,
       pagination bounds, canonical order, repeated scope/totals/tokens and
       missing-data empty/null semantics.
-- [ ] Reuse P12C1 ranking semantics instead of implementing a second ranking
+- [x] Reuse P12C1 ranking semantics instead of implementing a second ranking
       algorithm.
-- [ ] Implement set-based read-only ranking and matrix RPCs over the P14A1
+- [x] Re-source the P14A1 private snapshot token through the shared token helper
+      so a ranking page performs no preliminary paged P12C1 full-universe scan.
+- [x] Implement set-based read-only ranking and matrix RPCs over the P14A1
       snapshot helper with no get-or-create or per-cell query loop.
-- [ ] Prove reference products and baseline-only evidence never enter option
+- [x] Prove reference products and baseline-only evidence never enter option
       columns, and every returned cell belongs to the requested dossier,
       baseline, option and criterion scope.
 - [ ] Apply and phase-gate only after explicit live DB approval; run focused

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3029,6 +3029,8 @@ tokens without changing any revision, audit state or data row.
       algorithm.
 - [x] Re-source the P14A1 private snapshot token through the shared token helper
       so a ranking page performs no preliminary paged P12C1 full-universe scan.
+- [x] Share immutable option-display-label and derived-status expressions across
+      the active P12C1 ranking and P14A2 matrix definitions.
 - [x] Implement set-based read-only ranking and matrix RPCs over the P14A1
       snapshot helper with no get-or-create or per-cell query loop.
 - [x] Prove reference products and baseline-only evidence never enter option

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3011,6 +3011,8 @@ tokens without changing any revision, audit state or data row.
   `supabase/migrations/<timestamp>_technical_configuration_result_export_snapshot_token_source.sql`
 - Create immediately after the snapshot-token migration:
   `supabase/migrations/<timestamp>_technical_configuration_result_export_matrix_page.sql`
+- Create after live advisor feedback:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_helper_search_path.sql`
 - Create:
   `src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts`
 - Create:
@@ -3031,12 +3033,14 @@ tokens without changing any revision, audit state or data row.
       so a ranking page performs no preliminary paged P12C1 full-universe scan.
 - [x] Share immutable option-display-label and derived-status expressions across
       the active P12C1 ranking and P14A2 matrix definitions.
+- [x] Pin both shared immutable helpers to `search_path = pg_catalog` in the
+      fresh-DB source and a live superseding migration.
 - [x] Implement set-based read-only ranking and matrix RPCs over the P14A1
       snapshot helper with no get-or-create or per-cell query loop.
 - [x] Prove reference products and baseline-only evidence never enter option
       columns, and every returned cell belongs to the requested dossier,
       baseline, option and criterion scope.
-- [ ] Apply and phase-gate only after explicit live DB approval; run focused
+- [x] Apply and phase-gate only after explicit live DB approval; run focused
       authorization, plan/bounds and advisor checks.
 
 ### Exit gate

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -246,9 +246,11 @@ ranking_snapshot_token, total, page, page_size }`.
 2. Delegate ranking semantics to the P12C1 contract.
 3. Re-source the P14A1 private snapshot ranking token through the shared token
    helper so ranking pages do not trigger a preliminary paged P12C1 scan.
-4. Return only selected fields with bounded pages and deterministic keys.
-5. Add only the two P14A2 names to the manifest/allowlist.
-6. Run focused migration/whitelist tests and confirm green.
+4. Share immutable option-display-label and derived-status helpers between the
+   active ranking and matrix definitions.
+5. Return only selected fields with bounded pages and deterministic keys.
+6. Add only the two P14A2 names to the manifest/allowlist.
+7. Run focused migration/whitelist tests and confirm green.
 
 ### Refactor And Gate
 
@@ -277,16 +279,21 @@ workbook, UI or download.
   snapshot is superseded without changing its signature and now obtains the
   exact ranking token directly from the shared token helper. Matrix work is
   set-based over P14A1 validated IDs and pages cells before evidence joins.
+  Private immutable helpers now keep option labels and seven-status precedence
+  identical across the active ranking and matrix definitions.
 - The implementation is split across three ordered migrations to preserve
   applied P14A1 history and keep every source file below the mandatory
   450-line ceiling.
 - The rollback-only phase gate covers non-empty second pages, repeated metadata
   and tokens, complete ACLs, raw `admin` authorization and an actual
-  `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` bounded-call execution seam.
+  `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` wrapper-execution seam plus
+  source-level no-loop/get-or-create/page-limit guards.
 - Independent re-review resolved both initial Important findings and ended with
-  zero Critical/Important findings. The accepted residual limitation is that
-  the outer PL/pgSQL plan exposes aggregate execution/buffer/temp-spill
-  evidence, not internal statement plan nodes.
+  zero Critical/Important findings. PR review then correctly rejected the
+  outer-plan no-spill claim and identified shared-expression drift risk; RED
+  tests now lock the corrected evidence wording and shared helpers. The outer
+  PL/pgSQL plan still does not expose internal statement plan nodes or prove
+  their temporary-spill behavior.
 - Live apply, rollback-only execution and advisor evidence remain pending
   explicit approval for that exact live DB write.
 

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -192,6 +192,8 @@ workbook, UI or download.
   `supabase/migrations/<timestamp>_technical_configuration_result_export_snapshot_token_source.sql`
 - Create immediately after the snapshot-token migration:
   `supabase/migrations/<timestamp>_technical_configuration_result_export_matrix_page.sql`
+- Create after live advisor feedback:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_helper_search_path.sql`
 - Create:
   `src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts`
 - Create:
@@ -264,7 +266,7 @@ ranking_snapshot_token, total, page, page_size }`.
 **Deploy boundary:** two dormant read-only page RPCs; no adapter, collector,
 workbook, UI or download.
 
-### P14A2 Local Execution Evidence - 2026-08-02
+### P14A2 Execution Evidence - 2026-08-02
 
 - Read-only Supabase MCP inspection confirmed live P14A1 migration
   `20260802073104`, expected helper/function metadata and absence of both P14A2
@@ -281,9 +283,11 @@ workbook, UI or download.
   set-based over P14A1 validated IDs and pages cells before evidence joins.
   Private immutable helpers now keep option labels and seven-status precedence
   identical across the active ranking and matrix definitions.
-- The implementation is split across three ordered migrations to preserve
+- The implementation is split across four ordered migrations to preserve
   applied P14A1 history and keep every source file below the mandatory
-  450-line ceiling.
+  450-line ceiling. The fourth migration supersedes the already-applied helper
+  definitions by pinning `search_path = pg_catalog`; the first migration carries
+  the same setting for fresh databases.
 - The rollback-only phase gate covers non-empty second pages, repeated metadata
   and tokens, complete ACLs, raw `admin` authorization and an actual
   `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` wrapper-execution seam plus
@@ -294,8 +298,17 @@ workbook, UI or download.
   tests now lock the corrected evidence wording and shared helpers. The outer
   PL/pgSQL plan still does not expose internal statement plan nodes or prove
   their temporary-spill behavior.
-- Live apply, rollback-only execution and advisor evidence remain pending
-  explicit approval for that exact live DB write.
+- Supabase MCP applied the four repository migrations as live versions
+  `20260802111235`, `20260802111352`, `20260802111437` and `20260802112335`.
+  The first live gate attempt correctly rolled back when its fixture violated
+  the deployed non-null `supplementary_information` contract; the corrected
+  fixture uses the column's empty-string default semantics.
+- The corrected rollback-only phase gate passed authorization, bounds, ranking,
+  matrix, token, source-plan and read-only assertions twice, including the
+  superseding helper `search_path` check. Post-gate fixture counts remain zero.
+- Security/performance advisors were rerun after the superseding migration. The
+  P14A2 helper search-path warning is resolved; remaining notices are pre-existing
+  baseline findings outside this leaf.
 
 ## P14A3 - Typed Export Adapters And Stable Dataset Collector
 

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -186,8 +186,12 @@ workbook, UI or download.
 
 ### Planned Files
 
-- Create at execution time after migration-order inspection:
-  `supabase/migrations/<timestamp>_technical_configuration_result_export_pages.sql`
+- Create at execution time after migration-order and file-ceiling inspection:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_ranking_source.sql`
+- Create immediately after the ranking migration:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_snapshot_token_source.sql`
+- Create immediately after the snapshot-token migration:
+  `supabase/migrations/<timestamp>_technical_configuration_result_export_matrix_page.sql`
 - Create:
   `src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts`
 - Create:
@@ -196,6 +200,33 @@ workbook, UI or download.
 - Modify:
   `src/app/api/rpc/__tests__/technical-configuration-result-export-rpc-whitelist.test.ts`
 - Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+
+### Locked Page Contracts
+
+- Both requests are exactly
+  `{ p_dossier_id, p_baseline_version_id, p_option_ids, p_criterion_ids,
+p_page, p_page_size }` and reuse P14A1 scope validation.
+- Ranking page size is 1-100. Its exact item is
+  `{ option_id, supplier_id, supplier_name, display_label, eligibility,
+incomplete_criterion_count, failed_count, insufficient_evidence_count,
+exceeds_count, rank }`.
+- Ranking counters/ranks are computed once over the complete P12C1
+  dossier/baseline universe, then filtered to the validated option scope and
+  paginated in P12C1 presentation order. Criterion scope does not redefine
+  ranking semantics.
+- Matrix page size is 1-1000. Cells are ordered by validated criterion
+  ordinality, then option ordinality. Each exact cell is
+  `{ group_id, group_name, group_order, criterion_id, criterion_code,
+criterion_title, requirement_text, criterion_order, option_id, supplier_id,
+supplier_name, display_label, model, manufacturer, option_name, response_text,
+supplementary_information, document_links, technical_axis, evidence_axis,
+assessment_notes, conclusion }`.
+- Each `document_links` item is exactly
+  `{ document_id, document_name, document_url, citation_id, page_section,
+excerpt }`. Missing rows return nullable scalar fields and `document_links: []`.
+- Both responses are exactly
+  `{ data, dossier_id, baseline_version_id, snapshot_token,
+ranking_snapshot_token, total, page, page_size }`.
 
 ### RED
 
@@ -213,9 +244,11 @@ workbook, UI or download.
 
 1. Add set-based ranking and matrix list RPCs over the P14A1 helper.
 2. Delegate ranking semantics to the P12C1 contract.
-3. Return only selected fields with bounded pages and deterministic keys.
-4. Add only the two P14A2 names to the manifest/allowlist.
-5. Run focused migration/whitelist tests and confirm green.
+3. Re-source the P14A1 private snapshot ranking token through the shared token
+   helper so ranking pages do not trigger a preliminary paged P12C1 scan.
+4. Return only selected fields with bounded pages and deterministic keys.
+5. Add only the two P14A2 names to the manifest/allowlist.
+6. Run focused migration/whitelist tests and confirm green.
 
 ### Refactor And Gate
 
@@ -228,6 +261,34 @@ workbook, UI or download.
 
 **Deploy boundary:** two dormant read-only page RPCs; no adapter, collector,
 workbook, UI or download.
+
+### P14A2 Local Execution Evidence - 2026-08-02
+
+- Read-only Supabase MCP inspection confirmed live P14A1 migration
+  `20260802073104`, expected helper/function metadata and absence of both P14A2
+  RPCs before implementation.
+- Initial RED source/allowlist tests failed only because the page migrations,
+  phase gate and RPC names did not exist. Review RED then proved the snapshot
+  helper still invoked paged P12C1 before the export ranking source and that
+  the plan seam did not execute the function body; both regressions are now
+  locked by focused GREEN tests.
+- Ranking semantics live in one private set-returning source shared by the
+  backward-compatible P12C1 RPC and the scoped export page. The P14A1 private
+  snapshot is superseded without changing its signature and now obtains the
+  exact ranking token directly from the shared token helper. Matrix work is
+  set-based over P14A1 validated IDs and pages cells before evidence joins.
+- The implementation is split across three ordered migrations to preserve
+  applied P14A1 history and keep every source file below the mandatory
+  450-line ceiling.
+- The rollback-only phase gate covers non-empty second pages, repeated metadata
+  and tokens, complete ACLs, raw `admin` authorization and an actual
+  `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` bounded-call execution seam.
+- Independent re-review resolved both initial Important findings and ended with
+  zero Critical/Important findings. The accepted residual limitation is that
+  the outer PL/pgSQL plan exposes aggregate execution/buffer/temp-spill
+  evidence, not internal statement plan nodes.
+- Live apply, rollback-only execution and advisor evidence remain pending
+  explicit approval for that exact live DB write.
 
 ## P14A3 - Typed Export Adapters And Stable Dataset Collector
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -871,7 +871,8 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       repeated scope/totals/tokens và empty/null semantics bằng RED tests.
 - [x] P14A2.2 Reuse P12C1 ranking semantics; thêm set-based read-only matrix
       contract, không tạo ranking algorithm/query loop song song và không chạy
-      paged P12C1 lần hai chỉ để lấy ranking token.
+      paged P12C1 lần hai chỉ để lấy ranking token; dùng chung immutable helper
+      cho option display label và derived status.
 - [ ] P14A2.3 Thêm hai RPC names vào manifest/allowlist và phase-gate
       authorization, bounds, query plan sau explicit live approval.
 - [x] P14A2.4 Xác minh không có client/UI/workbook/download trong leaf.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -873,7 +873,7 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       contract, không tạo ranking algorithm/query loop song song và không chạy
       paged P12C1 lần hai chỉ để lấy ranking token; dùng chung immutable helper
       cho option display label và derived status.
-- [ ] P14A2.3 Thêm hai RPC names vào manifest/allowlist và phase-gate
+- [x] P14A2.3 Thêm hai RPC names vào manifest/allowlist và phase-gate
       authorization, bounds, query plan sau explicit live approval.
 - [x] P14A2.4 Xác minh không có client/UI/workbook/download trong leaf.
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -867,13 +867,14 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14A2 - Paginated Export Ranking And Matrix Contracts
 
-- [ ] P14A2.1 Khóa exact ranking/matrix payload, pagination, canonical order,
+- [x] P14A2.1 Khóa exact ranking/matrix payload, pagination, canonical order,
       repeated scope/totals/tokens và empty/null semantics bằng RED tests.
-- [ ] P14A2.2 Reuse P12C1 ranking semantics; thêm set-based read-only matrix
-      contract, không tạo ranking algorithm hoặc query loop song song.
+- [x] P14A2.2 Reuse P12C1 ranking semantics; thêm set-based read-only matrix
+      contract, không tạo ranking algorithm/query loop song song và không chạy
+      paged P12C1 lần hai chỉ để lấy ranking token.
 - [ ] P14A2.3 Thêm hai RPC names vào manifest/allowlist và phase-gate
       authorization, bounds, query plan sau explicit live approval.
-- [ ] P14A2.4 Xác minh không có client/UI/workbook/download trong leaf.
+- [x] P14A2.4 Xác minh không có client/UI/workbook/download trong leaf.
 
 ## Phase P14A3 - Typed Export Adapters And Stable Dataset Collector
 

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
@@ -52,6 +52,14 @@ const snapshotMigrationSource = readIfExists(SNAPSHOT_MIGRATION_PATH)
 const matrixMigrationSource = readIfExists(MATRIX_MIGRATION_PATH)
 const migrationSource = `${rankingMigrationSource}\n${snapshotMigrationSource}\n${matrixMigrationSource}`
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const optionDisplayLabelBlock = getFunctionBlock(
+  rankingMigrationSource,
+  "_technical_configuration_option_display_label"
+)
+const derivedStatusBlock = getFunctionBlock(
+  rankingMigrationSource,
+  "_technical_configuration_derived_status"
+)
 const rankingSnapshotBlock = getFunctionBlock(
   migrationSource,
   "_technical_configuration_reference_ranking_snapshot"
@@ -144,6 +152,39 @@ describe("P14A2 technical configuration result export page migration", () => {
     expect(exportRankingBlock).not.toContain("public.technical_configuration_manual_assessments")
   })
 
+  it("shares option labels and derived statuses across ranking and matrix surfaces", () => {
+    expect(optionDisplayLabelBlock).toContain(
+      "_technical_configuration_option_display_label(\n" +
+        "  p_supplier_name TEXT,\n" +
+        "  p_model TEXT,\n" +
+        "  p_option_name TEXT"
+    )
+    expect(optionDisplayLabelBlock).toContain("LANGUAGE sql\nIMMUTABLE")
+    expect(derivedStatusBlock).toContain(
+      "_technical_configuration_derived_status(\n" +
+        "  p_technical_axis TEXT,\n" +
+        "  p_evidence_axis TEXT"
+    )
+    expect(derivedStatusBlock).toContain("LANGUAGE sql\nIMMUTABLE")
+    for (const marker of [
+      "THEN 'not_evaluated'",
+      "THEN 'not_applicable'",
+      "THEN 'fails'",
+      "THEN 'unclear'",
+      "THEN 'insufficient_evidence'",
+      "ELSE p_technical_axis",
+    ]) {
+      expect(derivedStatusBlock).toContain(marker)
+    }
+    for (const functionBlock of [rankingSnapshotBlock, exportMatrixBlock]) {
+      expect(functionBlock).toContain("public._technical_configuration_option_display_label(")
+      expect(functionBlock).toContain("public._technical_configuration_derived_status(")
+      expect(functionBlock).not.toContain("supplier.name || ' ' || chr(183)")
+    }
+    expect(rankingSnapshotBlock).toContain("WHEN criterion.criterion_id IS NULL THEN NULL")
+    expect(exportMatrixBlock).not.toContain("WHEN assessment.technical_axis")
+  })
+
   it("reuses the exact ranking token without running the paged P12C1 RPC inside the snapshot", () => {
     expect(exportSnapshotBlock).toMatch(
       /v_ranking_snapshot_token :=\s+public\._technical_configuration_reference_ranking_token\(/
@@ -197,13 +238,9 @@ describe("P14A2 technical configuration result export page migration", () => {
       "LEFT JOIN public.technical_configuration_manual_assessments"
     )
     expect(exportMatrixBlock).toContain("COALESCE(evidence.document_links, '[]'::JSONB)")
-    expect(exportMatrixBlock).toContain("WHEN assessment.technical_axis IS NULL")
-    expect(exportMatrixBlock).toContain("THEN 'not_evaluated'")
-    expect(exportMatrixBlock).toContain("THEN 'not_applicable'")
-    expect(exportMatrixBlock).toContain("THEN 'fails'")
-    expect(exportMatrixBlock).toContain("THEN 'unclear'")
-    expect(exportMatrixBlock).toContain("THEN 'insufficient_evidence'")
-    expect(exportMatrixBlock).toContain("ELSE assessment.technical_axis")
+    expect(exportMatrixBlock).toContain(
+      "'conclusion', public._technical_configuration_derived_status("
+    )
     expect(
       getObjectKeys(
         exportMatrixBlock,
@@ -278,6 +315,9 @@ describe("P14A2 technical configuration result export page migration", () => {
     )
     expect(migrationSource).toContain("TO service_role;")
     for (const functionName of [
+      "_technical_configuration_option_display_label",
+      "_technical_configuration_derived_status",
+      "_technical_configuration_reference_ranking_snapshot",
       "technical_configuration_reference_ranking_list",
       "technical_configuration_result_export_ranking_list",
       "technical_configuration_result_export_matrix_list",
@@ -303,7 +343,7 @@ describe("P14A2 technical configuration result export page migration", () => {
       "matrix non-empty second page stays stable",
       "ranking page beyond end stays stable",
       "matrix page beyond end stays stable",
-      "matrix bounded call executes without temporary spill",
+      "matrix bounded wrapper executes and source stays set-based",
       "result export pages remain read-only",
       "P12C1 response remains backward compatible",
       "matrix PUBLIC execute revoked",
@@ -313,6 +353,7 @@ describe("P14A2 technical configuration result export page migration", () => {
       "ranking token helper anon execute revoked",
       "ranking token helper authenticated execute revoked",
       "ranking token helper service role execute granted",
+      "shared expression helpers are immutable and service-only",
       "raw admin role remains authorized",
     ]) {
       expect(phaseGateSource).toContain(marker)
@@ -321,5 +362,6 @@ describe("P14A2 technical configuration result export page migration", () => {
     expect(phaseGateSource).not.toContain(
       "EXPLAIN (FORMAT JSON) SELECT public.technical_configuration_result_export_matrix_list"
     )
+    expect(phaseGateSource).not.toContain('"Temp (Read|Written) Blocks"')
   })
 })

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
@@ -11,9 +11,15 @@ const RANKING_MIGRATION_FILE =
 const SNAPSHOT_MIGRATION_FILE =
   "20260802092215_technical_configuration_result_export_snapshot_token_source.sql"
 const MATRIX_MIGRATION_FILE = "20260802092216_technical_configuration_result_export_matrix_page.sql"
+const HELPER_SEARCH_PATH_MIGRATION_FILE =
+  "20260802092217_technical_configuration_result_export_helper_search_path.sql"
 const RANKING_MIGRATION_PATH = path.join(MIGRATIONS_DIR, RANKING_MIGRATION_FILE)
 const SNAPSHOT_MIGRATION_PATH = path.join(MIGRATIONS_DIR, SNAPSHOT_MIGRATION_FILE)
 const MATRIX_MIGRATION_PATH = path.join(MIGRATIONS_DIR, MATRIX_MIGRATION_FILE)
+const HELPER_SEARCH_PATH_MIGRATION_PATH = path.join(
+  MIGRATIONS_DIR,
+  HELPER_SEARCH_PATH_MIGRATION_FILE
+)
 const PHASE_GATE_PATH = path.join(
   REPO_ROOT,
   "supabase/tests/technical_configuration_result_export_pages_phase_gate.sql"
@@ -50,7 +56,8 @@ function getObjectKeys(source: string, startMarker: string, endMarker: string): 
 const rankingMigrationSource = readIfExists(RANKING_MIGRATION_PATH)
 const snapshotMigrationSource = readIfExists(SNAPSHOT_MIGRATION_PATH)
 const matrixMigrationSource = readIfExists(MATRIX_MIGRATION_PATH)
-const migrationSource = `${rankingMigrationSource}\n${snapshotMigrationSource}\n${matrixMigrationSource}`
+const helperSearchPathMigrationSource = readIfExists(HELPER_SEARCH_PATH_MIGRATION_PATH)
+const migrationSource = `${rankingMigrationSource}\n${snapshotMigrationSource}\n${matrixMigrationSource}\n${helperSearchPathMigrationSource}`
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
 const optionDisplayLabelBlock = getFunctionBlock(
   rankingMigrationSource,
@@ -97,9 +104,13 @@ describe("P14A2 technical configuration result export page migration", () => {
     expect(RANKING_MIGRATION_FILE.localeCompare(LATEST_DEPENDENCY_MIGRATION)).toBeGreaterThan(0)
     expect(SNAPSHOT_MIGRATION_FILE.localeCompare(RANKING_MIGRATION_FILE)).toBeGreaterThan(0)
     expect(MATRIX_MIGRATION_FILE.localeCompare(SNAPSHOT_MIGRATION_FILE)).toBeGreaterThan(0)
+    expect(HELPER_SEARCH_PATH_MIGRATION_FILE.localeCompare(MATRIX_MIGRATION_FILE)).toBeGreaterThan(
+      0
+    )
     expect(rankingMigrationSource).not.toBe("")
     expect(snapshotMigrationSource).not.toBe("")
     expect(matrixMigrationSource).not.toBe("")
+    expect(helperSearchPathMigrationSource).not.toBe("")
     expect(phaseGateSource).toContain("BEGIN;")
     expect(phaseGateSource).toContain("ROLLBACK;")
     expect(phaseGateSource).not.toContain("COMMIT;")
@@ -160,12 +171,15 @@ describe("P14A2 technical configuration result export page migration", () => {
         "  p_option_name TEXT"
     )
     expect(optionDisplayLabelBlock).toContain("LANGUAGE sql\nIMMUTABLE")
+    expect(optionDisplayLabelBlock).toContain("SET search_path = pg_catalog")
     expect(derivedStatusBlock).toContain(
       "_technical_configuration_derived_status(\n" +
         "  p_technical_axis TEXT,\n" +
         "  p_evidence_axis TEXT"
     )
     expect(derivedStatusBlock).toContain("LANGUAGE sql\nIMMUTABLE")
+    expect(derivedStatusBlock).toContain("SET search_path = pg_catalog")
+    expect(helperSearchPathMigrationSource.match(/SET search_path = pg_catalog/g)).toHaveLength(2)
     for (const marker of [
       "THEN 'not_evaluated'",
       "THEN 'not_applicable'",

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-pages-migration.test.ts
@@ -1,0 +1,325 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const LATEST_DEPENDENCY_MIGRATION =
+  "20260802054948_technical_configuration_result_export_manifest.sql"
+const RANKING_MIGRATION_FILE =
+  "20260802092214_technical_configuration_result_export_ranking_source.sql"
+const SNAPSHOT_MIGRATION_FILE =
+  "20260802092215_technical_configuration_result_export_snapshot_token_source.sql"
+const MATRIX_MIGRATION_FILE = "20260802092216_technical_configuration_result_export_matrix_page.sql"
+const RANKING_MIGRATION_PATH = path.join(MIGRATIONS_DIR, RANKING_MIGRATION_FILE)
+const SNAPSHOT_MIGRATION_PATH = path.join(MIGRATIONS_DIR, SNAPSHOT_MIGRATION_FILE)
+const MATRIX_MIGRATION_PATH = path.join(MIGRATIONS_DIR, MATRIX_MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_result_export_pages_phase_gate.sql"
+)
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const marker = `CREATE OR REPLACE FUNCTION public.${functionName}(`
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const end = source.indexOf("\n$$;", start + marker.length)
+  return source.slice(start, end === -1 ? source.length : end)
+}
+
+function getObjectKeys(source: string, startMarker: string, endMarker: string): string[] {
+  const start = source.indexOf(startMarker)
+  if (start === -1) return []
+
+  const contentStart = start + startMarker.length
+  const end = source.indexOf(endMarker, contentStart)
+  if (end === -1) return []
+
+  const markerKey = startMarker.match(/'([a-z_]+)'/)?.[1]
+  const remainingKeys = [...source.slice(contentStart, end).matchAll(/^\s*'([a-z_]+)',/gm)].map(
+    (match) => match[1]
+  )
+  return markerKey ? [markerKey, ...remainingKeys] : remainingKeys
+}
+
+const rankingMigrationSource = readIfExists(RANKING_MIGRATION_PATH)
+const snapshotMigrationSource = readIfExists(SNAPSHOT_MIGRATION_PATH)
+const matrixMigrationSource = readIfExists(MATRIX_MIGRATION_PATH)
+const migrationSource = `${rankingMigrationSource}\n${snapshotMigrationSource}\n${matrixMigrationSource}`
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const rankingSnapshotBlock = getFunctionBlock(
+  migrationSource,
+  "_technical_configuration_reference_ranking_snapshot"
+)
+const referenceRankingBlock = getFunctionBlock(
+  migrationSource,
+  "technical_configuration_reference_ranking_list"
+)
+const exportRankingBlock = getFunctionBlock(
+  migrationSource,
+  "technical_configuration_result_export_ranking_list"
+)
+const exportSnapshotBlock = getFunctionBlock(
+  snapshotMigrationSource,
+  "_technical_configuration_result_export_snapshot"
+)
+const exportMatrixBlock = getFunctionBlock(
+  migrationSource,
+  "technical_configuration_result_export_matrix_list"
+)
+
+const rankingResponseKeys = [
+  "data",
+  "dossier_id",
+  "baseline_version_id",
+  "snapshot_token",
+  "ranking_snapshot_token",
+  "total",
+  "page",
+  "page_size",
+]
+
+describe("P14A2 technical configuration result export page migration", () => {
+  it("sorts all bounded migrations after P14A1 and ships one rollback-only phase gate", () => {
+    expect(RANKING_MIGRATION_FILE.localeCompare(LATEST_DEPENDENCY_MIGRATION)).toBeGreaterThan(0)
+    expect(SNAPSHOT_MIGRATION_FILE.localeCompare(RANKING_MIGRATION_FILE)).toBeGreaterThan(0)
+    expect(MATRIX_MIGRATION_FILE.localeCompare(SNAPSHOT_MIGRATION_FILE)).toBeGreaterThan(0)
+    expect(rankingMigrationSource).not.toBe("")
+    expect(snapshotMigrationSource).not.toBe("")
+    expect(matrixMigrationSource).not.toBe("")
+    expect(phaseGateSource).toContain("BEGIN;")
+    expect(phaseGateSource).toContain("ROLLBACK;")
+    expect(phaseGateSource).not.toContain("COMMIT;")
+  })
+
+  it("freezes the private ranking source and both exact public page signatures", () => {
+    expect(rankingSnapshotBlock).toContain(
+      "_technical_configuration_reference_ranking_snapshot(\n" +
+        "  p_dossier_id UUID,\n" +
+        "  p_baseline_version_id UUID"
+    )
+    for (const functionBlock of [exportRankingBlock, exportMatrixBlock]) {
+      expect(functionBlock).toContain(
+        "  p_dossier_id UUID,\n" +
+          "  p_baseline_version_id UUID,\n" +
+          "  p_option_ids UUID[],\n" +
+          "  p_criterion_ids UUID[],\n" +
+          "  p_page INTEGER,\n" +
+          "  p_page_size INTEGER"
+      )
+      expect(functionBlock).toContain("RETURNS JSONB")
+      expect(functionBlock).toContain("LANGUAGE plpgsql\nSTABLE\nSECURITY DEFINER")
+      expect(functionBlock).toContain("SET search_path = public, pg_temp")
+      expect(functionBlock).toContain(
+        "PERFORM public._technical_configuration_require_global_user()"
+      )
+      expect(functionBlock).toContain("public._technical_configuration_result_export_snapshot(")
+    }
+  })
+
+  it("extracts P12C1 ranking semantics once and delegates both public ranking surfaces", () => {
+    expect(rankingSnapshotBlock).toContain("DENSE_RANK() OVER")
+    expect(rankingSnapshotBlock).toContain(
+      "COUNT(*) FILTER (WHERE scored.derived_status = 'fails')"
+    )
+    expect(rankingSnapshotBlock).toContain(
+      "COUNT(*) FILTER (WHERE scored.derived_status = 'insufficient_evidence')"
+    )
+    expect(rankingSnapshotBlock).toContain(
+      "COUNT(*) FILTER (WHERE scored.derived_status = 'exceeds')"
+    )
+    expect(referenceRankingBlock).toContain(
+      "public._technical_configuration_reference_ranking_snapshot("
+    )
+    expect(exportRankingBlock).toContain(
+      "public._technical_configuration_reference_ranking_snapshot("
+    )
+    expect(migrationSource.match(/DENSE_RANK\(\) OVER/g)).toHaveLength(1)
+    expect(referenceRankingBlock).not.toContain("public.technical_configuration_manual_assessments")
+    expect(exportRankingBlock).not.toContain("public.technical_configuration_manual_assessments")
+  })
+
+  it("reuses the exact ranking token without running the paged P12C1 RPC inside the snapshot", () => {
+    expect(exportSnapshotBlock).toMatch(
+      /v_ranking_snapshot_token :=\s+public\._technical_configuration_reference_ranking_token\(/
+    )
+    expect(exportSnapshotBlock).toContain("'ranking_snapshot_token', v_ranking_snapshot_token")
+    expect(exportSnapshotBlock).not.toContain(
+      "public.technical_configuration_reference_ranking_list("
+    )
+  })
+
+  it("locks bounded scoped ranking pages with exact P12C1 row keys and repeated tokens", () => {
+    expect(exportRankingBlock).toContain(
+      "p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100"
+    )
+    expect(exportRankingBlock).toContain("WITH ORDINALITY")
+    expect(exportRankingBlock).toContain(
+      "JOIN selected_options selected ON selected.option_id = ranking.option_id"
+    )
+    expect(exportRankingBlock).toMatch(/OFFSET \(p_page - 1\)::BIGINT \* p_page_size/)
+    expect(getObjectKeys(exportRankingBlock, "RETURN jsonb_build_object(", "\n  );\nEND;")).toEqual(
+      rankingResponseKeys
+    )
+    expect(
+      getObjectKeys(
+        rankingSnapshotBlock,
+        "jsonb_build_object(\n          'option_id'",
+        "\n        )\n  FROM aggregated"
+      )
+    ).toEqual([
+      "option_id",
+      "supplier_id",
+      "supplier_name",
+      "display_label",
+      "eligibility",
+      "incomplete_criterion_count",
+      "failed_count",
+      "insufficient_evidence_count",
+      "exceeds_count",
+      "rank",
+    ])
+  })
+
+  it("locks flattened matrix pages, sparse output and the seven-status conclusion", () => {
+    expect(exportMatrixBlock).toContain(
+      "p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 1000"
+    )
+    expect(exportMatrixBlock).toContain("WITH ORDINALITY")
+    expect(exportMatrixBlock).toContain("LEFT JOIN public.technical_configuration_comparison_sets")
+    expect(exportMatrixBlock).toContain("LEFT JOIN public.technical_configuration_option_responses")
+    expect(exportMatrixBlock).toContain(
+      "LEFT JOIN public.technical_configuration_manual_assessments"
+    )
+    expect(exportMatrixBlock).toContain("COALESCE(evidence.document_links, '[]'::JSONB)")
+    expect(exportMatrixBlock).toContain("WHEN assessment.technical_axis IS NULL")
+    expect(exportMatrixBlock).toContain("THEN 'not_evaluated'")
+    expect(exportMatrixBlock).toContain("THEN 'not_applicable'")
+    expect(exportMatrixBlock).toContain("THEN 'fails'")
+    expect(exportMatrixBlock).toContain("THEN 'unclear'")
+    expect(exportMatrixBlock).toContain("THEN 'insufficient_evidence'")
+    expect(exportMatrixBlock).toContain("ELSE assessment.technical_axis")
+    expect(
+      getObjectKeys(
+        exportMatrixBlock,
+        "jsonb_build_object(\n            'group_id'",
+        "\n          )"
+      )
+    ).toEqual([
+      "group_id",
+      "group_name",
+      "group_order",
+      "criterion_id",
+      "criterion_code",
+      "criterion_title",
+      "requirement_text",
+      "criterion_order",
+      "option_id",
+      "supplier_id",
+      "supplier_name",
+      "display_label",
+      "model",
+      "manufacturer",
+      "option_name",
+      "response_text",
+      "supplementary_information",
+      "document_links",
+      "technical_axis",
+      "evidence_axis",
+      "assessment_notes",
+      "conclusion",
+    ])
+    expect(
+      getObjectKeys(
+        exportMatrixBlock,
+        "jsonb_build_object(\n            'document_id'",
+        "\n          )"
+      )
+    ).toEqual([
+      "document_id",
+      "document_name",
+      "document_url",
+      "citation_id",
+      "page_section",
+      "excerpt",
+    ])
+    expect(getObjectKeys(exportMatrixBlock, "RETURN jsonb_build_object(", "\n  );\nEND;")).toEqual(
+      rankingResponseKeys
+    )
+  })
+
+  it("keeps every new function read-only, scoped and least-privilege", () => {
+    for (const functionBlock of [
+      rankingSnapshotBlock,
+      referenceRankingBlock,
+      exportRankingBlock,
+      exportMatrixBlock,
+    ]) {
+      expect(functionBlock).not.toMatch(/\bSELECT\s+(?:[a-z_]+\.)?\*/i)
+      expect(functionBlock).not.toMatch(
+        /\b(?:INSERT\s+INTO|UPDATE\s+public\.|DELETE\s+FROM|MERGE\s+INTO)\b/i
+      )
+      expect(functionBlock).not.toContain("technical_configuration_comparison_set_get_or_create")
+    }
+    expect(exportMatrixBlock).not.toContain("technical_configuration_reference_products")
+    expect(exportMatrixBlock).not.toContain("technical_configuration_reference_responses")
+    expect(exportMatrixBlock).not.toContain("technical_configuration_reference_citations")
+    expect(exportMatrixBlock).not.toContain("technical_configuration_baseline_documents")
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public._technical_configuration_reference_ranking_snapshot("
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public._technical_configuration_reference_ranking_snapshot("
+    )
+    expect(migrationSource).toContain("TO service_role;")
+    for (const functionName of [
+      "technical_configuration_reference_ranking_list",
+      "technical_configuration_result_export_ranking_list",
+      "technical_configuration_result_export_matrix_list",
+    ]) {
+      expect(migrationSource).toContain(`REVOKE ALL ON FUNCTION public.${functionName}(`)
+      expect(migrationSource).toContain(`GRANT EXECUTE ON FUNCTION public.${functionName}(`)
+    }
+    expect(migrationSource.match(/TO authenticated, service_role;/g)).toHaveLength(3)
+  })
+
+  it("defines focused authorization, bounds, plan and read-only phase gates", () => {
+    for (const marker of [
+      "missing claims rejected",
+      "denied role rejected",
+      "ranking page bounds rejected",
+      "matrix page bounds rejected",
+      "ranking preserves P12C1 ties and counters",
+      "ranking scope filters after complete-universe rank",
+      "matrix preserves requested criterion-option order",
+      "sparse matrix returns null and empty links",
+      "reference products never enter matrix cells",
+      "ranking non-empty second page stays stable",
+      "matrix non-empty second page stays stable",
+      "ranking page beyond end stays stable",
+      "matrix page beyond end stays stable",
+      "matrix bounded call executes without temporary spill",
+      "result export pages remain read-only",
+      "P12C1 response remains backward compatible",
+      "matrix PUBLIC execute revoked",
+      "matrix anon execute revoked",
+      "matrix service role execute granted",
+      "ranking token helper PUBLIC execute revoked",
+      "ranking token helper anon execute revoked",
+      "ranking token helper authenticated execute revoked",
+      "ranking token helper service role execute granted",
+      "raw admin role remains authorized",
+    ]) {
+      expect(phaseGateSource).toContain(marker)
+    }
+    expect(phaseGateSource).toContain("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)")
+    expect(phaseGateSource).not.toContain(
+      "EXPLAIN (FORMAT JSON) SELECT public.technical_configuration_result_export_matrix_list"
+    )
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-rpc-whitelist.test.ts
@@ -9,7 +9,11 @@ import {
   RESULT_EXPORT_RPC_FUNCTIONS,
 } from "@/lib/technical-configuration-result-export-rpcs"
 
-const P14A1_RPC_FUNCTIONS = ["technical_configuration_result_export_manifest_get"] as const
+const P14A2_RPC_FUNCTIONS = [
+  "technical_configuration_result_export_manifest_get",
+  "technical_configuration_result_export_ranking_list",
+  "technical_configuration_result_export_matrix_list",
+] as const
 
 async function invokeRpcProxy(fn: string) {
   const request = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST" })
@@ -17,20 +21,22 @@ async function invokeRpcProxy(fn: string) {
 }
 
 describe("technical configuration result export RPC whitelist", () => {
-  it("freezes exactly the P14A1 manifest RPC", () => {
+  it("freezes exactly the P14A1 manifest and P14A2 page RPCs", () => {
     expect(RESULT_EXPORT_RPC_FUNCTIONS).toEqual({
       getManifest: "technical_configuration_result_export_manifest_get",
+      listRanking: "technical_configuration_result_export_ranking_list",
+      listMatrix: "technical_configuration_result_export_matrix_list",
     })
-    expect(RESULT_EXPORT_RPC_FUNCTION_NAMES).toEqual(P14A1_RPC_FUNCTIONS)
+    expect(RESULT_EXPORT_RPC_FUNCTION_NAMES).toEqual(P14A2_RPC_FUNCTIONS)
   })
 
-  it("imports and spreads only the P14A1 manifest into the shared allowlist", () => {
+  it("imports and spreads only the P14A1/P14A2 result-export RPCs", () => {
     expect(
       [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_result_export_"))
-    ).toEqual(P14A1_RPC_FUNCTIONS)
+    ).toEqual(P14A2_RPC_FUNCTIONS)
   })
 
-  it.each(P14A1_RPC_FUNCTIONS)('allows result export RPC "%s" through the proxy', async (fn) => {
+  it.each(P14A2_RPC_FUNCTIONS)('allows result export RPC "%s" through the proxy', async (fn) => {
     const response = await invokeRpcProxy(fn)
 
     expect(response.status).toBe(411)

--- a/src/lib/technical-configuration-result-export-rpcs.ts
+++ b/src/lib/technical-configuration-result-export-rpcs.ts
@@ -1,7 +1,9 @@
-/** Named P14A1 result-export RPC shared by the proxy and future typed clients. */
+/** Named P14A1/P14A2 result-export RPCs shared by the proxy and future typed clients. */
 export const RESULT_EXPORT_RPC_FUNCTIONS = {
   getManifest: "technical_configuration_result_export_manifest_get",
+  listRanking: "technical_configuration_result_export_ranking_list",
+  listMatrix: "technical_configuration_result_export_matrix_list",
 } as const
 
-/** Ordered P14A1 result-export RPC names for allowlists and contract iteration. */
+/** Ordered P14A1/P14A2 result-export RPC names for allowlists and contract iteration. */
 export const RESULT_EXPORT_RPC_FUNCTION_NAMES = Object.values(RESULT_EXPORT_RPC_FUNCTIONS)

--- a/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
+++ b/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
@@ -11,6 +11,7 @@ CREATE OR REPLACE FUNCTION public._technical_configuration_option_display_label(
 RETURNS TEXT
 LANGUAGE sql
 IMMUTABLE
+SET search_path = pg_catalog
 AS $$
   SELECT p_supplier_name || ' ' || chr(183) || ' '
     || COALESCE(p_model, p_option_name);
@@ -23,6 +24,7 @@ CREATE OR REPLACE FUNCTION public._technical_configuration_derived_status(
 RETURNS TEXT
 LANGUAGE sql
 IMMUTABLE
+SET search_path = pg_catalog
 AS $$
   SELECT CASE
     WHEN p_technical_axis IS NULL THEN 'not_evaluated'

--- a/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
+++ b/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
@@ -1,0 +1,384 @@
+-- P14A2: one ranking source for P12C1 and bounded result-export ranking pages.
+-- Rollback with a new reviewed migration that drops the P14A2 ranking RPC and
+-- private helpers, then restores 20260731102715 as STABLE.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_reference_ranking_snapshot(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID
+)
+RETURNS TABLE (
+  option_id UUID,
+  rank_value BIGINT,
+  supplier_normalized_name TEXT,
+  identity_label TEXT,
+  ranking_item JSONB
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH canonical_criteria AS MATERIALIZED (
+    SELECT criterion.id AS criterion_id
+    FROM public.technical_configuration_baseline_criteria criterion
+    WHERE criterion.baseline_version_id = p_baseline_version_id
+  ),
+  option_universe AS MATERIALIZED (
+    SELECT
+      option_row.id AS option_id,
+      option_row.supplier_id,
+      supplier.name AS supplier_name,
+      supplier.normalized_name AS supplier_normalized_name,
+      COALESCE(option_row.model, option_row.option_name) AS identity_label,
+      supplier.name || ' ' || chr(183) || ' '
+        || COALESCE(option_row.model, option_row.option_name) AS display_label
+    FROM public.technical_configuration_options option_row
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+    WHERE option_row.dossier_id = p_dossier_id
+  ),
+  scored AS MATERIALIZED (
+    SELECT
+      option_row.option_id,
+      option_row.supplier_id,
+      option_row.supplier_name,
+      option_row.supplier_normalized_name,
+      option_row.identity_label,
+      option_row.display_label,
+      CASE
+        WHEN criterion.criterion_id IS NULL THEN 0
+        WHEN assessment.technical_axis = 'not_applicable' THEN 0
+        WHEN assessment.technical_axis IS NULL
+          OR assessment.evidence_axis IS NULL THEN 1
+        ELSE 0
+      END AS incomplete_criterion,
+      CASE
+        WHEN criterion.criterion_id IS NULL THEN NULL
+        WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'
+        WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'
+        WHEN assessment.technical_axis = 'fails' THEN 'fails'
+        WHEN assessment.technical_axis = 'unclear' THEN 'unclear'
+        WHEN assessment.evidence_axis IS NULL THEN 'not_evaluated'
+        WHEN assessment.evidence_axis IN ('partial', 'missing')
+          THEN 'insufficient_evidence'
+        ELSE assessment.technical_axis
+      END AS derived_status
+    FROM option_universe option_row
+    LEFT JOIN canonical_criteria criterion ON TRUE
+    LEFT JOIN public.technical_configuration_comparison_sets comparison_set
+      ON comparison_set.option_id = option_row.option_id
+     AND comparison_set.baseline_version_id = p_baseline_version_id
+     AND comparison_set.dossier_id = p_dossier_id
+    LEFT JOIN public.technical_configuration_manual_assessments assessment
+      ON assessment.comparison_set_id = comparison_set.id
+     AND assessment.baseline_version_id = p_baseline_version_id
+     AND assessment.criterion_id = criterion.criterion_id
+  ),
+  aggregated AS MATERIALIZED (
+    SELECT
+      scored.option_id,
+      scored.supplier_id,
+      scored.supplier_name,
+      scored.supplier_normalized_name,
+      scored.identity_label,
+      scored.display_label,
+      COUNT(*) FILTER (WHERE scored.incomplete_criterion = 1)
+        AS incomplete_criterion_count,
+      COUNT(*) FILTER (WHERE scored.derived_status = 'fails') AS failed_count,
+      COUNT(*) FILTER (WHERE scored.derived_status = 'insufficient_evidence')
+        AS insufficient_evidence_count,
+      COUNT(*) FILTER (WHERE scored.derived_status = 'exceeds') AS exceeds_count
+    FROM scored
+    GROUP BY
+      scored.option_id,
+      scored.supplier_id,
+      scored.supplier_name,
+      scored.supplier_normalized_name,
+      scored.identity_label,
+      scored.display_label
+  ),
+  eligible_ranked AS MATERIALIZED (
+    SELECT
+      aggregated.option_id,
+      DENSE_RANK() OVER (
+        ORDER BY
+          aggregated.failed_count,
+          aggregated.insufficient_evidence_count,
+          aggregated.exceeds_count DESC
+      ) AS rank
+    FROM aggregated
+    WHERE aggregated.incomplete_criterion_count = 0
+  )
+  SELECT
+    aggregated.option_id,
+    eligible.rank,
+    aggregated.supplier_normalized_name,
+    aggregated.identity_label,
+    jsonb_build_object(
+          'option_id', aggregated.option_id,
+          'supplier_id', aggregated.supplier_id,
+          'supplier_name', aggregated.supplier_name,
+          'display_label', aggregated.display_label,
+          'eligibility', CASE
+            WHEN aggregated.incomplete_criterion_count = 0 THEN 'eligible'
+            ELSE 'incomplete'
+          END,
+          'incomplete_criterion_count', aggregated.incomplete_criterion_count,
+          'failed_count', aggregated.failed_count,
+          'insufficient_evidence_count', aggregated.insufficient_evidence_count,
+          'exceeds_count', aggregated.exceeds_count,
+          'rank', eligible.rank
+        )
+  FROM aggregated
+  LEFT JOIN eligible_ranked eligible ON eligible.option_id = aggregated.option_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_reference_ranking_token(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT md5(concat_ws(
+    '|',
+    p_dossier_id::TEXT,
+    p_baseline_version_id::TEXT,
+    COALESCE((
+      SELECT string_agg(
+        concat_ws(
+          ':',
+          option_row.id::TEXT,
+          option_row.supplier_id::TEXT,
+          to_char(option_row.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US'),
+          to_char(supplier.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US')
+        ),
+        ',' ORDER BY
+          supplier.normalized_name,
+          COALESCE(option_row.model, option_row.option_name),
+          option_row.id
+      )
+      FROM public.technical_configuration_options option_row
+      JOIN public.technical_configuration_suppliers supplier
+        ON supplier.id = option_row.supplier_id
+       AND supplier.dossier_id = option_row.dossier_id
+      WHERE option_row.dossier_id = p_dossier_id
+    ), ''),
+    COALESCE((
+      SELECT string_agg(
+        criterion.id::TEXT,
+        ',' ORDER BY group_row.sort_order, criterion.sort_order, criterion.id
+      )
+      FROM public.technical_configuration_baseline_criteria criterion
+      JOIN public.technical_configuration_baseline_groups group_row
+        ON group_row.id = criterion.group_id
+       AND group_row.baseline_version_id = criterion.baseline_version_id
+      WHERE criterion.baseline_version_id = p_baseline_version_id
+    ), ''),
+    COALESCE((
+      SELECT string_agg(
+        concat_ws(
+          ':',
+          comparison_set.id::TEXT,
+          to_char(
+            comparison_set.updated_at AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.US'
+          ),
+          COALESCE(assessment.id::TEXT, ''),
+          COALESCE(assessment.revision::TEXT, ''),
+          COALESCE(assessment.technical_axis, ''),
+          COALESCE(assessment.evidence_axis, '')
+        ),
+        ',' ORDER BY comparison_set.option_id, assessment.criterion_id
+      )
+      FROM public.technical_configuration_comparison_sets comparison_set
+      LEFT JOIN public.technical_configuration_manual_assessments assessment
+        ON assessment.comparison_set_id = comparison_set.id
+       AND assessment.baseline_version_id = comparison_set.baseline_version_id
+      WHERE comparison_set.dossier_id = p_dossier_id
+        AND comparison_set.baseline_version_id = p_baseline_version_id
+    ), '')
+  ));
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_reference_ranking_list(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_page INTEGER,
+  p_page_size INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE v_total BIGINT; v_data JSONB; v_snapshot_token TEXT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_dossier_id IS NULL OR p_baseline_version_id IS NULL
+     OR p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_versions version
+    WHERE version.id = p_baseline_version_id
+      AND version.dossier_id = p_dossier_id
+  ) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  WITH ranked AS MATERIALIZED (
+    SELECT
+      ranking.option_id,
+      ranking.rank_value,
+      ranking.supplier_normalized_name,
+      ranking.identity_label,
+      ranking.ranking_item
+    FROM public._technical_configuration_reference_ranking_snapshot(
+      p_dossier_id, p_baseline_version_id
+    ) ranking
+  ),
+  paged AS (
+    SELECT ranking_item, rank_value, supplier_normalized_name, identity_label, option_id
+    FROM ranked
+    ORDER BY
+      CASE WHEN rank_value IS NULL THEN 1 ELSE 0 END,
+      rank_value, supplier_normalized_name, identity_label, option_id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT
+    (SELECT count(*) FROM ranked),
+    COALESCE((
+      SELECT jsonb_agg(
+        ranking_item ORDER BY
+          CASE WHEN rank_value IS NULL THEN 1 ELSE 0 END,
+          rank_value, supplier_normalized_name, identity_label, option_id
+      )
+      FROM paged
+    ), '[]'::JSONB)
+  INTO v_total, v_data;
+  v_snapshot_token := public._technical_configuration_reference_ranking_token(
+    p_dossier_id, p_baseline_version_id
+  );
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'dossier_id', p_dossier_id,
+    'baseline_version_id', p_baseline_version_id,
+    'snapshot_token', v_snapshot_token,
+    'total', v_total,
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_result_export_ranking_list(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_option_ids UUID[],
+  p_criterion_ids UUID[],
+  p_page INTEGER,
+  p_page_size INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE v_snapshot JSONB; v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  v_snapshot := public._technical_configuration_result_export_snapshot(
+    p_dossier_id, p_baseline_version_id, p_option_ids, p_criterion_ids
+  );
+  WITH selected_options AS MATERIALIZED (
+    SELECT option_id::UUID
+    FROM jsonb_array_elements_text(v_snapshot->'option_ids')
+      WITH ORDINALITY AS selected(option_id, ordinal)
+  ),
+  ranked AS MATERIALIZED (
+    SELECT
+      ranking.option_id,
+      ranking.rank_value,
+      ranking.supplier_normalized_name,
+      ranking.identity_label,
+      ranking.ranking_item
+    FROM public._technical_configuration_reference_ranking_snapshot(
+      p_dossier_id, p_baseline_version_id
+    ) ranking
+    JOIN selected_options selected ON selected.option_id = ranking.option_id
+  ),
+  paged AS (
+    SELECT
+      option_id,
+      rank_value,
+      supplier_normalized_name,
+      identity_label,
+      ranking_item
+    FROM ranked
+    ORDER BY
+      CASE WHEN rank_value IS NULL THEN 1 ELSE 0 END,
+      rank_value, supplier_normalized_name, identity_label, option_id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT COALESCE((
+    SELECT jsonb_agg(
+      ranking_item ORDER BY
+        CASE WHEN rank_value IS NULL THEN 1 ELSE 0 END,
+        rank_value, supplier_normalized_name, identity_label, option_id
+    )
+    FROM paged
+  ), '[]'::JSONB)
+  INTO v_data;
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'dossier_id', p_dossier_id,
+    'baseline_version_id', p_baseline_version_id,
+    'snapshot_token', v_snapshot->'snapshot_token',
+    'ranking_snapshot_token', v_snapshot->'ranking_snapshot_token',
+    'total', v_snapshot->'option_total',
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_reference_ranking_snapshot(
+  UUID, UUID
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_reference_ranking_snapshot(
+  UUID, UUID
+) TO service_role;
+REVOKE ALL ON FUNCTION public._technical_configuration_reference_ranking_token(
+  UUID, UUID
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_reference_ranking_token(
+  UUID, UUID
+) TO service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_reference_ranking_list(
+  UUID, UUID, INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_ranking_list(
+  UUID, UUID, INTEGER, INTEGER
+) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_result_export_ranking_list(
+  UUID, UUID, UUID[], UUID[], INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_result_export_ranking_list(
+  UUID, UUID, UUID[], UUID[], INTEGER, INTEGER
+) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
+++ b/supabase/migrations/20260802092214_technical_configuration_result_export_ranking_source.sql
@@ -3,6 +3,38 @@
 -- private helpers, then restores 20260731102715 as STABLE.
 BEGIN;
 
+CREATE OR REPLACE FUNCTION public._technical_configuration_option_display_label(
+  p_supplier_name TEXT,
+  p_model TEXT,
+  p_option_name TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_supplier_name || ' ' || chr(183) || ' '
+    || COALESCE(p_model, p_option_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_derived_status(
+  p_technical_axis TEXT,
+  p_evidence_axis TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_technical_axis IS NULL THEN 'not_evaluated'
+    WHEN p_technical_axis = 'not_applicable' THEN 'not_applicable'
+    WHEN p_technical_axis = 'fails' THEN 'fails'
+    WHEN p_technical_axis = 'unclear' THEN 'unclear'
+    WHEN p_evidence_axis IS NULL THEN 'not_evaluated'
+    WHEN p_evidence_axis IN ('partial', 'missing') THEN 'insufficient_evidence'
+    ELSE p_technical_axis
+  END;
+$$;
+
 CREATE OR REPLACE FUNCTION public._technical_configuration_reference_ranking_snapshot(
   p_dossier_id UUID,
   p_baseline_version_id UUID
@@ -31,8 +63,11 @@ AS $$
       supplier.name AS supplier_name,
       supplier.normalized_name AS supplier_normalized_name,
       COALESCE(option_row.model, option_row.option_name) AS identity_label,
-      supplier.name || ' ' || chr(183) || ' '
-        || COALESCE(option_row.model, option_row.option_name) AS display_label
+      public._technical_configuration_option_display_label(
+        supplier.name,
+        option_row.model,
+        option_row.option_name
+      ) AS display_label
     FROM public.technical_configuration_options option_row
     JOIN public.technical_configuration_suppliers supplier
       ON supplier.id = option_row.supplier_id
@@ -54,16 +89,11 @@ AS $$
           OR assessment.evidence_axis IS NULL THEN 1
         ELSE 0
       END AS incomplete_criterion,
-      CASE
-        WHEN criterion.criterion_id IS NULL THEN NULL
-        WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'
-        WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'
-        WHEN assessment.technical_axis = 'fails' THEN 'fails'
-        WHEN assessment.technical_axis = 'unclear' THEN 'unclear'
-        WHEN assessment.evidence_axis IS NULL THEN 'not_evaluated'
-        WHEN assessment.evidence_axis IN ('partial', 'missing')
-          THEN 'insufficient_evidence'
-        ELSE assessment.technical_axis
+      CASE WHEN criterion.criterion_id IS NULL THEN NULL
+        ELSE public._technical_configuration_derived_status(
+          assessment.technical_axis,
+          assessment.evidence_axis
+        )
       END AS derived_status
     FROM option_universe option_row
     LEFT JOIN canonical_criteria criterion ON TRUE
@@ -359,6 +389,18 @@ $$;
 REVOKE ALL ON FUNCTION public._technical_configuration_reference_ranking_snapshot(
   UUID, UUID
 ) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public._technical_configuration_option_display_label(
+  TEXT, TEXT, TEXT
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_option_display_label(
+  TEXT, TEXT, TEXT
+) TO service_role;
+REVOKE ALL ON FUNCTION public._technical_configuration_derived_status(
+  TEXT, TEXT
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_derived_status(
+  TEXT, TEXT
+) TO service_role;
 GRANT EXECUTE ON FUNCTION public._technical_configuration_reference_ranking_snapshot(
   UUID, UUID
 ) TO service_role;

--- a/supabase/migrations/20260802092215_technical_configuration_result_export_snapshot_token_source.sql
+++ b/supabase/migrations/20260802092215_technical_configuration_result_export_snapshot_token_source.sql
@@ -1,0 +1,392 @@
+-- P14A2: preserve the P14A1 snapshot contract while sourcing its ranking token
+-- directly, so ranking export pages compute the complete-universe ranking once.
+-- Rollback with a new reviewed migration that restores the P14A1 helper body.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_result_export_snapshot(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_option_ids UUID[],
+  p_criterion_ids UUID[]
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_snapshot_data JSONB;
+  v_snapshot_payload JSONB;
+  v_option_total BIGINT;
+  v_criterion_total BIGINT;
+  v_ranking_snapshot_token TEXT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_dossier_id IS NULL OR p_baseline_version_id IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF p_option_ids IS NOT NULL AND (
+    cardinality(p_option_ids) = 0
+    OR array_position(p_option_ids, NULL) IS NOT NULL
+    OR (
+      SELECT count(DISTINCT requested.option_id)
+      FROM unnest(p_option_ids) AS requested(option_id)
+    ) <> cardinality(p_option_ids)
+  ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF p_criterion_ids IS NOT NULL AND (
+    cardinality(p_criterion_ids) = 0
+    OR array_position(p_criterion_ids, NULL) IS NOT NULL
+    OR (
+      SELECT count(DISTINCT requested.criterion_id)
+      FROM unnest(p_criterion_ids) AS requested(criterion_id)
+    ) <> cardinality(p_criterion_ids)
+  ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions version
+    WHERE version.id = p_baseline_version_id
+      AND version.dossier_id = p_dossier_id
+  ) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  v_ranking_snapshot_token :=
+    public._technical_configuration_reference_ranking_token(
+      p_dossier_id,
+      p_baseline_version_id
+    );
+  WITH requested_options AS MATERIALIZED (
+    SELECT requested.option_id, requested.ordinal::BIGINT
+    FROM unnest(p_option_ids) WITH ORDINALITY AS requested(option_id, ordinal)
+    WHERE p_option_ids IS NOT NULL
+    UNION ALL
+    SELECT
+      option_row.id,
+      row_number() OVER (
+        ORDER BY
+          supplier.normalized_name,
+          COALESCE(option_row.model, option_row.option_name),
+          option_row.id
+      )
+    FROM public.technical_configuration_options option_row
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+    WHERE p_option_ids IS NULL
+      AND option_row.dossier_id = p_dossier_id
+  ),
+  scoped_options AS MATERIALIZED (
+    SELECT
+      requested.ordinal,
+      option_row.id AS option_id,
+      option_row.supplier_id,
+      supplier.name AS supplier_name,
+      supplier.normalized_name AS supplier_normalized_name,
+      option_row.model,
+      option_row.manufacturer,
+      option_row.option_name
+    FROM requested_options requested
+    JOIN public.technical_configuration_options option_row
+      ON option_row.id = requested.option_id
+     AND option_row.dossier_id = p_dossier_id
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+  ),
+  requested_criteria AS MATERIALIZED (
+    SELECT requested.criterion_id, requested.ordinal::BIGINT
+    FROM unnest(p_criterion_ids) WITH ORDINALITY AS requested(criterion_id, ordinal)
+    WHERE p_criterion_ids IS NOT NULL
+    UNION ALL
+    SELECT
+      criterion.id,
+      row_number() OVER (
+        ORDER BY group_row.sort_order, criterion.sort_order, criterion.id
+      )
+    FROM public.technical_configuration_baseline_criteria criterion
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+    WHERE p_criterion_ids IS NULL
+      AND criterion.baseline_version_id = p_baseline_version_id
+  ),
+  scoped_criteria AS MATERIALIZED (
+    SELECT
+      requested.ordinal,
+      group_row.id AS group_id,
+      group_row.name AS group_name,
+      group_row.sort_order AS group_order,
+      criterion.id AS criterion_id,
+      criterion.criterion_code,
+      criterion.title AS criterion_title,
+      criterion.requirement_text,
+      criterion.sort_order AS criterion_order
+    FROM requested_criteria requested
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.id = requested.criterion_id
+     AND criterion.baseline_version_id = p_baseline_version_id
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+  ),
+  dossier_context AS MATERIALIZED (
+    SELECT
+      dossier.id AS dossier_id,
+      dossier.device_type_name,
+      dossier.name AS dossier_name,
+      dossier.revision AS dossier_revision,
+      CASE WHEN dossier.archived_at IS NULL THEN NULL ELSE to_char(
+        dossier.archived_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      ) END AS archived_at,
+      version.id AS baseline_version_id,
+      version.dossier_id AS baseline_dossier_id,
+      version.version_number,
+      version.status AS baseline_status,
+      version.revision AS baseline_revision,
+      CASE WHEN version.locked_at IS NULL THEN NULL ELSE to_char(
+        version.locked_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      ) END AS locked_at
+    FROM public.technical_configuration_dossiers dossier
+    JOIN public.technical_configuration_baseline_versions version
+      ON version.dossier_id = dossier.id
+     AND version.id = p_baseline_version_id
+    WHERE dossier.id = p_dossier_id
+  )
+  SELECT
+    jsonb_build_object(
+      'dossier', jsonb_build_object(
+        'id', context.dossier_id,
+        'device_type_name', context.device_type_name,
+        'name', context.dossier_name,
+        'revision', context.dossier_revision,
+        'archived_at', context.archived_at
+      ),
+      'baseline_version', jsonb_build_object(
+        'id', context.baseline_version_id,
+        'dossier_id', context.baseline_dossier_id,
+        'version_number', context.version_number,
+        'status', context.baseline_status,
+        'revision', context.baseline_revision,
+        'locked_at', context.locked_at
+      ),
+      'option_ids', COALESCE(
+        (
+          SELECT jsonb_agg(scoped_option.option_id ORDER BY scoped_option.ordinal)
+          FROM scoped_options scoped_option
+        ),
+        '[]'::JSONB
+      ),
+      'criterion_ids', COALESCE(
+        (
+          SELECT jsonb_agg(scoped_criterion.criterion_id ORDER BY scoped_criterion.ordinal)
+          FROM scoped_criteria scoped_criterion
+        ),
+        '[]'::JSONB
+      ),
+      'option_total', (SELECT count(*) FROM scoped_options),
+      'criterion_total', (SELECT count(*) FROM scoped_criteria),
+      'ranking_snapshot_token', v_ranking_snapshot_token
+    ),
+    jsonb_build_object(
+      'dossier', jsonb_build_object(
+        'id', context.dossier_id,
+        'device_type_name', context.device_type_name,
+        'name', context.dossier_name,
+        'revision', context.dossier_revision,
+        'archived_at', context.archived_at
+      ),
+      'baseline_version', jsonb_build_object(
+        'id', context.baseline_version_id,
+        'dossier_id', context.baseline_dossier_id,
+        'version_number', context.version_number,
+        'status', context.baseline_status,
+        'revision', context.baseline_revision,
+        'locked_at', context.locked_at
+      ),
+      'options', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'option_id', scoped_option.option_id,
+              'supplier_id', scoped_option.supplier_id,
+              'supplier_name', scoped_option.supplier_name,
+              'supplier_normalized_name', scoped_option.supplier_normalized_name,
+              'model', scoped_option.model,
+              'manufacturer', scoped_option.manufacturer,
+              'option_name', scoped_option.option_name
+            )
+            ORDER BY scoped_option.ordinal
+          )
+          FROM scoped_options scoped_option
+        ),
+        '[]'::JSONB
+      ),
+      'criteria', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'group_id', scoped_criterion.group_id,
+              'group_name', scoped_criterion.group_name,
+              'group_order', scoped_criterion.group_order,
+              'criterion_id', scoped_criterion.criterion_id,
+              'criterion_code', scoped_criterion.criterion_code,
+              'criterion_title', scoped_criterion.criterion_title,
+              'requirement_text', scoped_criterion.requirement_text,
+              'criterion_order', scoped_criterion.criterion_order
+            )
+            ORDER BY scoped_criterion.ordinal
+          )
+          FROM scoped_criteria scoped_criterion
+        ),
+        '[]'::JSONB
+      ),
+      'comparison_sets', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'comparison_set_id', comparison_set.id,
+              'option_id', comparison_set.option_id,
+              'baseline_version_id', comparison_set.baseline_version_id
+            )
+            ORDER BY scoped_option.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+        ),
+        '[]'::JSONB
+      ),
+      'responses', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'response_id', response.id,
+              'comparison_set_id', response.comparison_set_id,
+              'criterion_id', response.criterion_id,
+              'response_text', response.response_text,
+              'supplementary_information', response.supplementary_information
+            )
+            ORDER BY scoped_option.ordinal, scoped_criterion.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_option_responses response
+            ON response.comparison_set_id = comparison_set.id
+           AND response.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = response.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'documents', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'document_id', document.id,
+              'option_id', document.option_id,
+              'document_name', document.name,
+              'document_url', document.url
+            )
+            ORDER BY scoped_option.ordinal, document.name, document.id
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_option_documents document
+            ON document.option_id = scoped_option.option_id
+        ),
+        '[]'::JSONB
+      ),
+      'citations', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'citation_id', citation.id,
+              'option_id', citation.option_id,
+              'comparison_set_id', citation.comparison_set_id,
+              'criterion_id', citation.criterion_id,
+              'document_id', citation.option_document_id,
+              'page_section', citation.page_section,
+              'excerpt', citation.excerpt
+            )
+            ORDER BY
+              scoped_option.ordinal,
+              scoped_criterion.ordinal,
+              citation.option_document_id,
+              citation.id
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_option_citations citation
+            ON citation.comparison_set_id = comparison_set.id
+           AND citation.option_id = scoped_option.option_id
+           AND citation.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = citation.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'assessments', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'assessment_id', assessment.id,
+              'comparison_set_id', assessment.comparison_set_id,
+              'criterion_id', assessment.criterion_id,
+              'technical_axis', assessment.technical_axis,
+              'evidence_axis', assessment.evidence_axis,
+              'assessment_notes', assessment.notes,
+              'assessment_revision', assessment.revision
+            )
+            ORDER BY scoped_option.ordinal, scoped_criterion.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_manual_assessments assessment
+            ON assessment.comparison_set_id = comparison_set.id
+           AND assessment.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = assessment.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'ranking_snapshot_token', v_ranking_snapshot_token
+    ),
+    (SELECT count(*) FROM scoped_options),
+    (SELECT count(*) FROM scoped_criteria)
+  INTO v_snapshot_data, v_snapshot_payload, v_option_total, v_criterion_total
+  FROM dossier_context context;
+  IF p_option_ids IS NOT NULL AND v_option_total <> cardinality(p_option_ids) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF p_criterion_ids IS NOT NULL
+     AND v_criterion_total <> cardinality(p_criterion_ids) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  RETURN v_snapshot_data || jsonb_build_object(
+    'snapshot_token',
+    md5(v_snapshot_payload::TEXT)
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public._technical_configuration_result_export_snapshot(
+  UUID, UUID, UUID[], UUID[]
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_result_export_snapshot(
+  UUID, UUID, UUID[], UUID[]
+) TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260802092216_technical_configuration_result_export_matrix_page.sql
+++ b/supabase/migrations/20260802092216_technical_configuration_result_export_matrix_page.sql
@@ -1,0 +1,199 @@
+-- P14A2: bounded, flattened, read-only result-export matrix pages.
+-- Rollback with a new reviewed migration that revokes and drops this RPC.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_result_export_matrix_list(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_option_ids UUID[],
+  p_criterion_ids UUID[],
+  p_page INTEGER,
+  p_page_size INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE v_snapshot JSONB; v_data JSONB; v_total BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 1000 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  v_snapshot := public._technical_configuration_result_export_snapshot(
+    p_dossier_id, p_baseline_version_id, p_option_ids, p_criterion_ids
+  );
+  v_total := (v_snapshot->>'option_total')::BIGINT
+    * (v_snapshot->>'criterion_total')::BIGINT;
+  WITH scoped_options AS MATERIALIZED (
+    SELECT
+      selected.ordinal,
+      option_row.id AS option_id,
+      option_row.supplier_id,
+      supplier.name AS supplier_name,
+      supplier.name || ' ' || chr(183) || ' '
+        || COALESCE(option_row.model, option_row.option_name) AS display_label,
+      option_row.model,
+      option_row.manufacturer,
+      option_row.option_name
+    FROM jsonb_array_elements_text(v_snapshot->'option_ids')
+      WITH ORDINALITY AS selected(option_id, ordinal)
+    JOIN public.technical_configuration_options option_row
+      ON option_row.id = selected.option_id::UUID
+     AND option_row.dossier_id = p_dossier_id
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+  ),
+  scoped_criteria AS MATERIALIZED (
+    SELECT
+      selected.ordinal,
+      group_row.id AS group_id,
+      group_row.name AS group_name,
+      group_row.sort_order AS group_order,
+      criterion.id AS criterion_id,
+      criterion.criterion_code,
+      criterion.title AS criterion_title,
+      criterion.requirement_text,
+      criterion.sort_order AS criterion_order
+    FROM jsonb_array_elements_text(v_snapshot->'criterion_ids')
+      WITH ORDINALITY AS selected(criterion_id, ordinal)
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.id = selected.criterion_id::UUID
+     AND criterion.baseline_version_id = p_baseline_version_id
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+  ),
+  paged_cells AS MATERIALIZED (
+    SELECT
+      criterion.group_id,
+      criterion.group_name,
+      criterion.group_order,
+      criterion.criterion_id,
+      criterion.criterion_code,
+      criterion.criterion_title,
+      criterion.requirement_text,
+      criterion.criterion_order,
+      option_row.option_id,
+      option_row.supplier_id,
+      option_row.supplier_name,
+      option_row.display_label,
+      option_row.model,
+      option_row.manufacturer,
+      option_row.option_name,
+      criterion.ordinal AS criterion_ordinal,
+      option_row.ordinal AS option_ordinal
+    FROM scoped_criteria criterion
+    CROSS JOIN scoped_options option_row
+    ORDER BY criterion.ordinal, option_row.ordinal
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  ),
+  evidence AS MATERIALIZED (
+    SELECT
+      cell.option_id,
+      cell.criterion_id,
+      jsonb_agg(
+        jsonb_build_object(
+            'document_id', document.id,
+            'document_name', document.name,
+            'document_url', document.url,
+            'citation_id', citation.id,
+            'page_section', citation.page_section,
+            'excerpt', citation.excerpt
+          )
+        ORDER BY document.name, document.id, citation.id
+      ) AS document_links
+    FROM paged_cells cell
+    JOIN public.technical_configuration_comparison_sets comparison_set
+      ON comparison_set.option_id = cell.option_id
+     AND comparison_set.dossier_id = p_dossier_id
+     AND comparison_set.baseline_version_id = p_baseline_version_id
+    JOIN public.technical_configuration_option_citations citation
+      ON citation.option_id = cell.option_id
+     AND citation.comparison_set_id = comparison_set.id
+     AND citation.baseline_version_id = p_baseline_version_id
+     AND citation.criterion_id = cell.criterion_id
+    JOIN public.technical_configuration_option_documents document
+      ON document.id = citation.option_document_id
+     AND document.option_id = cell.option_id
+    GROUP BY cell.option_id, cell.criterion_id
+  )
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+            'group_id', cell.group_id,
+            'group_name', cell.group_name,
+            'group_order', cell.group_order,
+            'criterion_id', cell.criterion_id,
+            'criterion_code', cell.criterion_code,
+            'criterion_title', cell.criterion_title,
+            'requirement_text', cell.requirement_text,
+            'criterion_order', cell.criterion_order,
+            'option_id', cell.option_id,
+            'supplier_id', cell.supplier_id,
+            'supplier_name', cell.supplier_name,
+            'display_label', cell.display_label,
+            'model', cell.model,
+            'manufacturer', cell.manufacturer,
+            'option_name', cell.option_name,
+            'response_text', response.response_text,
+            'supplementary_information', response.supplementary_information,
+            'document_links', COALESCE(evidence.document_links, '[]'::JSONB),
+            'technical_axis', assessment.technical_axis,
+            'evidence_axis', assessment.evidence_axis,
+            'assessment_notes', assessment.notes,
+            'conclusion', CASE
+              WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'
+              WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'
+              WHEN assessment.technical_axis = 'fails' THEN 'fails'
+              WHEN assessment.technical_axis = 'unclear' THEN 'unclear'
+              WHEN assessment.evidence_axis IS NULL THEN 'not_evaluated'
+              WHEN assessment.evidence_axis IN ('partial', 'missing')
+                THEN 'insufficient_evidence'
+              ELSE assessment.technical_axis
+            END
+          )
+    ORDER BY cell.criterion_ordinal, cell.option_ordinal
+  ), '[]'::JSONB)
+  INTO v_data
+  FROM paged_cells cell
+  LEFT JOIN public.technical_configuration_comparison_sets comparison_set
+    ON comparison_set.option_id = cell.option_id
+   AND comparison_set.dossier_id = p_dossier_id
+   AND comparison_set.baseline_version_id = p_baseline_version_id
+  LEFT JOIN public.technical_configuration_option_responses response
+    ON response.comparison_set_id = comparison_set.id
+   AND response.baseline_version_id = p_baseline_version_id
+   AND response.criterion_id = cell.criterion_id
+  LEFT JOIN public.technical_configuration_manual_assessments assessment
+    ON assessment.comparison_set_id = comparison_set.id
+   AND assessment.baseline_version_id = p_baseline_version_id
+   AND assessment.criterion_id = cell.criterion_id
+  LEFT JOIN evidence
+    ON evidence.option_id = cell.option_id
+   AND evidence.criterion_id = cell.criterion_id;
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'dossier_id', p_dossier_id,
+    'baseline_version_id', p_baseline_version_id,
+    'snapshot_token', v_snapshot->'snapshot_token',
+    'ranking_snapshot_token', v_snapshot->'ranking_snapshot_token',
+    'total', v_total,
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_result_export_matrix_list(
+  UUID, UUID, UUID[], UUID[], INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_result_export_matrix_list(
+  UUID, UUID, UUID[], UUID[], INTEGER, INTEGER
+) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/20260802092216_technical_configuration_result_export_matrix_page.sql
+++ b/supabase/migrations/20260802092216_technical_configuration_result_export_matrix_page.sql
@@ -34,8 +34,11 @@ BEGIN
       option_row.id AS option_id,
       option_row.supplier_id,
       supplier.name AS supplier_name,
-      supplier.name || ' ' || chr(183) || ' '
-        || COALESCE(option_row.model, option_row.option_name) AS display_label,
+      public._technical_configuration_option_display_label(
+        supplier.name,
+        option_row.model,
+        option_row.option_name
+      ) AS display_label,
       option_row.model,
       option_row.manufacturer,
       option_row.option_name
@@ -146,16 +149,10 @@ BEGIN
             'technical_axis', assessment.technical_axis,
             'evidence_axis', assessment.evidence_axis,
             'assessment_notes', assessment.notes,
-            'conclusion', CASE
-              WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'
-              WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'
-              WHEN assessment.technical_axis = 'fails' THEN 'fails'
-              WHEN assessment.technical_axis = 'unclear' THEN 'unclear'
-              WHEN assessment.evidence_axis IS NULL THEN 'not_evaluated'
-              WHEN assessment.evidence_axis IN ('partial', 'missing')
-                THEN 'insufficient_evidence'
-              ELSE assessment.technical_axis
-            END
+            'conclusion', public._technical_configuration_derived_status(
+              assessment.technical_axis,
+              assessment.evidence_axis
+            )
           )
     ORDER BY cell.criterion_ordinal, cell.option_ordinal
   ), '[]'::JSONB)

--- a/supabase/migrations/20260802092217_technical_configuration_result_export_helper_search_path.sql
+++ b/supabase/migrations/20260802092217_technical_configuration_result_export_helper_search_path.sql
@@ -1,0 +1,52 @@
+-- P14A2: pin search_path for the shared immutable export expressions after the
+-- initial live apply. Fresh databases receive the same setting from 092214.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_option_display_label(
+  p_supplier_name TEXT,
+  p_model TEXT,
+  p_option_name TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+SET search_path = pg_catalog
+AS $$
+  SELECT p_supplier_name || ' ' || chr(183) || ' '
+    || COALESCE(p_model, p_option_name);
+$$;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_derived_status(
+  p_technical_axis TEXT,
+  p_evidence_axis TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+SET search_path = pg_catalog
+AS $$
+  SELECT CASE
+    WHEN p_technical_axis IS NULL THEN 'not_evaluated'
+    WHEN p_technical_axis = 'not_applicable' THEN 'not_applicable'
+    WHEN p_technical_axis = 'fails' THEN 'fails'
+    WHEN p_technical_axis = 'unclear' THEN 'unclear'
+    WHEN p_evidence_axis IS NULL THEN 'not_evaluated'
+    WHEN p_evidence_axis IN ('partial', 'missing') THEN 'insufficient_evidence'
+    ELSE p_technical_axis
+  END;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_option_display_label(
+  TEXT, TEXT, TEXT
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_option_display_label(
+  TEXT, TEXT, TEXT
+) TO service_role;
+REVOKE ALL ON FUNCTION public._technical_configuration_derived_status(
+  TEXT, TEXT
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_derived_status(
+  TEXT, TEXT
+) TO service_role;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
+++ b/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
@@ -139,7 +139,8 @@ BEGIN
     NOT has_function_privilege('authenticated', v_helper_signature, 'EXECUTE')
     AND has_function_privilege('service_role', v_helper_signature, 'EXECUTE'));
   PERFORM pg_temp.assert_true('shared expression helpers are immutable and service-only',
-    (SELECT bool_and(proc.provolatile = 'i') FROM pg_proc proc
+    (SELECT bool_and(proc.provolatile = 'i' AND proc.proconfig = ARRAY['search_path=pg_catalog'])
+     FROM pg_proc proc
      WHERE proc.oid IN (v_label_helper_signature::regprocedure, v_status_helper_signature::regprocedure))
     AND NOT has_function_privilege('authenticated', v_label_helper_signature, 'EXECUTE')
     AND has_function_privilege('service_role', v_label_helper_signature, 'EXECUTE')
@@ -231,7 +232,7 @@ BEGIN
     ),
     (
       v_set_b_id, v_version_id, v_criterion_a_id, 'Option B response',
-      NULL, v_user_id, v_user_id
+      '', v_user_id, v_user_id
     );
   INSERT INTO public.technical_configuration_manual_assessments (
     comparison_set_id, baseline_version_id, criterion_id, technical_axis,

--- a/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
+++ b/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
@@ -1,0 +1,440 @@
+-- P14A2 rollback-only ranking/matrix authorization, bounds, plan and read-only gate.
+BEGIN;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN RAISE EXCEPTION '%', p_label; END IF;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT, p_expected_message TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE v_state TEXT; v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE, v_message = MESSAGE_TEXT;
+    IF v_state IS DISTINCT FROM p_expected_state
+       OR v_message IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION '%: expected [%] %, got [%] %',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role, 'role', 'authenticated',
+      'user_id', p_user_id::TEXT, 'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.snapshot_counts(p_dossier_id UUID, p_version_id UUID)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT jsonb_build_object(
+    'sets', (SELECT count(*) FROM public.technical_configuration_comparison_sets
+      WHERE dossier_id = p_dossier_id AND baseline_version_id = p_version_id),
+    'responses', (SELECT count(*) FROM public.technical_configuration_option_responses
+      WHERE baseline_version_id = p_version_id),
+    'documents', (SELECT count(*) FROM public.technical_configuration_option_documents d
+      JOIN public.technical_configuration_options o ON o.id = d.option_id
+      WHERE o.dossier_id = p_dossier_id),
+    'citations', (SELECT count(*) FROM public.technical_configuration_option_citations
+      WHERE baseline_version_id = p_version_id),
+    'assessments', (SELECT count(*) FROM public.technical_configuration_manual_assessments
+      WHERE baseline_version_id = p_version_id),
+    'dossier_revision', (SELECT revision FROM public.technical_configuration_dossiers
+      WHERE id = p_dossier_id),
+    'baseline_revision', (SELECT revision FROM public.technical_configuration_baseline_versions
+      WHERE id = p_version_id)
+  );
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_group_id UUID := gen_random_uuid();
+  v_criterion_a_id UUID := gen_random_uuid();
+  v_criterion_b_id UUID := gen_random_uuid();
+  v_supplier_a_id UUID := gen_random_uuid();
+  v_supplier_b_id UUID := gen_random_uuid();
+  v_supplier_c_id UUID := gen_random_uuid();
+  v_option_a_id UUID := gen_random_uuid();
+  v_option_b_id UUID := gen_random_uuid();
+  v_option_c_id UUID := gen_random_uuid();
+  v_set_a_id UUID := gen_random_uuid();
+  v_set_b_id UUID := gen_random_uuid();
+  v_document_id UUID := gen_random_uuid();
+  v_reference_product_id UUID := gen_random_uuid();
+  v_full_ranking JSONB;
+  v_selected_ranking JSONB;
+  v_reference_ranking JSONB;
+  v_matrix JSONB;
+  v_page_one JSONB;
+  v_page_two JSONB;
+  v_beyond JSONB;
+  v_sparse_cell JSONB;
+  v_before JSONB;
+  v_after JSONB;
+  v_ranking_definition TEXT;
+  v_matrix_definition TEXT;
+  v_snapshot_definition TEXT;
+  v_plan JSON;
+  v_ranking_signature TEXT :=
+    'public.technical_configuration_result_export_ranking_list(uuid,uuid,uuid[],uuid[],integer,integer)';
+  v_matrix_signature TEXT :=
+    'public.technical_configuration_result_export_matrix_list(uuid,uuid,uuid[],uuid[],integer,integer)';
+  v_helper_signature TEXT :=
+    'public._technical_configuration_reference_ranking_snapshot(uuid,uuid)';
+  v_token_helper_signature TEXT :=
+    'public._technical_configuration_reference_ranking_token(uuid,uuid)';
+  v_snapshot_helper_signature TEXT :=
+    'public._technical_configuration_result_export_snapshot(uuid,uuid,uuid[],uuid[])';
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_result_export_pages_phase_gate'));
+
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P14A2 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  PERFORM pg_temp.assert_true('ranking PUBLIC execute revoked',
+    NOT has_function_privilege('public', v_ranking_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking anon execute revoked',
+    NOT has_function_privilege('anon', v_ranking_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking authenticated execute granted',
+    has_function_privilege('authenticated', v_ranking_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('matrix PUBLIC execute revoked',
+    NOT has_function_privilege('public', v_matrix_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('matrix anon execute revoked',
+    NOT has_function_privilege('anon', v_matrix_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('matrix authenticated execute granted',
+    has_function_privilege('authenticated', v_matrix_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('matrix service role execute granted',
+    has_function_privilege('service_role', v_matrix_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('private ranking helper stays service-only',
+    NOT has_function_privilege('authenticated', v_helper_signature, 'EXECUTE')
+    AND has_function_privilege('service_role', v_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking token helper PUBLIC execute revoked',
+    NOT has_function_privilege('public', v_token_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking token helper anon execute revoked',
+    NOT has_function_privilege('anon', v_token_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking token helper authenticated execute revoked',
+    NOT has_function_privilege('authenticated', v_token_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('ranking token helper service role execute granted',
+    has_function_privilege('service_role', v_token_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('all page functions are stable',
+    (SELECT bool_and(proc.provolatile = 's')
+     FROM pg_proc proc
+     WHERE proc.oid IN (
+       v_ranking_signature::regprocedure,
+       v_matrix_signature::regprocedure,
+       v_helper_signature::regprocedure,
+       v_token_helper_signature::regprocedure,
+       v_snapshot_helper_signature::regprocedure,
+       'public.technical_configuration_reference_ranking_list(uuid,uuid,integer,integer)'::regprocedure
+     )));
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, created_by, updated_by
+  ) VALUES (
+    v_dossier_id, 'P14A2 device ' || v_suffix, 'P14A2 dossier ' || v_suffix,
+    v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, revision,
+    created_by, updated_by
+  ) VALUES (
+    v_version_id, v_dossier_id, 1, 'draft', 3, 1, v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES (
+    v_group_id, v_version_id, 'P14A2 Group', 1, v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id, baseline_version_id, group_id, criterion_code, title, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES
+    (
+      v_criterion_a_id, v_version_id, v_group_id, 'TC-0001', 'Criterion A',
+      'Requirement A', 1, v_user_id, v_user_id
+    ),
+    (
+      v_criterion_b_id, v_version_id, v_group_id, 'TC-0002', 'Criterion B',
+      'Requirement B', 2, v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  ) VALUES
+    (v_supplier_a_id, v_dossier_id, 'A Supplier', v_user_id, v_user_id),
+    (v_supplier_b_id, v_dossier_id, 'B Supplier', v_user_id, v_user_id),
+    (v_supplier_c_id, v_dossier_id, 'C Supplier', v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, model, manufacturer, option_name,
+    created_by, updated_by
+  ) VALUES
+    (
+      v_option_a_id, v_dossier_id, v_supplier_a_id, 'Model A', 'Maker A',
+      'Option A', v_user_id, v_user_id
+    ),
+    (
+      v_option_b_id, v_dossier_id, v_supplier_b_id, 'Model B', 'Maker B',
+      'Option B', v_user_id, v_user_id
+    ),
+    (
+      v_option_c_id, v_dossier_id, v_supplier_c_id, 'Model C', 'Maker C',
+      'Option C', v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id, dossier_id, option_id, baseline_version_id, created_by, updated_by
+  ) VALUES
+    (v_set_a_id, v_dossier_id, v_option_a_id, v_version_id, v_user_id, v_user_id),
+    (v_set_b_id, v_dossier_id, v_option_b_id, v_version_id, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_option_responses (
+    comparison_set_id, baseline_version_id, criterion_id, response_text,
+    supplementary_information, created_by, updated_by
+  ) VALUES
+    (
+      v_set_a_id, v_version_id, v_criterion_a_id, 'Option A response',
+      'Option A supplementary', v_user_id, v_user_id
+    ),
+    (
+      v_set_b_id, v_version_id, v_criterion_a_id, 'Option B response',
+      NULL, v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_manual_assessments (
+    comparison_set_id, baseline_version_id, criterion_id, technical_axis,
+    evidence_axis, notes, created_by, updated_by
+  ) VALUES
+    (v_set_a_id, v_version_id, v_criterion_a_id, 'meets', 'complete', '', v_user_id, v_user_id),
+    (v_set_a_id, v_version_id, v_criterion_b_id, 'exceeds', 'complete', '', v_user_id, v_user_id),
+    (v_set_b_id, v_version_id, v_criterion_a_id, 'meets', 'complete', '', v_user_id, v_user_id),
+    (v_set_b_id, v_version_id, v_criterion_b_id, 'exceeds', 'complete', '', v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_option_documents (
+    id, option_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_document_id, v_option_a_id, 'P14A2 document',
+    'https://example.com/p14a2.pdf', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_option_citations (
+    option_id, baseline_version_id, comparison_set_id, option_document_id,
+    criterion_id, page_section, excerpt, created_by, updated_by
+  ) VALUES (
+    v_option_a_id, v_version_id, v_set_a_id, v_document_id,
+    v_criterion_a_id, 'Section A', 'Citation A', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_reference_products (
+    id, baseline_version_id, model, description, created_by, updated_by
+  ) VALUES (
+    v_reference_product_id, v_version_id, 'REFERENCE-LEAK-MARKER',
+    'REFERENCE-LEAK-MARKER', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_reference_responses (
+    baseline_version_id, reference_product_id, criterion_id, response_text,
+    created_by, updated_by
+  ) VALUES (
+    v_version_id, v_reference_product_id, v_criterion_a_id,
+    'REFERENCE-LEAK-MARKER', v_user_id, v_user_id
+  );
+
+  v_before := pg_temp.snapshot_counts(v_dossier_id, v_version_id);
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_result_export_ranking_list(%L,%L,NULL,NULL,1,100)',
+      v_dossier_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('user', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'denied role rejected',
+    format(
+      'SELECT public.technical_configuration_result_export_matrix_list(%L,%L,NULL,NULL,1,1000)',
+      v_dossier_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id, NULL, NULL, 1, 1
+  ) INTO v_page_one;
+  PERFORM pg_temp.assert_true('raw admin role remains authorized',
+    v_page_one->>'total' = '3');
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'ranking page bounds rejected',
+    format(
+      'SELECT public.technical_configuration_result_export_ranking_list(%L,%L,NULL,NULL,0,101)',
+      v_dossier_id, v_version_id
+    ),
+    'PT422', 'validation_error'
+  );
+  PERFORM pg_temp.expect_error(
+    'matrix page bounds rejected',
+    format(
+      'SELECT public.technical_configuration_result_export_matrix_list(%L,%L,NULL,NULL,1,1001)',
+      v_dossier_id, v_version_id
+    ),
+    'PT422', 'validation_error'
+  );
+
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id, NULL, NULL, 1, 100
+  ) INTO v_full_ranking;
+  PERFORM pg_temp.assert_true('ranking preserves P12C1 ties and counters',
+    v_full_ranking->>'total' = '3'
+    AND v_full_ranking->'data'->0->>'rank' = '1'
+    AND v_full_ranking->'data'->1->>'rank' = '1'
+    AND v_full_ranking->'data'->2->>'eligibility' = 'incomplete'
+    AND v_full_ranking->'data'->2->>'incomplete_criterion_count' = '2');
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id,
+    ARRAY[v_option_c_id, v_option_a_id], NULL, 1, 100
+  ) INTO v_selected_ranking;
+  PERFORM pg_temp.assert_true('ranking scope filters after complete-universe rank',
+    v_selected_ranking->>'total' = '2'
+    AND v_selected_ranking->'data'->0->>'option_id' = v_option_a_id::TEXT
+    AND v_selected_ranking->'data'->0->>'rank' = '1'
+    AND v_selected_ranking->'data'->1->>'option_id' = v_option_c_id::TEXT);
+  SELECT public.technical_configuration_reference_ranking_list(
+    v_dossier_id, v_version_id, 1, 100
+  ) INTO v_reference_ranking;
+  PERFORM pg_temp.assert_true('P12C1 response remains backward compatible',
+    v_reference_ranking->'data' = v_full_ranking->'data'
+    AND v_reference_ranking->'total' = v_full_ranking->'total'
+    AND v_reference_ranking->>'snapshot_token'
+      = v_full_ranking->>'ranking_snapshot_token');
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id, NULL, NULL, 1, 2
+  ) INTO v_page_one;
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id, NULL, NULL, 2, 2
+  ) INTO v_page_two;
+  PERFORM pg_temp.assert_true('ranking non-empty second page stays stable',
+    jsonb_array_length(v_page_one->'data') = 2
+    AND jsonb_array_length(v_page_two->'data') = 1
+    AND v_page_two->'data'->0->>'option_id' = v_option_c_id::TEXT
+    AND v_page_two->>'total' = v_page_one->>'total'
+    AND v_page_two->>'snapshot_token' = v_page_one->>'snapshot_token'
+    AND v_page_two->>'ranking_snapshot_token'
+      = v_page_one->>'ranking_snapshot_token'
+    AND v_page_one->>'page' = '1'
+    AND v_page_two->>'page' = '2'
+    AND v_page_two->>'page_size' = '2');
+  SELECT public.technical_configuration_result_export_ranking_list(
+    v_dossier_id, v_version_id, NULL, NULL, 2, 100
+  ) INTO v_beyond;
+  PERFORM pg_temp.assert_true('ranking page beyond end stays stable',
+    v_beyond->'data' = '[]'::JSONB
+    AND v_beyond->'total' = v_full_ranking->'total'
+    AND v_beyond->>'snapshot_token' = v_full_ranking->>'snapshot_token');
+
+  SELECT public.technical_configuration_result_export_matrix_list(
+    v_dossier_id, v_version_id,
+    ARRAY[v_option_b_id, v_option_a_id, v_option_c_id],
+    ARRAY[v_criterion_b_id, v_criterion_a_id],
+    1, 1000
+  ) INTO v_matrix;
+  PERFORM pg_temp.assert_true('matrix preserves requested criterion-option order',
+    v_matrix->>'total' = '6'
+    AND v_matrix->'data'->0->>'criterion_id' = v_criterion_b_id::TEXT
+    AND v_matrix->'data'->0->>'option_id' = v_option_b_id::TEXT
+    AND v_matrix->'data'->3->>'criterion_id' = v_criterion_a_id::TEXT
+    AND v_matrix->'data'->3->>'option_id' = v_option_b_id::TEXT);
+  SELECT cell INTO v_sparse_cell
+  FROM jsonb_array_elements(v_matrix->'data') cell
+  WHERE cell->>'option_id' = v_option_c_id::TEXT
+    AND cell->>'criterion_id' = v_criterion_a_id::TEXT;
+  PERFORM pg_temp.assert_true('sparse matrix returns null and empty links',
+    v_sparse_cell->'response_text' = 'null'::JSONB
+    AND v_sparse_cell->'technical_axis' = 'null'::JSONB
+    AND v_sparse_cell->'document_links' = '[]'::JSONB
+    AND v_sparse_cell->>'conclusion' = 'not_evaluated');
+  PERFORM pg_temp.assert_true('reference products never enter matrix cells',
+    position('REFERENCE-LEAK-MARKER' IN v_matrix::TEXT) = 0);
+  SELECT public.technical_configuration_result_export_matrix_list(
+    v_dossier_id, v_version_id,
+    ARRAY[v_option_b_id, v_option_a_id, v_option_c_id],
+    ARRAY[v_criterion_b_id, v_criterion_a_id],
+    1, 4
+  ) INTO v_page_one;
+  SELECT public.technical_configuration_result_export_matrix_list(
+    v_dossier_id, v_version_id,
+    ARRAY[v_option_b_id, v_option_a_id, v_option_c_id],
+    ARRAY[v_criterion_b_id, v_criterion_a_id],
+    2, 4
+  ) INTO v_page_two;
+  PERFORM pg_temp.assert_true('matrix non-empty second page stays stable',
+    jsonb_array_length(v_page_one->'data') = 4
+    AND jsonb_array_length(v_page_two->'data') = 2
+    AND v_page_two->'data'->0->>'criterion_id' = v_criterion_a_id::TEXT
+    AND v_page_two->'data'->0->>'option_id' = v_option_a_id::TEXT
+    AND v_page_two->'data'->1->>'option_id' = v_option_c_id::TEXT
+    AND v_page_two->>'total' = v_page_one->>'total'
+    AND v_page_two->>'snapshot_token' = v_page_one->>'snapshot_token'
+    AND v_page_two->>'ranking_snapshot_token'
+      = v_page_one->>'ranking_snapshot_token'
+    AND v_page_one->>'page' = '1'
+    AND v_page_two->>'page' = '2'
+    AND v_page_two->>'page_size' = '4');
+  SELECT public.technical_configuration_result_export_matrix_list(
+    v_dossier_id, v_version_id, NULL, NULL, 2, 1000
+  ) INTO v_beyond;
+  PERFORM pg_temp.assert_true('matrix page beyond end stays stable',
+    v_beyond->'data' = '[]'::JSONB
+    AND v_beyond->>'snapshot_token' = v_full_ranking->>'snapshot_token');
+
+  SELECT pg_get_functiondef(v_ranking_signature::regprocedure),
+         pg_get_functiondef(v_matrix_signature::regprocedure),
+         pg_get_functiondef(v_snapshot_helper_signature::regprocedure)
+  INTO v_ranking_definition, v_matrix_definition, v_snapshot_definition;
+  PERFORM pg_temp.assert_true('snapshot token avoids repeated ranking page scan',
+    position(
+      'TECHNICAL_CONFIGURATION_REFERENCE_RANKING_LIST'
+      IN upper(v_snapshot_definition)
+    ) = 0
+    AND position(
+      '_TECHNICAL_CONFIGURATION_REFERENCE_RANKING_TOKEN'
+      IN upper(v_snapshot_definition)
+    ) > 0);
+  EXECUTE format(
+    'EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT public.technical_configuration_result_export_matrix_list(%L,%L,NULL,NULL,1,1000)',
+    v_dossier_id, v_version_id
+  ) INTO v_plan;
+  PERFORM pg_temp.assert_true('matrix bounded call executes without temporary spill',
+    v_plan IS NOT NULL
+    AND v_plan::TEXT !~ '"Temp (Read|Written) Blocks": [1-9]'
+    AND position(' LOOP' IN upper(v_ranking_definition || v_matrix_definition)) = 0
+    AND position('GET_OR_CREATE' IN upper(v_ranking_definition || v_matrix_definition)) = 0
+    AND position('LIMIT P_PAGE_SIZE' IN upper(v_ranking_definition || v_matrix_definition)) > 0);
+
+  v_after := pg_temp.snapshot_counts(v_dossier_id, v_version_id);
+  PERFORM pg_temp.assert_true('result export pages remain read-only', v_before = v_after);
+END;
+$gate$;
+
+ROLLBACK;

--- a/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
+++ b/supabase/tests/technical_configuration_result_export_pages_phase_gate.sql
@@ -106,6 +106,8 @@ DECLARE
     'public._technical_configuration_reference_ranking_token(uuid,uuid)';
   v_snapshot_helper_signature TEXT :=
     'public._technical_configuration_result_export_snapshot(uuid,uuid,uuid[],uuid[])';
+  v_label_helper_signature TEXT := 'public._technical_configuration_option_display_label(text,text,text)';
+  v_status_helper_signature TEXT := 'public._technical_configuration_derived_status(text,text)';
 BEGIN
   PERFORM pg_advisory_xact_lock(
     hashtext('technical_configuration_result_export_pages_phase_gate'));
@@ -136,6 +138,13 @@ BEGIN
   PERFORM pg_temp.assert_true('private ranking helper stays service-only',
     NOT has_function_privilege('authenticated', v_helper_signature, 'EXECUTE')
     AND has_function_privilege('service_role', v_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('shared expression helpers are immutable and service-only',
+    (SELECT bool_and(proc.provolatile = 'i') FROM pg_proc proc
+     WHERE proc.oid IN (v_label_helper_signature::regprocedure, v_status_helper_signature::regprocedure))
+    AND NOT has_function_privilege('authenticated', v_label_helper_signature, 'EXECUTE')
+    AND has_function_privilege('service_role', v_label_helper_signature, 'EXECUTE')
+    AND NOT has_function_privilege('authenticated', v_status_helper_signature, 'EXECUTE')
+    AND has_function_privilege('service_role', v_status_helper_signature, 'EXECUTE'));
   PERFORM pg_temp.assert_true('ranking token helper PUBLIC execute revoked',
     NOT has_function_privilege('public', v_token_helper_signature, 'EXECUTE'));
   PERFORM pg_temp.assert_true('ranking token helper anon execute revoked',
@@ -425,9 +434,8 @@ BEGIN
     'EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT public.technical_configuration_result_export_matrix_list(%L,%L,NULL,NULL,1,1000)',
     v_dossier_id, v_version_id
   ) INTO v_plan;
-  PERFORM pg_temp.assert_true('matrix bounded call executes without temporary spill',
+  PERFORM pg_temp.assert_true('matrix bounded wrapper executes and source stays set-based',
     v_plan IS NOT NULL
-    AND v_plan::TEXT !~ '"Temp (Read|Written) Blocks": [1-9]'
     AND position(' LOOP' IN upper(v_ranking_definition || v_matrix_definition)) = 0
     AND position('GET_OR_CREATE' IN upper(v_ranking_definition || v_matrix_definition)) = 0
     AND position('LIMIT P_PAGE_SIZE' IN upper(v_ranking_definition || v_matrix_definition)) > 0);


### PR DESCRIPTION
## Summary

- add the P14A2 bounded ranking RPC with exact P12C1 complete-universe semantics and a 100-row page cap
- supersede the private P14A1 snapshot helper to source the exact ranking token directly, avoiding a preliminary paged P12C1 full scan
- add the flattened matrix RPC with validated criterion/option ordinality, sparse null/empty semantics, exact evidence links and a 1000-cell page cap
- share private immutable option-label and derived-status helpers across ranking and matrix surfaces
- allowlist only the two new P14A2 RPC names and update the P14 OpenSpec contracts, TDD evidence and migration order

## Scope

P14A2 only. No P14A3 typed adapters/collector, UI, workbook rendering or download flow is included.

## Evidence

- initial RED proved the migrations, phase gate and RPC names were absent
- review RED proved the snapshot helper caused a repeated full-universe ranking scan and that outer PL/pgSQL EXPLAIN cannot establish nested temp-spill behavior
- shared immutable helpers remove option-label and seven-status expression drift between ranking and matrix
- both immutable helpers pin `search_path = pg_catalog` while remaining service-role-only
- focused P12C1/P14A1/P14A2 tests: 35/35 passed
- format, no-explicit-any, diff-only dedupe, typecheck and git diff checks passed
- React Doctor: 100/100, no issues
- strict OpenSpec validation passed
- all changed source/test files remain below the 450-line hard ceiling

The rollback-only phase gate executes the bounded matrix wrapper and separately checks the function source for no loop/get-or-create path and an explicit page-size limit. It does not claim visibility into nested PL/pgSQL statement plans or temp-spill behavior.

## Live DB status

Applied through Supabase MCP on 2026-08-02:

- `20260802092214` -> live `20260802111235`
- `20260802092215` -> live `20260802111352`
- `20260802092216` -> live `20260802111437`
- helper search-path hardening `20260802092217` -> live `20260802112335`

The first rollback-only phase-gate attempt aborted cleanly because its fixture used `NULL` against the deployed `supplementary_information NOT NULL DEFAULT ''` contract. The corrected fixture uses `''`; the full gate then passed twice, including after the superseding helper migration, and left zero fixture dossiers.

Security/performance advisors were rerun. The P14A2 helper search-path warning is resolved; remaining notices are pre-existing baseline findings outside this leaf. P14A2.3 is complete.

Refs #840

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P14A2 paginated export pages for ranking and a flattened matrix with deterministic order, bounded pages, and read-only behavior. Reuses a single P12C1 ranking source, sources the ranking token directly, and aligns helpers/tokens across surfaces, addressing Linear #840.

- **New Features**
  - New read-only RPCs: ranking and matrix pages with stable `snapshot_token`/`ranking_snapshot_token` and page caps (100/1000).
  - Ranking: computed once over the complete P12C1 universe via a shared `DENSE_RANK` source, then filtered to the requested options; exact item shape and stable ties/counters.
  - Matrix: flattened criterion×option cells with validated ordinality, sparse null/empty semantics, exact document links, and a seven-status conclusion; reference/baseline-only evidence excluded. Shared immutable option-label and derived-status helpers now pin `search_path = pg_catalog`.

- **Migration**
  - Apply, in order: 20260802092214, 20260802092215, 20260802092216, 20260802092217; then run the rollback-only phase gate.
  - Functions are STABLE and least-privilege: public pages granted to `authenticated`/`service_role`; private helpers service-only. No live DB apply yet; proceed only after explicit approval.

<sup>Written for commit 607270c871d01f9899a712472a321d9667cb590a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated ranking exports with filtering, eligibility details, ranking metrics, and consistent snapshot information.
  * Added paginated matrix exports with deterministic criterion and option ordering.
  * Matrix results now include responses, assessments, document links, missing-data handling, and conclusion statuses.
  * Scoped exports preserve complete-universe totals and ranking positions for reliable comparisons.
* **Bug Fixes**
  * Improved consistency between ranking and matrix export data through shared snapshots and tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->