### PR TITLE
feat: add P14A3 typed export collector

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3059,24 +3059,30 @@ P14A1 snapshot identities. No UI can call them yet and no export file exists.
 ### Planned files
 
 - Create:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-types.ts`
+- Create:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts`
+- Create:
   `src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts`
 - Create:
   `src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts`
 - Create:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-fixtures.ts`
 
 ### Tasks
 
-- [ ] Write RED adapter tests for exact wire decoding, error taxonomy, nullable
+- [x] Write RED adapter tests for exact wire decoding, error taxonomy, nullable
       fields and rejection of malformed identities/totals/tokens.
-- [ ] Write RED collector tests for all pages, deterministic key uniqueness,
+- [x] Write RED collector tests for all pages, deterministic key uniqueness,
       complete-before-publish, requested-surface short-circuiting and final
       manifest revalidation.
-- [ ] Implement module-local typed RPC adapters through the existing
+- [x] Implement module-local typed RPC adapters through the existing
       technical-configuration RPC client; do not change shared `callRpc()`.
-- [ ] Collect pages sequentially, validate every response against the first
+- [x] Collect pages sequentially, validate every response against the first
       manifest and reject the entire dataset when the final manifest differs.
-- [ ] Prove `ranking_only` never fetches matrix pages and
+- [x] Prove `ranking_only` never fetches matrix pages and
       `detailed_matrix_only` never fetches ranking pages.
 
 ### Exit gate

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -369,21 +369,21 @@ UI or download.
   PT404/PT409/PT422/PT500 and sanitized HTTP 500 handling, malformed 2xx JSON,
   malformed identity/selected-scope totals/tokens, exact bounded-page
   cardinality, zero/one/many pages, duplicate or missing matrix keys, malformed
-  nested document links, final-manifest drift, cancellation signal forwarding
-  and requested-surface suppression.
+  nested document links, final-manifest drift, custom and timeout cancellation
+  reason preservation, deep runtime freezing and requested-surface suppression.
 - The adapter calls the existing `callTechnicalConfigurationRpc()` seam and the
   collector reuses `collectStableTechnicalConfigurationPages()`. No shared
   `callRpc()` behavior, query key, hook, UI, ExcelJS, workbook or download seam
   changed.
 - Approved file ownership extraction keeps each source below the repository
-  threshold: types `149`, decoders `348`, RPC adapter `129` and collector `226`
+  threshold: types `149`, decoders `348`, RPC adapter `130` and collector `242`
   lines.
 - Ranking pages use fixed size `100`; matrix pages use fixed size `1000`.
   Collection is sequential, validates dossier/baseline identity, page metadata,
   manifest totals, both opaque tokens and deterministic keys, and only returns
   the frozen dataset after the final manifest matches the first.
-- Focused P14A3 tests pass `24/24`; shared pagination and reference-ranking
-  regressions bring the focused total to `43/43`. Format, no-explicit-any,
+- Focused P14A3 tests pass `29/29`; shared pagination and reference-ranking
+  regressions bring the focused total to `48/48`. Format, no-explicit-any,
   diff-only dedupe and typecheck gates pass. React Doctor reports `100/100`, and
   strict OpenSpec validation passes.
 

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -315,11 +315,17 @@ workbook, UI or download.
 ### Planned Files
 
 - Create:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-types.ts`
+- Create:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts`
+- Create:
   `src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts`
 - Create:
   `src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts`
 - Create:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-fixtures.ts`
 
 ### RED
 
@@ -351,6 +357,35 @@ workbook, UI or download.
 
 **Deploy boundary:** typed data contract only; no production caller, ExcelJS,
 UI or download.
+
+### P14A3 Execution Evidence - 2026-08-02
+
+- Read-only Supabase MCP inspection confirmed the applied P14A1/P14A2 live
+  migrations and all three export RPC signatures, `STABLE SECURITY DEFINER`
+  metadata, pinned `search_path`, authenticated-only Data API exposure and exact
+  public JSON keys. P14A3 adds no migration and performs no live DB write.
+- Initial RED failed because the planned adapter and collector modules did not
+  exist. The focused suite now covers exact/nullable wire decoding, typed
+  PT404/PT409/PT422/PT500 and sanitized HTTP 500 handling, malformed 2xx JSON,
+  malformed identity/selected-scope totals/tokens, exact bounded-page
+  cardinality, zero/one/many pages, duplicate or missing matrix keys, malformed
+  nested document links, final-manifest drift, cancellation signal forwarding
+  and requested-surface suppression.
+- The adapter calls the existing `callTechnicalConfigurationRpc()` seam and the
+  collector reuses `collectStableTechnicalConfigurationPages()`. No shared
+  `callRpc()` behavior, query key, hook, UI, ExcelJS, workbook or download seam
+  changed.
+- Approved file ownership extraction keeps each source below the repository
+  threshold: types `149`, decoders `348`, RPC adapter `129` and collector `226`
+  lines.
+- Ranking pages use fixed size `100`; matrix pages use fixed size `1000`.
+  Collection is sequential, validates dossier/baseline identity, page metadata,
+  manifest totals, both opaque tokens and deterministic keys, and only returns
+  the frozen dataset after the final manifest matches the first.
+- Focused P14A3 tests pass `24/24`; shared pagination and reference-ranking
+  regressions bring the focused total to `43/43`. Format, no-explicit-any,
+  diff-only dedupe and typecheck gates pass. React Doctor reports `100/100`, and
+  strict OpenSpec validation passes.
 
 ## P14B1 - Result Workbook Schema And Representative Fixtures
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -879,12 +879,12 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14A3 - Typed Export Adapters And Stable Dataset Collector
 
-- [ ] P14A3.1 Khóa exact wire decoding, typed errors, nullable fields và malformed
+- [x] P14A3.1 Khóa exact wire decoding, typed errors, nullable fields và malformed
       identity/total/token rejection.
-- [ ] P14A3.2 Thu tuần tự mọi required page, validate keys/totals/tokens, đọc lại
+- [x] P14A3.2 Thu tuần tự mọi required page, validate keys/totals/tokens, đọc lại
       manifest và không publish partial dataset.
-- [ ] P14A3.3 Không fetch ranking hoặc matrix surface ngoài mode người dùng chọn.
-- [ ] P14A3.4 Không mount query/UI, không import ExcelJS và không download.
+- [x] P14A3.3 Không fetch ranking hoặc matrix surface ngoài mode người dùng chọn.
+- [x] P14A3.4 Không mount query/UI, không import ExcelJS và không download.
 
 ## Phase P14B1 - Result Workbook Schema And Representative Fixtures
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { RESULT_EXPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-result-export-rpcs"
+
+import { collectTechnicalConfigurationResultExportDataset } from "../technical-configuration-result-export-data"
+import {
+  getTechnicalConfigurationResultExportManifest,
+  TechnicalConfigurationResultExportError,
+} from "../technical-configuration-result-export-rpc"
+import {
+  BASELINE_ID,
+  createManyPageFixture,
+  createPagedHandler,
+  CRITERION_IDS,
+  DOSSIER_ID,
+  exportRequest,
+  installRpcMock,
+  jsonResponse,
+  manifestResponse,
+  matrixRows,
+  OPTION_IDS,
+  rankingRows,
+  type RpcCall,
+} from "./technical-configuration-result-export-fixtures"
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("P14A3 result export RPC adapters", () => {
+  it.each([
+    { label: "PT404", status: 404, code: "PT404", kind: "not_found" },
+    { label: "PT409", status: 409, code: "PT409", kind: "conflict" },
+    { label: "PT422", status: 422, code: "PT422", kind: "validation" },
+    { label: "PT500", status: 500, code: "PT500", kind: "server" },
+    { label: "sanitized 500", status: 500, code: undefined, kind: "server" },
+  ] as const)("classifies $label failures as $kind", async ({ status, code, kind }) => {
+    installRpcMock(() =>
+      jsonResponse(
+        code === undefined
+          ? { error: "RPC upstream error" }
+          : { error: { code, message: "rpc_error", details: "details", hint: "hint" } },
+        status
+      )
+    )
+
+    await expect(
+      getTechnicalConfigurationResultExportManifest({
+        p_dossier_id: DOSSIER_ID,
+        p_baseline_version_id: BASELINE_ID,
+        p_option_ids: null,
+        p_criterion_ids: null,
+      })
+    ).rejects.toMatchObject({
+      name: "TechnicalConfigurationResultExportError",
+      kind,
+      status,
+      code,
+    })
+  })
+
+  it("classifies malformed successful JSON as an invalid response", async () => {
+    installRpcMock(() => new Response("not-json", { status: 200 }))
+
+    await expect(
+      getTechnicalConfigurationResultExportManifest({
+        p_dossier_id: DOSSIER_ID,
+        p_baseline_version_id: BASELINE_ID,
+        p_option_ids: null,
+        p_criterion_ids: null,
+      })
+    ).rejects.toMatchObject({ kind: "invalid_response", status: 200 })
+  })
+
+  it.each([
+    {
+      name: "malformed identity",
+      response: {
+        ...manifestResponse,
+        data: {
+          ...manifestResponse.data,
+          dossier: { ...manifestResponse.data.dossier, id: "not-a-uuid" },
+        },
+      },
+    },
+    {
+      name: "selected option total mismatch",
+      response: {
+        ...manifestResponse,
+        data: { ...manifestResponse.data, option_total: 1 },
+      },
+    },
+    {
+      name: "selected criterion total mismatch",
+      response: {
+        ...manifestResponse,
+        data: { ...manifestResponse.data, criterion_total: 1 },
+      },
+    },
+    {
+      name: "empty token",
+      response: {
+        ...manifestResponse,
+        data: { ...manifestResponse.data, snapshot_token: "" },
+      },
+    },
+    {
+      name: "unexpected field",
+      response: {
+        ...manifestResponse,
+        data: { ...manifestResponse.data, option_ids: OPTION_IDS },
+      },
+    },
+  ])("rejects $name instead of accepting a malformed manifest", async ({ response }) => {
+    installRpcMock(() => jsonResponse(response))
+
+    await expect(
+      getTechnicalConfigurationResultExportManifest({
+        p_dossier_id: DOSSIER_ID,
+        p_baseline_version_id: BASELINE_ID,
+        p_option_ids: OPTION_IDS,
+        p_criterion_ids: CRITERION_IDS,
+      })
+    ).rejects.toBeInstanceOf(TechnicalConfigurationResultExportError)
+  })
+})
+
+describe("P14A3 stable result export dataset collector", () => {
+  it("collects real bounded pages sequentially and freezes the complete dataset", async () => {
+    const fixture = createManyPageFixture()
+    const { calls } = installRpcMock(
+      createPagedHandler({
+        manifest: fixture.manifest,
+        finalManifest: fixture.manifest,
+        rankingPages: [fixture.rankings.slice(0, 100), fixture.rankings.slice(100)],
+        matrixPages: [fixture.matrix.slice(0, 1000), fixture.matrix.slice(1000)],
+      })
+    )
+
+    const dataset = await collectTechnicalConfigurationResultExportDataset({
+      ...exportRequest(),
+      optionIds: fixture.optionIds,
+      criterionIds: fixture.criterionIds,
+    })
+
+    expect(dataset.ranking).toHaveLength(101)
+    expect(dataset.matrix).toHaveLength(1010)
+    expect(Object.isFrozen(dataset)).toBe(true)
+    expect(Object.isFrozen(dataset.ranking)).toBe(true)
+    expect(Object.isFrozen(dataset.matrix)).toBe(true)
+    expect(calls.map(({ fn, args }) => [fn, args.p_page ?? null])).toEqual([
+      [RESULT_EXPORT_RPC_FUNCTIONS.getManifest, null],
+      [RESULT_EXPORT_RPC_FUNCTIONS.listRanking, 1],
+      [RESULT_EXPORT_RPC_FUNCTIONS.listRanking, 2],
+      [RESULT_EXPORT_RPC_FUNCTIONS.listMatrix, 1],
+      [RESULT_EXPORT_RPC_FUNCTIONS.listMatrix, 2],
+      [RESULT_EXPORT_RPC_FUNCTIONS.getManifest, null],
+    ])
+  })
+
+  it("collects a zero-cell matrix when one selected dimension is empty", async () => {
+    const emptyManifest = { data: { ...manifestResponse.data, option_total: 0 } }
+    const { calls } = installRpcMock(
+      createPagedHandler({
+        manifest: emptyManifest,
+        finalManifest: emptyManifest,
+        rankingPages: [[]],
+        matrixPages: [[]],
+      })
+    )
+
+    await expect(
+      collectTechnicalConfigurationResultExportDataset({
+        ...exportRequest(),
+        optionIds: null,
+      })
+    ).resolves.toMatchObject({ ranking: [], matrix: [] })
+    expect(calls).toHaveLength(4)
+  })
+
+  it.each([
+    {
+      mode: "ranking_only",
+      expected: [
+        RESULT_EXPORT_RPC_FUNCTIONS.getManifest,
+        RESULT_EXPORT_RPC_FUNCTIONS.listRanking,
+        RESULT_EXPORT_RPC_FUNCTIONS.getManifest,
+      ],
+    },
+    {
+      mode: "detailed_matrix_only",
+      expected: [
+        RESULT_EXPORT_RPC_FUNCTIONS.getManifest,
+        RESULT_EXPORT_RPC_FUNCTIONS.listMatrix,
+        RESULT_EXPORT_RPC_FUNCTIONS.getManifest,
+      ],
+    },
+  ] as const)("never fetches an unrequested surface in $mode mode", async ({ mode, expected }) => {
+    const { calls } = installRpcMock(createPagedHandler())
+
+    const dataset = await collectTechnicalConfigurationResultExportDataset(exportRequest(mode))
+
+    expect(dataset.mode).toBe(mode)
+    expect(calls.map(({ fn }) => fn)).toEqual(expected)
+  })
+
+  it("forwards and preserves cancellation from the active page request", async () => {
+    const controller = new AbortController()
+    const abortError = new DOMException("cancelled", "AbortError")
+    let activeSignal: AbortSignal | null = null
+    installRpcMock(({ fn, signal }) => {
+      if (fn === RESULT_EXPORT_RPC_FUNCTIONS.getManifest) return jsonResponse(manifestResponse)
+      activeSignal = signal
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
+      })
+    })
+
+    const result = collectTechnicalConfigurationResultExportDataset({
+      ...exportRequest("ranking_only"),
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(activeSignal).toBe(controller.signal))
+    controller.abort(abortError)
+
+    await expect(result).rejects.toBe(abortError)
+  })
+
+  it.each([
+    {
+      name: "changed ranking token",
+      kind: "snapshot_changed",
+      handler: createPagedHandler({
+        rankingPageOverrides: { 1: { ranking_snapshot_token: "ranking-v2" } },
+      }),
+    },
+    {
+      name: "changed ranking identity",
+      kind: "invalid_response",
+      handler: createPagedHandler({
+        rankingPageOverrides: { 1: { dossier_id: OPTION_IDS[0] } },
+      }),
+    },
+    {
+      name: "changed ranking total",
+      kind: "snapshot_changed",
+      handler: createPagedHandler({
+        rankingPages: [createManyPageFixture().rankings.slice(0, 100)],
+        rankingPageOverrides: { 1: { total: 102 } },
+      }),
+    },
+    {
+      name: "oversized ranking page",
+      kind: "invalid_response",
+      handler: createPagedHandler({
+        rankingPageOverrides: {
+          1: { data: Array.from({ length: 101 }, () => rankingRows[0]), total: 101 },
+        },
+      }),
+    },
+    {
+      name: "duplicate matrix key",
+      kind: "snapshot_changed",
+      handler: createPagedHandler({
+        matrixPages: [[matrixRows[0], matrixRows[0], matrixRows[2], matrixRows[3]]],
+      }),
+    },
+    {
+      name: "missing matrix key",
+      kind: "snapshot_changed",
+      handler: createPagedHandler({
+        matrixPages: [
+          [
+            ...matrixRows.slice(0, 3),
+            { ...matrixRows[3], option_id: "30000000-0000-4000-8000-000000000099" },
+          ],
+        ],
+      }),
+    },
+    {
+      name: "malformed nested document link",
+      kind: "invalid_response",
+      handler: createPagedHandler({
+        matrixPageOverrides: {
+          1: {
+            data: [
+              {
+                ...matrixRows[0],
+                document_links: [{ ...matrixRows[0].document_links[0], citation_id: "bad" }],
+              },
+              ...matrixRows.slice(1),
+            ],
+          },
+        },
+      }),
+    },
+    {
+      name: "changed final manifest",
+      kind: "snapshot_changed",
+      handler: createPagedHandler({
+        finalManifest: {
+          data: {
+            ...manifestResponse.data,
+            dossier: { ...manifestResponse.data.dossier, revision: 10 },
+            snapshot_token: "snapshot-v2",
+          },
+        },
+      }),
+    },
+  ] as const)("rejects the whole dataset on $name", async ({ handler, kind }) => {
+    installRpcMock(handler)
+
+    await expect(
+      collectTechnicalConfigurationResultExportDataset(exportRequest())
+    ).rejects.toMatchObject({
+      name: "TechnicalConfigurationResultExportError",
+      kind,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-data.test.ts
@@ -5,6 +5,7 @@ import { RESULT_EXPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-resul
 import { collectTechnicalConfigurationResultExportDataset } from "../technical-configuration-result-export-data"
 import {
   getTechnicalConfigurationResultExportManifest,
+  listTechnicalConfigurationResultExportRanking,
   TechnicalConfigurationResultExportError,
 } from "../technical-configuration-result-export-rpc"
 import {
@@ -24,6 +25,54 @@ import {
 } from "./technical-configuration-result-export-fixtures"
 
 afterEach(() => vi.unstubAllGlobals())
+
+function pendingRpcResponse(signal: AbortSignal | null): Promise<Response> {
+  if (signal?.aborted) return Promise.reject(signal.reason)
+  return new Promise((_resolve, reject) => {
+    signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
+  })
+}
+
+function startPendingRankingRpc(signal: AbortSignal) {
+  let activeSignal: AbortSignal | null = null
+  installRpcMock(({ signal: requestSignal }) => {
+    activeSignal = requestSignal
+    return pendingRpcResponse(requestSignal)
+  })
+  return {
+    result: listTechnicalConfigurationResultExportRanking(
+      {
+        p_dossier_id: DOSSIER_ID,
+        p_baseline_version_id: BASELINE_ID,
+        p_option_ids: OPTION_IDS,
+        p_criterion_ids: CRITERION_IDS,
+        p_page: 1,
+        p_page_size: 100,
+      },
+      signal
+    ),
+    waitUntilActive: () => vi.waitFor(() => expect(activeSignal).toBe(signal)),
+  }
+}
+
+function startPendingCollection(
+  mode: "ranking_only" | "detailed_matrix_only",
+  signal: AbortSignal
+) {
+  let activeSignal: AbortSignal | null = null
+  installRpcMock(({ fn, signal: requestSignal }) => {
+    if (fn === RESULT_EXPORT_RPC_FUNCTIONS.getManifest) return jsonResponse(manifestResponse)
+    activeSignal = requestSignal
+    return pendingRpcResponse(requestSignal)
+  })
+  return {
+    result: collectTechnicalConfigurationResultExportDataset({
+      ...exportRequest(mode),
+      signal,
+    }),
+    waitUntilActive: () => vi.waitFor(() => expect(activeSignal).toBe(signal)),
+  }
+}
 
 describe("P14A3 result export RPC adapters", () => {
   it.each([
@@ -55,6 +104,29 @@ describe("P14A3 result export RPC adapters", () => {
       status,
       code,
     })
+  })
+
+  it("preserves a custom cancellation reason at the RPC adapter boundary", async () => {
+    const controller = new AbortController()
+    const reason = new Error("custom RPC cancellation")
+    const { result, waitUntilActive } = startPendingRankingRpc(controller.signal)
+    await waitUntilActive()
+    controller.abort(reason)
+
+    await expect(result).rejects.toBe(reason)
+  })
+
+  it("preserves AbortSignal.timeout() at the RPC adapter boundary", async () => {
+    const signal = AbortSignal.timeout(100)
+    const { result, waitUntilActive } = startPendingRankingRpc(signal)
+    const rejection = result.then(
+      () => null,
+      (error: unknown) => error
+    )
+    await waitUntilActive()
+    await vi.waitFor(() => expect(signal.aborted).toBe(true))
+
+    await expect(rejection).resolves.toBe(signal.reason)
   })
 
   it("classifies malformed successful JSON as an invalid response", async () => {
@@ -156,6 +228,21 @@ describe("P14A3 stable result export dataset collector", () => {
     ])
   })
 
+  it("deep-freezes collected rows and nested document links", async () => {
+    installRpcMock(createPagedHandler())
+
+    const dataset = await collectTechnicalConfigurationResultExportDataset(exportRequest())
+
+    expect(dataset.mode).toBe("full")
+    if (dataset.mode !== "full") throw new Error("Expected a full export dataset.")
+    for (const row of dataset.ranking) expect(Object.isFrozen(row)).toBe(true)
+    for (const cell of dataset.matrix) {
+      expect(Object.isFrozen(cell)).toBe(true)
+      expect(Object.isFrozen(cell.document_links)).toBe(true)
+      for (const link of cell.document_links) expect(Object.isFrozen(link)).toBe(true)
+    }
+  })
+
   it("collects a zero-cell matrix when one selected dimension is empty", async () => {
     const emptyManifest = { data: { ...manifestResponse.data, option_total: 0 } }
     const { calls } = installRpcMock(
@@ -202,26 +289,37 @@ describe("P14A3 stable result export dataset collector", () => {
     expect(calls.map(({ fn }) => fn)).toEqual(expected)
   })
 
-  it("forwards and preserves cancellation from the active page request", async () => {
+  it.each([
+    {
+      mode: "ranking_only",
+      name: "AbortError",
+      reason: new DOMException("cancelled", "AbortError"),
+    },
+    {
+      mode: "detailed_matrix_only",
+      name: "custom error",
+      reason: new Error("custom cancellation"),
+    },
+  ] as const)("forwards and preserves $name cancellation in $mode", async ({ mode, reason }) => {
     const controller = new AbortController()
-    const abortError = new DOMException("cancelled", "AbortError")
-    let activeSignal: AbortSignal | null = null
-    installRpcMock(({ fn, signal }) => {
-      if (fn === RESULT_EXPORT_RPC_FUNCTIONS.getManifest) return jsonResponse(manifestResponse)
-      activeSignal = signal
-      return new Promise((_resolve, reject) => {
-        signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
-      })
-    })
+    const { result, waitUntilActive } = startPendingCollection(mode, controller.signal)
+    await waitUntilActive()
+    controller.abort(reason)
 
-    const result = collectTechnicalConfigurationResultExportDataset({
-      ...exportRequest("ranking_only"),
-      signal: controller.signal,
-    })
-    await vi.waitFor(() => expect(activeSignal).toBe(controller.signal))
-    controller.abort(abortError)
+    await expect(result).rejects.toBe(reason)
+  })
 
-    await expect(result).rejects.toBe(abortError)
+  it("preserves the reason from AbortSignal.timeout()", async () => {
+    const signal = AbortSignal.timeout(100)
+    const { result, waitUntilActive } = startPendingCollection("ranking_only", signal)
+    const rejection = result.then(
+      () => null,
+      (error: unknown) => error
+    )
+    await waitUntilActive()
+    await vi.waitFor(() => expect(signal.aborted).toBe(true))
+
+    await expect(rejection).resolves.toBe(signal.reason)
   })
 
   it.each([

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-fixtures.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-fixtures.ts
@@ -1,0 +1,245 @@
+import { vi } from "vitest"
+
+import { RESULT_EXPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-result-export-rpcs"
+
+import type { TechnicalConfigurationResultExportMode } from "../technical-configuration-result-export-data"
+
+export const DOSSIER_ID = "10000000-0000-4000-8000-000000000001"
+export const BASELINE_ID = "20000000-0000-4000-8000-000000000001"
+export const OPTION_IDS = [
+  "30000000-0000-4000-8000-000000000001",
+  "30000000-0000-4000-8000-000000000002",
+] as const
+const SUPPLIER_IDS = [
+  "40000000-0000-4000-8000-000000000001",
+  "40000000-0000-4000-8000-000000000002",
+] as const
+export const CRITERION_IDS = [
+  "50000000-0000-4000-8000-000000000001",
+  "50000000-0000-4000-8000-000000000002",
+] as const
+const GROUP_ID = "60000000-0000-4000-8000-000000000001"
+const DOCUMENT_ID = "70000000-0000-4000-8000-000000000001"
+const CITATION_ID = "80000000-0000-4000-8000-000000000001"
+
+export const manifestResponse = {
+  data: {
+    dossier: {
+      id: DOSSIER_ID,
+      device_type_name: "Máy siêu âm",
+      name: "Cấu hình máy siêu âm",
+      revision: 9,
+      archived_at: null,
+    },
+    baseline_version: {
+      id: BASELINE_ID,
+      dossier_id: DOSSIER_ID,
+      version_number: 3,
+      status: "locked",
+      revision: 4,
+      locked_at: "2026-08-01T02:03:04.000Z",
+    },
+    option_total: 2,
+    criterion_total: 2,
+    snapshot_token: "snapshot-v1",
+    ranking_snapshot_token: "ranking-v1",
+  },
+}
+
+export const rankingRows = OPTION_IDS.map((optionId, index) => ({
+  option_id: optionId,
+  supplier_id: SUPPLIER_IDS[index],
+  supplier_name: `Nhà cung cấp ${index + 1}`,
+  display_label: `Phương án ${index + 1}`,
+  eligibility: index === 0 ? ("eligible" as const) : ("incomplete" as const),
+  incomplete_criterion_count: index,
+  failed_count: 0,
+  insufficient_evidence_count: 0,
+  exceeds_count: index === 0 ? 2 : 0,
+  rank: index === 0 ? 1 : null,
+}))
+
+function createMatrixCell(criterionIndex: number, optionIndex: number) {
+  return {
+    group_id: GROUP_ID,
+    group_name: "Nhóm chung",
+    group_order: 1,
+    criterion_id: CRITERION_IDS[criterionIndex],
+    criterion_code: `TC-${criterionIndex + 1}`,
+    criterion_title: `Tiêu chí ${criterionIndex + 1}`,
+    requirement_text: `Yêu cầu ${criterionIndex + 1}`,
+    criterion_order: criterionIndex + 1,
+    option_id: OPTION_IDS[optionIndex],
+    supplier_id: SUPPLIER_IDS[optionIndex],
+    supplier_name: `Nhà cung cấp ${optionIndex + 1}`,
+    display_label: `Phương án ${optionIndex + 1}`,
+    model: optionIndex === 0 ? "Model A" : null,
+    manufacturer: optionIndex === 0 ? "Hãng A" : null,
+    option_name: optionIndex === 0 ? "Gói A" : null,
+    response_text: optionIndex === 0 ? "Đáp ứng" : null,
+    supplementary_information: optionIndex === 0 ? "" : null,
+    document_links:
+      criterionIndex === 0 && optionIndex === 0
+        ? [
+            {
+              document_id: DOCUMENT_ID,
+              document_name: "Tài liệu kỹ thuật",
+              document_url: "https://example.com/document",
+              citation_id: CITATION_ID,
+              page_section: null,
+              excerpt: "Đoạn trích",
+            },
+          ]
+        : [],
+    technical_axis: optionIndex === 0 ? ("meets" as const) : null,
+    evidence_axis: optionIndex === 0 ? ("complete" as const) : null,
+    assessment_notes: optionIndex === 0 ? "" : null,
+    conclusion: optionIndex === 0 ? ("meets" as const) : ("not_evaluated" as const),
+  }
+}
+
+export const matrixRows = [
+  createMatrixCell(0, 0),
+  createMatrixCell(0, 1),
+  createMatrixCell(1, 0),
+  createMatrixCell(1, 1),
+]
+
+export type RpcCall = {
+  fn: string
+  args: Record<string, unknown>
+  signal: AbortSignal | null
+}
+
+export function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+export function installRpcMock(handler: (call: RpcCall) => Response | Promise<Response>): {
+  calls: RpcCall[]
+} {
+  const calls: RpcCall[] = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const call = {
+        fn: decodeURIComponent(String(input).split("/").at(-1) ?? ""),
+        args: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+        signal: init?.signal ?? null,
+      }
+      calls.push(call)
+      return handler(call)
+    })
+  )
+  return { calls }
+}
+
+export function exportRequest(mode: TechnicalConfigurationResultExportMode = "full") {
+  return {
+    mode,
+    dossierId: DOSSIER_ID,
+    baselineVersionId: BASELINE_ID,
+    optionIds: OPTION_IDS,
+    criterionIds: CRITERION_IDS,
+  } as const
+}
+
+export function createPagedHandler({
+  manifest = manifestResponse,
+  finalManifest = manifestResponse,
+  rankingPages = [rankingRows],
+  matrixPages = [matrixRows],
+  rankingPageOverrides = {},
+  matrixPageOverrides = {},
+}: {
+  manifest?: unknown
+  finalManifest?: unknown
+  rankingPages?: unknown[][]
+  matrixPages?: unknown[][]
+  rankingPageOverrides?: Record<number, Record<string, unknown>>
+  matrixPageOverrides?: Record<number, Record<string, unknown>>
+} = {}) {
+  let manifestCalls = 0
+  return ({ fn, args }: RpcCall) => {
+    if (fn === RESULT_EXPORT_RPC_FUNCTIONS.getManifest) {
+      manifestCalls += 1
+      return jsonResponse(manifestCalls === 1 ? manifest : finalManifest)
+    }
+    if (fn === RESULT_EXPORT_RPC_FUNCTIONS.listRanking) {
+      const page = Number(args.p_page)
+      return jsonResponse({
+        data: rankingPages[page - 1] ?? [],
+        dossier_id: DOSSIER_ID,
+        baseline_version_id: BASELINE_ID,
+        snapshot_token: "snapshot-v1",
+        ranking_snapshot_token: "ranking-v1",
+        total: rankingPages.flat().length,
+        page,
+        page_size: 100,
+        ...rankingPageOverrides[page],
+      })
+    }
+    if (fn === RESULT_EXPORT_RPC_FUNCTIONS.listMatrix) {
+      const page = Number(args.p_page)
+      return jsonResponse({
+        data: matrixPages[page - 1] ?? [],
+        dossier_id: DOSSIER_ID,
+        baseline_version_id: BASELINE_ID,
+        snapshot_token: "snapshot-v1",
+        ranking_snapshot_token: "ranking-v1",
+        total: matrixPages.flat().length,
+        page,
+        page_size: 1000,
+        ...matrixPageOverrides[page],
+      })
+    }
+    throw new Error(`Unexpected RPC: ${fn}`)
+  }
+}
+
+function indexedUuid(namespace: number, index: number) {
+  return `${String(namespace).padStart(8, "0")}-0000-4000-8000-${String(index + 1).padStart(
+    12,
+    "0"
+  )}`
+}
+
+export function createManyPageFixture() {
+  const optionIds = Array.from({ length: 101 }, (_, index) => indexedUuid(30, index))
+  const supplierIds = Array.from({ length: 101 }, (_, index) => indexedUuid(40, index))
+  const criterionIds = Array.from({ length: 10 }, (_, index) => indexedUuid(50, index))
+  const rankings = optionIds.map((optionId, index) => ({
+    ...rankingRows[0],
+    option_id: optionId,
+    supplier_id: supplierIds[index],
+    supplier_name: `Nhà cung cấp ${index + 1}`,
+    display_label: `Phương án ${index + 1}`,
+    rank: index + 1,
+  }))
+  const matrix = criterionIds.flatMap((criterionId, criterionIndex) =>
+    optionIds.map((optionId, optionIndex) => ({
+      ...matrixRows[0],
+      criterion_id: criterionId,
+      criterion_code: `TC-${criterionIndex + 1}`,
+      criterion_title: `Tiêu chí ${criterionIndex + 1}`,
+      requirement_text: `Yêu cầu ${criterionIndex + 1}`,
+      criterion_order: criterionIndex + 1,
+      option_id: optionId,
+      supplier_id: supplierIds[optionIndex],
+      supplier_name: `Nhà cung cấp ${optionIndex + 1}`,
+      display_label: `Phương án ${optionIndex + 1}`,
+      document_links: [],
+    }))
+  )
+  const manifest = {
+    data: {
+      ...manifestResponse.data,
+      option_total: optionIds.length,
+      criterion_total: criterionIds.length,
+    },
+  }
+  return { optionIds, criterionIds, rankings, matrix, manifest }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts
@@ -1,0 +1,226 @@
+import { collectStableTechnicalConfigurationPages } from "./technical-configuration-pagination"
+import {
+  getTechnicalConfigurationResultExportManifest,
+  listTechnicalConfigurationResultExportMatrix,
+  listTechnicalConfigurationResultExportRanking,
+  TechnicalConfigurationResultExportError,
+} from "./technical-configuration-result-export-rpc"
+import type {
+  TechnicalConfigurationResultExportDataset,
+  TechnicalConfigurationResultExportManifestWire,
+  TechnicalConfigurationResultExportMatrixCellWire,
+  TechnicalConfigurationResultExportMatrixPageWireResponse,
+  TechnicalConfigurationResultExportRankingItemWire,
+  TechnicalConfigurationResultExportRankingPageWireResponse,
+  TechnicalConfigurationResultExportRequest,
+  TechnicalConfigurationResultExportScopeRpcArgs,
+} from "./technical-configuration-result-export-types"
+
+export type {
+  TechnicalConfigurationResultExportDataset,
+  TechnicalConfigurationResultExportDocumentLinkWire,
+  TechnicalConfigurationResultExportManifestWire,
+  TechnicalConfigurationResultExportManifestWireResponse,
+  TechnicalConfigurationResultExportMatrixCellWire,
+  TechnicalConfigurationResultExportMatrixPageWireResponse,
+  TechnicalConfigurationResultExportMode,
+  TechnicalConfigurationResultExportPageRpcArgs,
+  TechnicalConfigurationResultExportRankingItemWire,
+  TechnicalConfigurationResultExportRankingPageWireResponse,
+  TechnicalConfigurationResultExportRequest,
+  TechnicalConfigurationResultExportScopeRpcArgs,
+} from "./technical-configuration-result-export-types"
+
+const RANKING_PAGE_SIZE = 100
+const MATRIX_PAGE_SIZE = 1000
+
+function snapshotChanged(): TechnicalConfigurationResultExportError {
+  return new TechnicalConfigurationResultExportError(
+    "snapshot_changed",
+    "Result export snapshot changed during collection."
+  )
+}
+
+function isAbortError(error: unknown): error is DOMException {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function sameTokens(
+  page: {
+    snapshot_token: string
+    ranking_snapshot_token: string
+  },
+  manifest: TechnicalConfigurationResultExportManifestWire
+) {
+  return (
+    page.snapshot_token === manifest.snapshot_token &&
+    page.ranking_snapshot_token === manifest.ranking_snapshot_token
+  )
+}
+
+function sameStringSet(actual: Iterable<string>, expected: readonly string[]) {
+  const actualSet = new Set(actual)
+  const expectedSet = new Set(expected)
+  return (
+    actualSet.size === expectedSet.size && [...actualSet].every((value) => expectedSet.has(value))
+  )
+}
+
+function sameManifest(
+  first: TechnicalConfigurationResultExportManifestWire,
+  final: TechnicalConfigurationResultExportManifestWire
+) {
+  return (
+    first.dossier.id === final.dossier.id &&
+    first.dossier.device_type_name === final.dossier.device_type_name &&
+    first.dossier.name === final.dossier.name &&
+    first.dossier.revision === final.dossier.revision &&
+    first.dossier.archived_at === final.dossier.archived_at &&
+    first.baseline_version.id === final.baseline_version.id &&
+    first.baseline_version.dossier_id === final.baseline_version.dossier_id &&
+    first.baseline_version.version_number === final.baseline_version.version_number &&
+    first.baseline_version.status === final.baseline_version.status &&
+    first.baseline_version.revision === final.baseline_version.revision &&
+    first.baseline_version.locked_at === final.baseline_version.locked_at &&
+    first.option_total === final.option_total &&
+    first.criterion_total === final.criterion_total &&
+    first.snapshot_token === final.snapshot_token &&
+    first.ranking_snapshot_token === final.ranking_snapshot_token
+  )
+}
+
+function freezeManifest(manifest: TechnicalConfigurationResultExportManifestWire) {
+  return Object.freeze({
+    ...manifest,
+    dossier: Object.freeze({ ...manifest.dossier }),
+    baseline_version: Object.freeze({ ...manifest.baseline_version }),
+  })
+}
+
+async function collectRanking(
+  scope: TechnicalConfigurationResultExportScopeRpcArgs,
+  manifest: TechnicalConfigurationResultExportManifestWire,
+  signal?: AbortSignal
+) {
+  try {
+    const { items } = await collectStableTechnicalConfigurationPages<
+      TechnicalConfigurationResultExportRankingItemWire,
+      TechnicalConfigurationResultExportRankingPageWireResponse
+    >({
+      loadPage: async (page) => {
+        const response = await listTechnicalConfigurationResultExportRanking(
+          { ...scope, p_page: page, p_page_size: RANKING_PAGE_SIZE },
+          signal
+        )
+        if (response.total !== manifest.option_total || !sameTokens(response, manifest)) {
+          throw snapshotChanged()
+        }
+        return response
+      },
+      snapshotError: "Result export ranking snapshot changed.",
+      getItemKey: (item) => item.option_id,
+      isSameSnapshot: (first, next) =>
+        first.snapshot_token === next.snapshot_token &&
+        first.ranking_snapshot_token === next.ranking_snapshot_token,
+    })
+    if (
+      scope.p_option_ids !== null &&
+      !sameStringSet(
+        items.map((item) => item.option_id),
+        scope.p_option_ids
+      )
+    ) {
+      throw snapshotChanged()
+    }
+    return Object.freeze(items)
+  } catch (error) {
+    if (error instanceof TechnicalConfigurationResultExportError || isAbortError(error)) throw error
+    throw snapshotChanged()
+  }
+}
+
+function validateMatrixKeys(
+  items: readonly TechnicalConfigurationResultExportMatrixCellWire[],
+  manifest: TechnicalConfigurationResultExportManifestWire,
+  scope: TechnicalConfigurationResultExportScopeRpcArgs
+) {
+  if (items.length === 0 && manifest.option_total * manifest.criterion_total === 0) return
+  const optionIds = items.map((item) => item.option_id)
+  const criterionIds = items.map((item) => item.criterion_id)
+  if (
+    new Set(optionIds).size !== manifest.option_total ||
+    new Set(criterionIds).size !== manifest.criterion_total ||
+    (scope.p_option_ids !== null && !sameStringSet(optionIds, scope.p_option_ids)) ||
+    (scope.p_criterion_ids !== null && !sameStringSet(criterionIds, scope.p_criterion_ids))
+  ) {
+    throw snapshotChanged()
+  }
+}
+
+async function collectMatrix(
+  scope: TechnicalConfigurationResultExportScopeRpcArgs,
+  manifest: TechnicalConfigurationResultExportManifestWire,
+  signal?: AbortSignal
+) {
+  const expectedTotal = manifest.option_total * manifest.criterion_total
+  if (!Number.isSafeInteger(expectedTotal)) throw snapshotChanged()
+  try {
+    const { items } = await collectStableTechnicalConfigurationPages<
+      TechnicalConfigurationResultExportMatrixCellWire,
+      TechnicalConfigurationResultExportMatrixPageWireResponse
+    >({
+      loadPage: async (page) => {
+        const response = await listTechnicalConfigurationResultExportMatrix(
+          { ...scope, p_page: page, p_page_size: MATRIX_PAGE_SIZE },
+          signal
+        )
+        if (response.total !== expectedTotal || !sameTokens(response, manifest)) {
+          throw snapshotChanged()
+        }
+        return response
+      },
+      snapshotError: "Result export matrix snapshot changed.",
+      getItemKey: (item) => `${item.criterion_id}:${item.option_id}`,
+      isSameSnapshot: (first, next) =>
+        first.snapshot_token === next.snapshot_token &&
+        first.ranking_snapshot_token === next.ranking_snapshot_token,
+    })
+    validateMatrixKeys(items, manifest, scope)
+    return Object.freeze(items)
+  } catch (error) {
+    if (error instanceof TechnicalConfigurationResultExportError || isAbortError(error)) throw error
+    throw snapshotChanged()
+  }
+}
+
+/** Collects one complete stable result-export dataset without mounting UI state. */
+export async function collectTechnicalConfigurationResultExportDataset(
+  request: TechnicalConfigurationResultExportRequest
+): Promise<TechnicalConfigurationResultExportDataset> {
+  const scope = {
+    p_dossier_id: request.dossierId,
+    p_baseline_version_id: request.baselineVersionId,
+    p_option_ids: request.optionIds,
+    p_criterion_ids: request.criterionIds,
+  } satisfies TechnicalConfigurationResultExportScopeRpcArgs
+  const firstManifest = (await getTechnicalConfigurationResultExportManifest(scope, request.signal))
+    .data
+  const ranking =
+    request.mode === "detailed_matrix_only"
+      ? null
+      : await collectRanking(scope, firstManifest, request.signal)
+  const matrix =
+    request.mode === "ranking_only"
+      ? null
+      : await collectMatrix(scope, firstManifest, request.signal)
+  const finalManifest = (await getTechnicalConfigurationResultExportManifest(scope, request.signal))
+    .data
+  if (!sameManifest(firstManifest, finalManifest)) throw snapshotChanged()
+
+  return Object.freeze({
+    mode: request.mode,
+    manifest: freezeManifest(firstManifest),
+    ranking,
+    matrix,
+  }) as TechnicalConfigurationResultExportDataset
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-data.ts
@@ -97,6 +97,20 @@ function freezeManifest(manifest: TechnicalConfigurationResultExportManifestWire
   })
 }
 
+function freezeRankingItems(items: readonly TechnicalConfigurationResultExportRankingItemWire[]) {
+  for (const item of items) Object.freeze(item)
+  return Object.freeze(items)
+}
+
+function freezeMatrixItems(items: readonly TechnicalConfigurationResultExportMatrixCellWire[]) {
+  for (const item of items) {
+    for (const link of item.document_links) Object.freeze(link)
+    Object.freeze(item.document_links)
+    Object.freeze(item)
+  }
+  return Object.freeze(items)
+}
+
 async function collectRanking(
   scope: TechnicalConfigurationResultExportScopeRpcArgs,
   manifest: TechnicalConfigurationResultExportManifestWire,
@@ -132,8 +146,9 @@ async function collectRanking(
     ) {
       throw snapshotChanged()
     }
-    return Object.freeze(items)
+    return freezeRankingItems(items)
   } catch (error) {
+    if (signal?.aborted) throw signal.reason
     if (error instanceof TechnicalConfigurationResultExportError || isAbortError(error)) throw error
     throw snapshotChanged()
   }
@@ -186,8 +201,9 @@ async function collectMatrix(
         first.ranking_snapshot_token === next.ranking_snapshot_token,
     })
     validateMatrixKeys(items, manifest, scope)
-    return Object.freeze(items)
+    return freezeMatrixItems(items)
   } catch (error) {
+    if (signal?.aborted) throw signal.reason
     if (error instanceof TechnicalConfigurationResultExportError || isAbortError(error)) throw error
     throw snapshotChanged()
   }

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts
@@ -86,8 +86,8 @@ function exactRecord(value: unknown, keys: readonly string[], path: string) {
     return invalidResponse(path)
   }
   const record = value as Record<string, unknown>
-  const actualKeys = Object.keys(record).sort()
-  const expectedKeys = [...keys].sort()
+  const actualKeys = Object.keys(record).sort((left, right) => left.localeCompare(right))
+  const expectedKeys = [...keys].sort((left, right) => left.localeCompare(right))
   if (
     actualKeys.length !== expectedKeys.length ||
     actualKeys.some((key, index) => key !== expectedKeys[index])

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-decoders.ts
@@ -1,0 +1,348 @@
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+  TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES,
+  TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES,
+} from "@/lib/technical-configuration-evaluation"
+
+import type {
+  TechnicalConfigurationResultExportDocumentLinkWire,
+  TechnicalConfigurationResultExportManifestWireResponse,
+  TechnicalConfigurationResultExportMatrixCellWire,
+  TechnicalConfigurationResultExportPageRpcArgs,
+  TechnicalConfigurationResultExportRankingItemWire,
+  TechnicalConfigurationResultExportScopeRpcArgs,
+} from "./technical-configuration-result-export-types"
+
+export type TechnicalConfigurationResultExportErrorKind =
+  | "permission_denied"
+  | "not_found"
+  | "conflict"
+  | "validation"
+  | "server"
+  | "transport"
+  | "invalid_response"
+  | "snapshot_changed"
+
+/** Typed failure for every non-cancellation P14 result-export operation. */
+export class TechnicalConfigurationResultExportError extends Error {
+  readonly kind: TechnicalConfigurationResultExportErrorKind
+  readonly status?: number
+  readonly code?: string
+  readonly details?: string
+  readonly hint?: string
+
+  constructor(
+    kind: TechnicalConfigurationResultExportErrorKind,
+    message: string,
+    metadata: {
+      status?: number
+      code?: string
+      details?: string
+      hint?: string
+      cause?: unknown
+    } = {}
+  ) {
+    super(message, { cause: metadata.cause })
+    this.name = "TechnicalConfigurationResultExportError"
+    this.kind = kind
+    this.status = metadata.status
+    this.code = metadata.code
+    this.details = metadata.details
+    this.hint = metadata.hint
+  }
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const MANIFEST_DATA_KEYS =
+  "dossier baseline_version option_total criterion_total snapshot_token ranking_snapshot_token".split(
+    " "
+  )
+const DOSSIER_KEYS = "id device_type_name name revision archived_at".split(" ")
+const BASELINE_KEYS = "id dossier_id version_number status revision locked_at".split(" ")
+const PAGE_KEYS =
+  "data dossier_id baseline_version_id snapshot_token ranking_snapshot_token total page page_size".split(
+    " "
+  )
+const RANKING_ITEM_KEYS =
+  "option_id supplier_id supplier_name display_label eligibility incomplete_criterion_count failed_count insufficient_evidence_count exceeds_count rank".split(
+    " "
+  )
+const DOCUMENT_LINK_KEYS =
+  "document_id document_name document_url citation_id page_section excerpt".split(" ")
+const MATRIX_CELL_KEYS =
+  "group_id group_name group_order criterion_id criterion_code criterion_title requirement_text criterion_order option_id supplier_id supplier_name display_label model manufacturer option_name response_text supplementary_information document_links technical_axis evidence_axis assessment_notes conclusion".split(
+    " "
+  )
+
+function invalidResponse(path: string): never {
+  throw new TechnicalConfigurationResultExportError(
+    "invalid_response",
+    `Invalid result export response at ${path}.`
+  )
+}
+
+function exactRecord(value: unknown, keys: readonly string[], path: string) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalidResponse(path)
+  }
+  const record = value as Record<string, unknown>
+  const actualKeys = Object.keys(record).sort()
+  const expectedKeys = [...keys].sort()
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    return invalidResponse(path)
+  }
+  return record
+}
+
+function stringValue(value: unknown, path: string): string {
+  return typeof value === "string" ? value : invalidResponse(path)
+}
+
+function nonEmptyString(value: unknown, path: string): string {
+  const result = stringValue(value, path)
+  return result.length > 0 ? result : invalidResponse(path)
+}
+
+function nullableString(value: unknown, path: string): string | null {
+  return value === null ? null : stringValue(value, path)
+}
+
+function uuidValue(value: unknown, path: string): string {
+  const result = stringValue(value, path)
+  return UUID_PATTERN.test(result) ? result : invalidResponse(path)
+}
+
+function integerValue(value: unknown, path: string, minimum = 0): number {
+  return Number.isSafeInteger(value) && Number(value) >= minimum
+    ? Number(value)
+    : invalidResponse(path)
+}
+
+function enumValue<T extends string>(value: unknown, values: readonly T[], path: string): T {
+  return typeof value === "string" && values.includes(value as T)
+    ? (value as T)
+    : invalidResponse(path)
+}
+
+function nullableEnum<T extends string>(
+  value: unknown,
+  values: readonly T[],
+  path: string
+): T | null {
+  return value === null ? null : enumValue(value, values, path)
+}
+
+/** Decode and validate the exact result-export manifest wire contract. */
+export function decodeManifest(
+  value: unknown,
+  args: TechnicalConfigurationResultExportScopeRpcArgs
+): TechnicalConfigurationResultExportManifestWireResponse {
+  const response = exactRecord(value, ["data"], "manifest")
+  const data = exactRecord(response.data, MANIFEST_DATA_KEYS, "manifest.data")
+  const dossier = exactRecord(data.dossier, DOSSIER_KEYS, "manifest.data.dossier")
+  const baseline = exactRecord(
+    data.baseline_version,
+    BASELINE_KEYS,
+    "manifest.data.baseline_version"
+  )
+  const dossierId = uuidValue(dossier.id, "manifest.data.dossier.id")
+  const baselineId = uuidValue(baseline.id, "manifest.data.baseline_version.id")
+  const baselineDossierId = uuidValue(
+    baseline.dossier_id,
+    "manifest.data.baseline_version.dossier_id"
+  )
+  if (
+    dossierId !== args.p_dossier_id ||
+    baselineId !== args.p_baseline_version_id ||
+    baselineDossierId !== dossierId
+  ) {
+    return invalidResponse("manifest.data.identity")
+  }
+  const optionTotal = integerValue(data.option_total, "manifest.data.option_total")
+  const criterionTotal = integerValue(data.criterion_total, "manifest.data.criterion_total")
+  if (
+    (args.p_option_ids !== null && args.p_option_ids.length !== optionTotal) ||
+    (args.p_criterion_ids !== null && args.p_criterion_ids.length !== criterionTotal)
+  ) {
+    return invalidResponse("manifest.data.scope_totals")
+  }
+  return {
+    data: {
+      dossier: {
+        id: dossierId,
+        device_type_name: stringValue(
+          dossier.device_type_name,
+          "manifest.data.dossier.device_type_name"
+        ),
+        name: stringValue(dossier.name, "manifest.data.dossier.name"),
+        revision: integerValue(dossier.revision, "manifest.data.dossier.revision"),
+        archived_at: nullableString(dossier.archived_at, "manifest.data.dossier.archived_at"),
+      },
+      baseline_version: {
+        id: baselineId,
+        dossier_id: baselineDossierId,
+        version_number: integerValue(
+          baseline.version_number,
+          "manifest.data.baseline_version.version_number",
+          1
+        ),
+        status: enumValue(
+          baseline.status,
+          ["draft", "locked"] as const,
+          "manifest.data.baseline_version.status"
+        ),
+        revision: integerValue(baseline.revision, "manifest.data.baseline_version.revision"),
+        locked_at: nullableString(baseline.locked_at, "manifest.data.baseline_version.locked_at"),
+      },
+      option_total: optionTotal,
+      criterion_total: criterionTotal,
+      snapshot_token: nonEmptyString(data.snapshot_token, "manifest.data.snapshot_token"),
+      ranking_snapshot_token: nonEmptyString(
+        data.ranking_snapshot_token,
+        "manifest.data.ranking_snapshot_token"
+      ),
+    },
+  }
+}
+
+/** Decode and validate shared result-export page metadata. */
+export function decodePageMetadata(
+  value: unknown,
+  args: TechnicalConfigurationResultExportPageRpcArgs,
+  path: string
+) {
+  const response = exactRecord(value, PAGE_KEYS, path)
+  const dossierId = uuidValue(response.dossier_id, `${path}.dossier_id`)
+  const baselineId = uuidValue(response.baseline_version_id, `${path}.baseline_version_id`)
+  const page = integerValue(response.page, `${path}.page`, 1)
+  const pageSize = integerValue(response.page_size, `${path}.page_size`, 1)
+  if (
+    dossierId !== args.p_dossier_id ||
+    baselineId !== args.p_baseline_version_id ||
+    page !== args.p_page ||
+    pageSize !== args.p_page_size
+  ) {
+    return invalidResponse(`${path}.identity`)
+  }
+  const data = response.data
+  if (!Array.isArray(data)) return invalidResponse(`${path}.data`)
+  const total = integerValue(response.total, `${path}.total`)
+  const offset = (page - 1) * pageSize
+  const expectedPageLength = Math.min(pageSize, Math.max(total - offset, 0))
+  if (data.length !== expectedPageLength) {
+    return invalidResponse(`${path}.data.length`)
+  }
+  return {
+    data,
+    dossierId,
+    baselineId,
+    page,
+    pageSize,
+    total,
+    snapshotToken: nonEmptyString(response.snapshot_token, `${path}.snapshot_token`),
+    rankingSnapshotToken: nonEmptyString(
+      response.ranking_snapshot_token,
+      `${path}.ranking_snapshot_token`
+    ),
+  }
+}
+
+/** Decode one exact result-export ranking row. */
+export function decodeRankingItem(
+  value: unknown,
+  index: number
+): TechnicalConfigurationResultExportRankingItemWire {
+  const path = `ranking.data[${index}]`
+  const row = exactRecord(value, RANKING_ITEM_KEYS, path)
+  return {
+    option_id: uuidValue(row.option_id, `${path}.option_id`),
+    supplier_id: uuidValue(row.supplier_id, `${path}.supplier_id`),
+    supplier_name: stringValue(row.supplier_name, `${path}.supplier_name`),
+    display_label: stringValue(row.display_label, `${path}.display_label`),
+    eligibility: enumValue(
+      row.eligibility,
+      ["eligible", "incomplete"] as const,
+      `${path}.eligibility`
+    ),
+    incomplete_criterion_count: integerValue(
+      row.incomplete_criterion_count,
+      `${path}.incomplete_criterion_count`
+    ),
+    failed_count: integerValue(row.failed_count, `${path}.failed_count`),
+    insufficient_evidence_count: integerValue(
+      row.insufficient_evidence_count,
+      `${path}.insufficient_evidence_count`
+    ),
+    exceeds_count: integerValue(row.exceeds_count, `${path}.exceeds_count`),
+    rank: row.rank === null ? null : integerValue(row.rank, `${path}.rank`, 1),
+  }
+}
+
+function decodeDocumentLink(
+  value: unknown,
+  path: string
+): TechnicalConfigurationResultExportDocumentLinkWire {
+  const row = exactRecord(value, DOCUMENT_LINK_KEYS, path)
+  return {
+    document_id: uuidValue(row.document_id, `${path}.document_id`),
+    document_name: stringValue(row.document_name, `${path}.document_name`),
+    document_url: stringValue(row.document_url, `${path}.document_url`),
+    citation_id: uuidValue(row.citation_id, `${path}.citation_id`),
+    page_section: nullableString(row.page_section, `${path}.page_section`),
+    excerpt: nullableString(row.excerpt, `${path}.excerpt`),
+  }
+}
+
+/** Decode one exact result-export matrix cell. */
+export function decodeMatrixCell(
+  value: unknown,
+  index: number
+): TechnicalConfigurationResultExportMatrixCellWire {
+  const path = `matrix.data[${index}]`
+  const row = exactRecord(value, MATRIX_CELL_KEYS, path)
+  if (!Array.isArray(row.document_links)) return invalidResponse(`${path}.document_links`)
+  return {
+    group_id: uuidValue(row.group_id, `${path}.group_id`),
+    group_name: stringValue(row.group_name, `${path}.group_name`),
+    group_order: integerValue(row.group_order, `${path}.group_order`),
+    criterion_id: uuidValue(row.criterion_id, `${path}.criterion_id`),
+    criterion_code: stringValue(row.criterion_code, `${path}.criterion_code`),
+    criterion_title: nullableString(row.criterion_title, `${path}.criterion_title`),
+    requirement_text: stringValue(row.requirement_text, `${path}.requirement_text`),
+    criterion_order: integerValue(row.criterion_order, `${path}.criterion_order`),
+    option_id: uuidValue(row.option_id, `${path}.option_id`),
+    supplier_id: uuidValue(row.supplier_id, `${path}.supplier_id`),
+    supplier_name: stringValue(row.supplier_name, `${path}.supplier_name`),
+    display_label: stringValue(row.display_label, `${path}.display_label`),
+    model: nullableString(row.model, `${path}.model`),
+    manufacturer: nullableString(row.manufacturer, `${path}.manufacturer`),
+    option_name: nullableString(row.option_name, `${path}.option_name`),
+    response_text: nullableString(row.response_text, `${path}.response_text`),
+    supplementary_information: nullableString(
+      row.supplementary_information,
+      `${path}.supplementary_information`
+    ),
+    document_links: row.document_links.map((link, linkIndex) =>
+      decodeDocumentLink(link, `${path}.document_links[${linkIndex}]`)
+    ),
+    technical_axis: nullableEnum(
+      row.technical_axis,
+      TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES,
+      `${path}.technical_axis`
+    ),
+    evidence_axis: nullableEnum(
+      row.evidence_axis,
+      TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES,
+      `${path}.evidence_axis`
+    ),
+    assessment_notes: nullableString(row.assessment_notes, `${path}.assessment_notes`),
+    conclusion: enumValue(
+      row.conclusion,
+      TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+      `${path}.conclusion`
+    ),
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
@@ -56,6 +56,7 @@ async function callResultExportRpc<T>(
   try {
     return decode(await callTechnicalConfigurationRpc<unknown>(fn, args, { signal }))
   } catch (error) {
+    if (signal?.aborted) throw signal.reason
     if (error instanceof TechnicalConfigurationResultExportError) throw error
     if (error instanceof TechnicalConfigurationRpcError) throw mapRpcError(error)
     if (error instanceof DOMException && error.name === "AbortError") throw error

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
@@ -90,7 +90,7 @@ export function listTechnicalConfigurationResultExportRanking(
     (value) => {
       const page = decodePageMetadata(value, args, "ranking")
       return {
-        data: page.data.map(decodeRankingItem),
+        data: page.data.map((item, index) => decodeRankingItem(item, index)),
         dossier_id: page.dossierId,
         baseline_version_id: page.baselineId,
         snapshot_token: page.snapshotToken,
@@ -115,7 +115,7 @@ export function listTechnicalConfigurationResultExportMatrix(
     (value) => {
       const page = decodePageMetadata(value, args, "matrix")
       return {
-        data: page.data.map(decodeMatrixCell),
+        data: page.data.map((item, index) => decodeMatrixCell(item, index)),
         dossier_id: page.dossierId,
         baseline_version_id: page.baselineId,
         snapshot_token: page.snapshotToken,

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-rpc.ts
@@ -1,0 +1,129 @@
+import { RESULT_EXPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-result-export-rpcs"
+
+import {
+  callTechnicalConfigurationRpc,
+  TechnicalConfigurationRpcError,
+} from "./technical-configuration-rpc"
+import {
+  decodeManifest,
+  decodeMatrixCell,
+  decodePageMetadata,
+  decodeRankingItem,
+  TechnicalConfigurationResultExportError,
+} from "./technical-configuration-result-export-decoders"
+import type { TechnicalConfigurationResultExportErrorKind } from "./technical-configuration-result-export-decoders"
+import type {
+  TechnicalConfigurationResultExportManifestWireResponse,
+  TechnicalConfigurationResultExportMatrixPageWireResponse,
+  TechnicalConfigurationResultExportPageRpcArgs,
+  TechnicalConfigurationResultExportRankingPageWireResponse,
+  TechnicalConfigurationResultExportScopeRpcArgs,
+} from "./technical-configuration-result-export-types"
+
+export { TechnicalConfigurationResultExportError } from "./technical-configuration-result-export-decoders"
+export type { TechnicalConfigurationResultExportErrorKind } from "./technical-configuration-result-export-decoders"
+
+function rpcErrorKind(
+  error: TechnicalConfigurationRpcError
+): TechnicalConfigurationResultExportErrorKind {
+  if (error.status >= 200 && error.status < 300) return "invalid_response"
+  if (error.code === "42501" || error.status === 401 || error.status === 403) {
+    return "permission_denied"
+  }
+  if (error.code === "PT404" || error.status === 404) return "not_found"
+  if (error.code === "PT409" || error.status === 409) return "conflict"
+  if (error.code === "PT422" || error.status === 422) return "validation"
+  if (error.code === "PT500" || error.status >= 500) return "server"
+  return "transport"
+}
+
+function mapRpcError(error: TechnicalConfigurationRpcError) {
+  return new TechnicalConfigurationResultExportError(rpcErrorKind(error), error.message, {
+    status: error.status,
+    code: error.code,
+    details: error.details,
+    hint: error.hint,
+    cause: error,
+  })
+}
+
+async function callResultExportRpc<T>(
+  fn: string,
+  args: object,
+  decode: (value: unknown) => T,
+  signal?: AbortSignal
+): Promise<T> {
+  try {
+    return decode(await callTechnicalConfigurationRpc<unknown>(fn, args, { signal }))
+  } catch (error) {
+    if (error instanceof TechnicalConfigurationResultExportError) throw error
+    if (error instanceof TechnicalConfigurationRpcError) throw mapRpcError(error)
+    if (error instanceof DOMException && error.name === "AbortError") throw error
+    throw new TechnicalConfigurationResultExportError("transport", "Result export RPC failed.", {
+      cause: error,
+    })
+  }
+}
+
+/** Fetch and decode one stable result-export manifest. */
+export function getTechnicalConfigurationResultExportManifest(
+  args: TechnicalConfigurationResultExportScopeRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationResultExportManifestWireResponse> {
+  return callResultExportRpc(
+    RESULT_EXPORT_RPC_FUNCTIONS.getManifest,
+    args,
+    (value) => decodeManifest(value, args),
+    signal
+  )
+}
+
+/** Fetch and decode one bounded result-export ranking page. */
+export function listTechnicalConfigurationResultExportRanking(
+  args: TechnicalConfigurationResultExportPageRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationResultExportRankingPageWireResponse> {
+  return callResultExportRpc(
+    RESULT_EXPORT_RPC_FUNCTIONS.listRanking,
+    args,
+    (value) => {
+      const page = decodePageMetadata(value, args, "ranking")
+      return {
+        data: page.data.map(decodeRankingItem),
+        dossier_id: page.dossierId,
+        baseline_version_id: page.baselineId,
+        snapshot_token: page.snapshotToken,
+        ranking_snapshot_token: page.rankingSnapshotToken,
+        total: page.total,
+        page: page.page,
+        page_size: page.pageSize,
+      }
+    },
+    signal
+  )
+}
+
+/** Fetch and decode one bounded result-export matrix page. */
+export function listTechnicalConfigurationResultExportMatrix(
+  args: TechnicalConfigurationResultExportPageRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationResultExportMatrixPageWireResponse> {
+  return callResultExportRpc(
+    RESULT_EXPORT_RPC_FUNCTIONS.listMatrix,
+    args,
+    (value) => {
+      const page = decodePageMetadata(value, args, "matrix")
+      return {
+        data: page.data.map(decodeMatrixCell),
+        dossier_id: page.dossierId,
+        baseline_version_id: page.baselineId,
+        snapshot_token: page.snapshotToken,
+        ranking_snapshot_token: page.rankingSnapshotToken,
+        total: page.total,
+        page: page.page,
+        page_size: page.pageSize,
+      }
+    },
+    signal
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-types.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-types.ts
@@ -1,0 +1,149 @@
+import type {
+  TechnicalConfigurationDerivedStatus,
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+import type { TechnicalConfigurationBaselineStatus } from "./baseline-types"
+import type { TechnicalConfigurationReferenceRankingEligibility } from "./reference-ranking-types"
+
+export type TechnicalConfigurationResultExportScopeRpcArgs = {
+  p_dossier_id: string
+  p_baseline_version_id: string
+  p_option_ids: readonly string[] | null
+  p_criterion_ids: readonly string[] | null
+}
+
+export type TechnicalConfigurationResultExportPageRpcArgs =
+  TechnicalConfigurationResultExportScopeRpcArgs & {
+    p_page: number
+    p_page_size: number
+  }
+
+export type TechnicalConfigurationResultExportManifestWire = {
+  readonly dossier: {
+    readonly id: string
+    readonly device_type_name: string
+    readonly name: string
+    readonly revision: number
+    readonly archived_at: string | null
+  }
+  readonly baseline_version: {
+    readonly id: string
+    readonly dossier_id: string
+    readonly version_number: number
+    readonly status: TechnicalConfigurationBaselineStatus
+    readonly revision: number
+    readonly locked_at: string | null
+  }
+  readonly option_total: number
+  readonly criterion_total: number
+  readonly snapshot_token: string
+  readonly ranking_snapshot_token: string
+}
+
+export type TechnicalConfigurationResultExportManifestWireResponse = {
+  readonly data: TechnicalConfigurationResultExportManifestWire
+}
+
+export type TechnicalConfigurationResultExportRankingItemWire = {
+  readonly option_id: string
+  readonly supplier_id: string
+  readonly supplier_name: string
+  readonly display_label: string
+  readonly eligibility: TechnicalConfigurationReferenceRankingEligibility
+  readonly incomplete_criterion_count: number
+  readonly failed_count: number
+  readonly insufficient_evidence_count: number
+  readonly exceeds_count: number
+  readonly rank: number | null
+}
+
+export type TechnicalConfigurationResultExportRankingPageWireResponse = {
+  readonly data: TechnicalConfigurationResultExportRankingItemWire[]
+  readonly dossier_id: string
+  readonly baseline_version_id: string
+  readonly snapshot_token: string
+  readonly ranking_snapshot_token: string
+  readonly total: number
+  readonly page: number
+  readonly page_size: number
+}
+
+export type TechnicalConfigurationResultExportDocumentLinkWire = {
+  readonly document_id: string
+  readonly document_name: string
+  readonly document_url: string
+  readonly citation_id: string
+  readonly page_section: string | null
+  readonly excerpt: string | null
+}
+
+export type TechnicalConfigurationResultExportMatrixCellWire = {
+  readonly group_id: string
+  readonly group_name: string
+  readonly group_order: number
+  readonly criterion_id: string
+  readonly criterion_code: string
+  readonly criterion_title: string | null
+  readonly requirement_text: string
+  readonly criterion_order: number
+  readonly option_id: string
+  readonly supplier_id: string
+  readonly supplier_name: string
+  readonly display_label: string
+  readonly model: string | null
+  readonly manufacturer: string | null
+  readonly option_name: string | null
+  readonly response_text: string | null
+  readonly supplementary_information: string | null
+  readonly document_links: readonly TechnicalConfigurationResultExportDocumentLinkWire[]
+  readonly technical_axis: TechnicalConfigurationTechnicalAxis | null
+  readonly evidence_axis: TechnicalConfigurationEvidenceAxis | null
+  readonly assessment_notes: string | null
+  readonly conclusion: TechnicalConfigurationDerivedStatus
+}
+
+export type TechnicalConfigurationResultExportMatrixPageWireResponse = {
+  readonly data: TechnicalConfigurationResultExportMatrixCellWire[]
+  readonly dossier_id: string
+  readonly baseline_version_id: string
+  readonly snapshot_token: string
+  readonly ranking_snapshot_token: string
+  readonly total: number
+  readonly page: number
+  readonly page_size: number
+}
+
+export type TechnicalConfigurationResultExportMode =
+  "full" | "ranking_only" | "detailed_matrix_only"
+
+export type TechnicalConfigurationResultExportRequest = {
+  readonly mode: TechnicalConfigurationResultExportMode
+  readonly dossierId: string
+  readonly baselineVersionId: string
+  readonly optionIds: readonly string[] | null
+  readonly criterionIds: readonly string[] | null
+  readonly signal?: AbortSignal
+}
+
+type ResultExportDatasetBase = {
+  readonly manifest: TechnicalConfigurationResultExportManifestWire
+}
+
+export type TechnicalConfigurationResultExportDataset =
+  | (ResultExportDatasetBase & {
+      readonly mode: "full"
+      readonly ranking: readonly TechnicalConfigurationResultExportRankingItemWire[]
+      readonly matrix: readonly TechnicalConfigurationResultExportMatrixCellWire[]
+    })
+  | (ResultExportDatasetBase & {
+      readonly mode: "ranking_only"
+      readonly ranking: readonly TechnicalConfigurationResultExportRankingItemWire[]
+      readonly matrix: null
+    })
+  | (ResultExportDatasetBase & {
+      readonly mode: "detailed_matrix_only"
+      readonly ranking: null
+      readonly matrix: readonly TechnicalConfigurationResultExportMatrixCellWire[]
+    })


### PR DESCRIPTION
## Summary
- add exact typed manifest, ranking-page, matrix-page, row, and nested document-link decoders with a stable error taxonomy
- collect requested export surfaces sequentially through the shared stable-page collector, validate identities/totals/tokens/keys, reread the final manifest, and publish only a frozen complete dataset
- split types, decoders, RPC adapters, collector, and test fixtures into P14A3-owned modules below repository file-size thresholds

## Scope boundary
- no mounted query or hook, UI, workbook, ExcelJS, Blob, or download behavior
- no shared callRpc() change, SQL migration, or live database write
- depends on the P14A2 contracts delivered by PR #848

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- verify:ts-docstrings
- typecheck
- focused Vitest: 43/43 across P14A3, shared pagination, and reference-ranking collector regressions
- React Doctor changed scan: 100/100
- openspec validate add-technical-configuration-comparison --strict
- git diff --cached --check

Closes #841
Refs #840

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed result export decoders, RPC adapters, and a stable sequential collector for P14A3. Validates and freezes a complete dataset; satisfies Linear #841 with P14A2 contracts and no UI, hook, or DB changes.

- New Features
  - Exact decoders for manifest, ranking page, matrix page, row, and nested document links; stable errors: PT404/PT409/PT422/PT500, permission_denied, transport, invalid_response, snapshot_changed (sanitized 500s and malformed 2xx JSON handled).
  - Sequential collection with identity/totals/tokens/key validation, strict page-length checks, deep-freezing of rows and nested links, and a final manifest recheck; modes: full, ranking_only, detailed_matrix_only; zero-matrix supported; page sizes: ranking 100, matrix 1000.
  - Uses the existing technical-configuration RPC seam (no shared `callRpc()` changes); preserves custom and `AbortSignal.timeout()` cancellation reasons; short-circuits unrequested surfaces. Tests and gates pass (Vitest 48/48 focused across P14A3, shared pagination, and reference-ranking; typecheck/format/no-explicit-any; React Doctor 100/100; strict OpenSpec).

- Refactors
  - Split P14A3 types, decoders, RPC adapters, collector, and test fixtures into module-owned files to stay under repository file-size thresholds.

<sup>Written for commit 3a55662b8c90b2af5a4d20a3c1850ee761a99db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added technical-configuration result export data collection for ranking and matrix views.
  * Added support for paginated, scope-limited exports with cancellation handling.
  * Added validation for response structure, snapshot consistency, totals, identifiers, and document links.
  * Added clear error handling for transport, permission, conflict, validation, and server failures.

* **Tests**
  * Added comprehensive coverage for pagination, malformed responses, changing snapshots, empty data, mode-specific fetching, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->