### PR TITLE
[P14B1] Result workbook schema and representative fixtures

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3165,6 +3165,7 @@ matrix dimensions. No workbook or production UI consumes them yet.
 
 ### Planned files
 
+- Create: `src/lib/technical-configuration-result-excel-contract-types.ts`
 - Create: `src/lib/technical-configuration-result-excel-contract.ts`
 - Create:
   `src/lib/__tests__/technical-configuration-result-excel-fixtures.ts`
@@ -3173,16 +3174,16 @@ matrix dimensions. No workbook or production UI consumes them yet.
 
 ### Tasks
 
-- [ ] Write RED contract tests for the three content modes, visible sheet order,
+- [x] Write RED contract tests for the three content modes, visible sheet order,
       hidden `_meta`, exact four matrix context columns and exact three-column
       option groups.
-- [ ] Define one output-only versioned workbook model; do not add an import,
+- [x] Define one output-only versioned workbook model; do not add an import,
       parser or apply contract.
-- [ ] Encode continuation-sheet planning from Excel's physical column limit;
+- [x] Encode continuation-sheet planning from Excel's physical column limit;
       never truncate or introduce a hidden option cap.
-- [ ] Add deterministic in-memory fixtures for empty/sparse/tied/missing-data
+- [x] Add deterministic in-memory fixtures for empty/sparse/tied/missing-data
       cases and more than 100 options x 102 criteria.
-- [ ] Keep fixture generation local to tests and free of seed/live DB access.
+- [x] Keep fixture generation local to tests and free of seed/live DB access.
 
 ### Exit gate
 

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -521,6 +521,7 @@ workbook model, ExcelJS, UI, Blob/download, parser/import/apply or seed.
 
 ### Planned Files
 
+- Create: `src/lib/technical-configuration-result-excel-contract-types.ts`
 - Create: `src/lib/technical-configuration-result-excel-contract.ts`
 - Create:
   `src/lib/__tests__/technical-configuration-result-excel-fixtures.ts`
@@ -550,7 +551,44 @@ workbook model, ExcelJS, UI, Blob/download, parser/import/apply or seed.
 1. Compare baseline/option workbook contracts for naming/version conventions;
    share only generic contracts that are genuinely identical.
 2. Run standard TypeScript gates and focused pure tests.
-3. Validate OpenSpec strictly, review, merge and sync `main`.
+3. Validate OpenSpec strictly, review and open a non-draft PR. Merge and sync
+   `main` remain a separately approved follow-up.
+
+### Execution Evidence - 2026-08-03
+
+- The preserved pre-P14A4 stash was applied without dropping it. Its original
+  pure draft passed `11/11`, providing a recovery baseline before contract
+  changes.
+- RED added P14A4 ordered-axis ownership, narrowed-order and asymmetric
+  dimension coverage. The focused suite reported `2 failed / 10 passed`;
+  GREEN used `optionAxis` and `criterionAxis` as the independent ordered
+  sources and passed `12/12`.
+- Independent review required overview scope, a complete sparse `2 x 2`
+  fixture with one explicit `not_evaluated` cell, a true `2 of 3` narrowed
+  selection, the exact `5,460`-option boundary and independent deterministic
+  fixture construction.
+- Review-follow-up RED reported `1 failed / 11 passed`, only because overview
+  scope was absent. GREEN shares one pure scope builder between overview and
+  hidden `_meta` and passes `12/12`.
+- Final `mix-gpt-5.6` review found the narrowed test still mixed `2 x 2` axes
+  with a `3 x 3` manifest/ranking/matrix source, and missing-data coverage
+  nulled descriptors on matrix cells even though option headers own them.
+  RED reported `2 failed / 10 passed`; GREEN adds a consistent selected-scope
+  fixture, filters axes/ranking/matrix together, sets manifest totals to
+  `2 x 2` and covers nullable descriptors on `optionAxis`, passing `12/12`.
+- Boundary coverage proves one matrix sheet fits exactly `5,460` options in
+  `16,384` physical columns, while `5,461` options partition as `5,460 + 1`
+  without truncation. Empty coverage includes `0 x 0`, `1 x 0` and `0 x 1`.
+- Local gates passed: Prettier, no explicit `any`, diff-only dedupe, exported
+  TSDoc, typecheck, all eight P14 export files (`86/86`), React Doctor
+  (`100/100`), `git diff --check`, the output-only import boundary and strict
+  OpenSpec validation.
+- Code Review Graph, GitNexus and exact repository search found no equivalent
+  output-only result-workbook model or generic worksheet partition capability
+  to reuse. Existing baseline/option contracts own different templates; the
+  closest option path also owns ExcelJS/import parsing and is outside P14B1.
+- All fixtures remain deterministic and in-memory. No seed, live DB operation,
+  ExcelJS/rendering, Blob/download, UI or parser/import/apply work was added.
 
 **Deploy boundary:** pure model and test fixtures; no rendering or side effect.
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -904,12 +904,12 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14B1 - Result Workbook Schema And Representative Fixtures
 
-- [ ] P14B1.1 Khóa ba content mode, visible sheet order, hidden `_meta`, bốn
+- [x] P14B1.1 Khóa ba content mode, visible sheet order, hidden `_meta`, bốn
       context columns và ba cột cho mỗi option.
-- [ ] P14B1.2 Tạo output-only versioned workbook model, không parser/import/apply.
-- [ ] P14B1.3 Partition continuation matrix sheets theo giới hạn cột vật lý,
+- [x] P14B1.2 Tạo output-only versioned workbook model, không parser/import/apply.
+- [x] P14B1.3 Partition continuation matrix sheets theo giới hạn cột vật lý,
       không truncate/hidden cap.
-- [ ] P14B1.4 Tạo fixture in-memory deterministic lớn hơn 100 options x 102
+- [x] P14B1.4 Tạo fixture in-memory deterministic lớn hơn 100 options x 102
       criteria; tuyệt đối không seed hoặc đọc/ghi live DB.
 
 ## Phase P14B2 - Approved ExcelJS Workbook Rendering

--- a/src/lib/__tests__/technical-configuration-result-excel-contract.test.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-contract.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, expectTypeOf, it } from "vitest"
+
+import {
+  EXCEL_WORKSHEET_MAX_COLUMNS,
+  RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS,
+  RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET,
+  RESULT_WORKBOOK_META_KEYS,
+  RESULT_WORKBOOK_OPTION_COLUMNS,
+  RESULT_WORKBOOK_TEMPLATE_KIND,
+  RESULT_WORKBOOK_TEMPLATE_VERSION,
+  createTechnicalConfigurationResultWorkbookModel,
+  type TechnicalConfigurationResultWorkbookModel,
+  type TechnicalConfigurationResultWorkbookBuildInput,
+  type TechnicalConfigurationResultWorkbookSheetModel,
+} from "@/lib/technical-configuration-result-excel-contract"
+
+import type { TechnicalConfigurationResultExportDataset } from "@/app/(app)/technical-configurations/technical-configuration-result-export-types"
+
+import {
+  createContinuationResultWorkbookFixture,
+  createEmptyResultWorkbookFixture,
+  createEmptyOptionsSingleCriterionResultWorkbookFixture,
+  createMatrixBoundaryResultWorkbookFixture,
+  createMissingDataResultWorkbookFixture,
+  createNarrowedResultWorkbookFixture,
+  createRepresentativeLargeResultWorkbookFixture,
+  createResultWorkbookFixture,
+  createSingleOptionEmptyCriteriaResultWorkbookFixture,
+  createSparseResultWorkbookFixture,
+  createTiedRankingResultWorkbookFixture,
+} from "./technical-configuration-result-excel-fixtures"
+
+type ResultWorkbookSheetKind = TechnicalConfigurationResultWorkbookSheetModel["kind"]
+
+type WorkbookBuildContextKey = "option_ids" | "criterion_ids" | "generated_at" | "generated_by"
+
+type WorkbookDatasetSource<T> = T extends unknown ? Omit<T, WorkbookBuildContextKey> : never
+
+function getSheet<K extends ResultWorkbookSheetKind>(
+  workbook: TechnicalConfigurationResultWorkbookModel,
+  kind: K
+): Extract<TechnicalConfigurationResultWorkbookSheetModel, { kind: K }> {
+  const sheet = workbook.sheets.find((candidate) => candidate.kind === kind)
+  expect(sheet).toBeDefined()
+  return sheet as Extract<TechnicalConfigurationResultWorkbookSheetModel, { kind: K }>
+}
+
+describe("technical configuration result workbook contract", () => {
+  it("accepts the P14A4 stable dataset shape without a production app dependency", () => {
+    expectTypeOf<TechnicalConfigurationResultExportDataset>().toMatchTypeOf<
+      WorkbookDatasetSource<TechnicalConfigurationResultWorkbookBuildInput>
+    >()
+    expectTypeOf<TechnicalConfigurationResultWorkbookBuildInput["optionAxis"]>().toEqualTypeOf<
+      TechnicalConfigurationResultExportDataset["optionAxis"]
+    >()
+    expectTypeOf<TechnicalConfigurationResultWorkbookBuildInput["criterionAxis"]>().toEqualTypeOf<
+      TechnicalConfigurationResultExportDataset["criterionAxis"]
+    >()
+  })
+
+  it("locks the versioned output-only constants and exact column groups", () => {
+    expect(RESULT_WORKBOOK_TEMPLATE_KIND).toBe("technical_configuration_result")
+    expect(RESULT_WORKBOOK_TEMPLATE_VERSION).toBe(1)
+    expect(EXCEL_WORKSHEET_MAX_COLUMNS).toBe(16_384)
+    expect(RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET).toBe(5_460)
+    expect(RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS).toEqual([
+      "STT",
+      "Nhóm tiêu chí",
+      "Mã tiêu chí",
+      "Yêu cầu cấu hình cơ sở",
+    ])
+    expect(RESULT_WORKBOOK_OPTION_COLUMNS).toEqual([
+      "Phản hồi nhà cung cấp",
+      "Thông tin bổ sung / tài liệu",
+      "Kết luận đánh giá",
+    ])
+    expect(RESULT_WORKBOOK_META_KEYS).toEqual([
+      "template_kind",
+      "template_version",
+      "dossier_id",
+      "baseline_version_id",
+      "snapshot_token",
+      "ranking_snapshot_token",
+      "content_mode",
+      "option_scope",
+      "criterion_scope",
+      "ordered_option_ids",
+      "ordered_criterion_ids",
+      "generated_at",
+      "generated_by",
+    ])
+  })
+
+  it.each([
+    ["full", ["Tổng quan", "Xếp hạng", "Ma trận chi tiết", "_meta"]],
+    ["ranking_only", ["Tổng quan", "Xếp hạng", "_meta"]],
+    ["detailed_matrix_only", ["Tổng quan", "Ma trận chi tiết", "_meta"]],
+  ] as const)("locks %s sheet order and keeps exactly one hidden _meta", (mode, names) => {
+    const workbook = createTechnicalConfigurationResultWorkbookModel(
+      createResultWorkbookFixture({
+        mode,
+        optionCount: 2,
+        criterionCount: 2,
+      })
+    )
+
+    expect(workbook.sheets.map((sheet) => sheet.name)).toEqual(names)
+    expect(workbook.sheets.map((sheet) => sheet.state)).toEqual(
+      names.map((name) => (name === "_meta" ? "hidden" : "visible"))
+    )
+    expect(workbook.sheets.filter((sheet) => sheet.kind === "meta")).toHaveLength(1)
+  })
+
+  it("locks metadata identity, selected scopes and stable narrowed ordering", () => {
+    const fixture = createNarrowedResultWorkbookFixture()
+    const optionIds = fixture.optionAxis.map((option) => option.option_id)
+    const criterionIds = fixture.criterionAxis.map((criterion) => criterion.criterion_id)
+    const workbook = createTechnicalConfigurationResultWorkbookModel(fixture)
+    const meta = getSheet(workbook, "meta")
+    const overview = getSheet(workbook, "overview")
+    const ranking = getSheet(workbook, "ranking")
+    const matrix = getSheet(workbook, "matrix")
+
+    expect(overview.summary).toMatchObject({
+      option_total: optionIds.length,
+      criterion_total: criterionIds.length,
+    })
+    expect(ranking.rows).toHaveLength(optionIds.length)
+    expect(ranking.rows.map((row) => row.option_id)).toEqual(expect.arrayContaining(optionIds))
+    expect(fixture.matrix).toHaveLength(optionIds.length * criterionIds.length)
+    expect(meta.metadata).toEqual({
+      template_kind: "technical_configuration_result",
+      template_version: 1,
+      dossier_id: fixture.manifest.dossier.id,
+      baseline_version_id: fixture.manifest.baseline_version.id,
+      snapshot_token: "snapshot-v1",
+      ranking_snapshot_token: "ranking-v1",
+      content_mode: "full",
+      option_scope: "selected",
+      criterion_scope: "selected",
+      ordered_option_ids: optionIds,
+      ordered_criterion_ids: criterionIds,
+      generated_at: "2026-08-02T12:34:56.000Z",
+      generated_by: "Nguyen Van A",
+    })
+    expect(matrix.option_groups.map((option) => option.option_id)).toEqual(optionIds)
+    expect(matrix.rows.map((criterion) => criterion.criterion_id)).toEqual(criterionIds)
+  })
+
+  it("builds overview, ranking and matrix row models without rendering", () => {
+    const workbook = createTechnicalConfigurationResultWorkbookModel(
+      createSparseResultWorkbookFixture()
+    )
+    const overview = getSheet(workbook, "overview")
+    const ranking = getSheet(workbook, "ranking")
+    const matrix = getSheet(workbook, "matrix")
+
+    expect(overview.summary).toMatchObject({
+      option_total: 2,
+      criterion_total: 2,
+      scope: {
+        option_scope: "all",
+        criterion_scope: "all",
+        ordered_option_ids: [],
+        ordered_criterion_ids: [],
+      },
+      ranking_summary: {
+        eligible_total: 2,
+        incomplete_total: 0,
+        reference_ranking_disclaimer: true,
+      },
+    })
+    expect(ranking.rows).toHaveLength(2)
+    expect(ranking.rows[0]).toMatchObject({
+      option_id: matrix.option_groups[0].option_id,
+      rank: 1,
+    })
+    expect(matrix.context_columns).toEqual(RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS)
+    expect(matrix.option_columns).toEqual(RESULT_WORKBOOK_OPTION_COLUMNS)
+    expect(matrix.rows).toHaveLength(2)
+    expect(matrix.rows[0]).toMatchObject({
+      stt: 1,
+      criterion_code: "TC-001",
+      requirement_text: "Yeu cau cau hinh 1",
+    })
+    expect(matrix.rows.every((row) => row.option_values.length === 2)).toBe(true)
+    expect(
+      matrix.rows
+        .flatMap((row) => row.option_values)
+        .filter((value) => value.conclusion === "not_evaluated")
+    ).toHaveLength(1)
+  })
+
+  it("keeps an empty requested matrix sheet and omits unrequested ranking summary", () => {
+    const empty = createTechnicalConfigurationResultWorkbookModel(
+      createEmptyResultWorkbookFixture()
+    )
+    const matrixOnly = createTechnicalConfigurationResultWorkbookModel(
+      createResultWorkbookFixture({
+        mode: "detailed_matrix_only",
+        optionCount: 1,
+        criterionCount: 1,
+      })
+    )
+
+    expect(getSheet(empty, "matrix")).toMatchObject({
+      name: "Ma trận chi tiết",
+      option_groups: [],
+      rows: [],
+    })
+    expect(getSheet(matrixOnly, "overview").summary.ranking_summary).toBeNull()
+    expect(matrixOnly.sheets.some((sheet) => sheet.kind === "ranking")).toBe(false)
+  })
+
+  it("preserves independent ordered axes for asymmetric empty matrices", () => {
+    const singleOption = createTechnicalConfigurationResultWorkbookModel(
+      createSingleOptionEmptyCriteriaResultWorkbookFixture()
+    )
+    const singleCriterion = createTechnicalConfigurationResultWorkbookModel(
+      createEmptyOptionsSingleCriterionResultWorkbookFixture()
+    )
+
+    expect(getSheet(singleOption, "matrix")).toMatchObject({
+      option_groups: [{ display_label: "Phuong an 1" }],
+      rows: [],
+    })
+    expect(getSheet(singleCriterion, "matrix")).toMatchObject({
+      option_groups: [],
+      rows: [{ criterion_code: "TC-001", option_values: [] }],
+    })
+  })
+
+  it("preserves tied dense ranks and explicit missing data", () => {
+    const tied = createTechnicalConfigurationResultWorkbookModel(
+      createTiedRankingResultWorkbookFixture()
+    )
+    const missing = createTechnicalConfigurationResultWorkbookModel(
+      createMissingDataResultWorkbookFixture()
+    )
+
+    expect(getSheet(tied, "ranking").rows.map((row) => row.rank)).toEqual([1, 1])
+    expect(
+      getSheet(tied, "overview").summary.ranking_summary?.top_ten.map((row) => row.rank)
+    ).toEqual([1, 1])
+    expect(getSheet(missing, "overview").summary.ranking_summary).toMatchObject({
+      eligible_total: 0,
+      incomplete_total: 1,
+    })
+    const missingMatrix = getSheet(missing, "matrix")
+    expect(missingMatrix.option_groups[0]).toMatchObject({
+      model: null,
+      manufacturer: null,
+      option_name: null,
+    })
+    expect(missingMatrix.rows[0].option_values[0]).toMatchObject({
+      response_text: null,
+      supplementary_information: null,
+      technical_axis: null,
+      evidence_axis: null,
+      assessment_notes: null,
+      conclusion: "not_evaluated",
+    })
+  })
+
+  it("partitions only after the Excel physical column boundary without truncation", () => {
+    const boundary = createTechnicalConfigurationResultWorkbookModel(
+      createMatrixBoundaryResultWorkbookFixture()
+    )
+    const workbook = createTechnicalConfigurationResultWorkbookModel(
+      createContinuationResultWorkbookFixture()
+    )
+    const boundaryMatrix = getSheet(boundary, "matrix")
+    const matrices = workbook.sheets.filter(
+      (
+        sheet
+      ): sheet is Extract<TechnicalConfigurationResultWorkbookSheetModel, { kind: "matrix" }> =>
+        sheet.kind === "matrix"
+    )
+
+    expect(boundaryMatrix.option_groups).toHaveLength(RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET)
+    expect(
+      boundaryMatrix.context_columns.length +
+        boundaryMatrix.option_groups.length * RESULT_WORKBOOK_OPTION_COLUMNS.length
+    ).toBe(EXCEL_WORKSHEET_MAX_COLUMNS)
+    expect(boundary.sheets.filter((sheet) => sheet.kind === "matrix")).toHaveLength(1)
+    expect(matrices.map((sheet) => sheet.name)).toEqual(["Ma trận chi tiết", "Ma trận chi tiết 2"])
+    expect(matrices.map((sheet) => sheet.option_groups.length)).toEqual([5_460, 1])
+    expect(matrices.flatMap((sheet) => sheet.option_groups)).toHaveLength(5_461)
+    expect(matrices.every((sheet) => sheet.context_columns.length === 4)).toBe(true)
+    expect(
+      matrices.every(
+        (sheet) =>
+          sheet.context_columns.length +
+            sheet.option_groups.length * RESULT_WORKBOOK_OPTION_COLUMNS.length <=
+          EXCEL_WORKSHEET_MAX_COLUMNS
+      )
+    ).toBe(true)
+  })
+
+  it("builds the deterministic representative fixture above 100 options x 102 criteria", () => {
+    const firstFixture = createRepresentativeLargeResultWorkbookFixture()
+    const secondFixture = createRepresentativeLargeResultWorkbookFixture()
+    const first = createTechnicalConfigurationResultWorkbookModel(firstFixture)
+    const second = createTechnicalConfigurationResultWorkbookModel(secondFixture)
+    const matrix = getSheet(first, "matrix")
+
+    expect(firstFixture).not.toBe(secondFixture)
+    expect(firstFixture.manifest.option_total).toBe(101)
+    expect(firstFixture.manifest.criterion_total).toBe(102)
+    expect(firstFixture.matrix).toHaveLength(101 * 102)
+    expect(matrix.option_groups).toHaveLength(101)
+    expect(matrix.rows).toHaveLength(102)
+    expect(matrix.rows.every((row) => row.option_values.length === 101)).toBe(true)
+    expect(first).toEqual(second)
+  })
+})

--- a/src/lib/__tests__/technical-configuration-result-excel-contract.test.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-contract.test.ts
@@ -126,7 +126,10 @@ describe("technical configuration result workbook contract", () => {
       criterion_total: criterionIds.length,
     })
     expect(ranking.rows).toHaveLength(optionIds.length)
-    expect(ranking.rows.map((row) => row.option_id)).toEqual(expect.arrayContaining(optionIds))
+    // Ranking preserves its caller-supplied order independently of the option axis.
+    expect(ranking.rows.map((row) => row.option_id)).toEqual(
+      fixture.ranking.map((row) => row.option_id)
+    )
     expect(fixture.matrix).toHaveLength(optionIds.length * criterionIds.length)
     expect(meta.metadata).toEqual({
       template_kind: "technical_configuration_result",
@@ -143,6 +146,7 @@ describe("technical configuration result workbook contract", () => {
       generated_at: "2026-08-02T12:34:56.000Z",
       generated_by: "Nguyen Van A",
     })
+    expect(Object.keys(meta.metadata)).toEqual([...RESULT_WORKBOOK_META_KEYS])
     expect(matrix.option_groups.map((option) => option.option_id)).toEqual(optionIds)
     expect(matrix.rows.map((criterion) => criterion.criterion_id)).toEqual(criterionIds)
   })

--- a/src/lib/__tests__/technical-configuration-result-excel-fixtures.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-fixtures.ts
@@ -1,0 +1,308 @@
+import type {
+  TechnicalConfigurationResultWorkbookBuildInput,
+  TechnicalConfigurationResultWorkbookContentMode,
+  TechnicalConfigurationResultWorkbookCriterionSource,
+  TechnicalConfigurationResultWorkbookMatrixSourceCell,
+  TechnicalConfigurationResultWorkbookOptionSource,
+  TechnicalConfigurationResultWorkbookRankingSourceRow,
+} from "@/lib/technical-configuration-result-excel-contract"
+
+const DOSSIER_ID = "10000000-0000-4000-8000-000000000001"
+const BASELINE_VERSION_ID = "20000000-0000-4000-8000-000000000001"
+const GENERATED_AT = "2026-08-02T12:34:56.000Z"
+const GENERATED_BY = "Nguyen Van A"
+
+interface FixtureOptions {
+  readonly mode?: TechnicalConfigurationResultWorkbookContentMode
+  readonly optionCount: number
+  readonly criterionCount: number
+  readonly selectedOptionIds?: readonly string[] | null
+  readonly selectedCriterionIds?: readonly string[] | null
+  readonly rankingFactory?: (
+    row: TechnicalConfigurationResultWorkbookRankingSourceRow,
+    index: number
+  ) => TechnicalConfigurationResultWorkbookRankingSourceRow
+  readonly matrixFactory?: (
+    cell: TechnicalConfigurationResultWorkbookMatrixSourceCell,
+    criterionIndex: number,
+    optionIndex: number
+  ) => TechnicalConfigurationResultWorkbookMatrixSourceCell
+}
+
+function indexedUuid(namespace: number, index: number) {
+  return `${String(namespace).padStart(8, "0")}-0000-4000-8000-${String(index + 1).padStart(
+    12,
+    "0"
+  )}`
+}
+
+function createOptionAxisItem(
+  optionId: string,
+  supplierId: string,
+  index: number
+): TechnicalConfigurationResultWorkbookOptionSource {
+  return {
+    option_id: optionId,
+    supplier_id: supplierId,
+    supplier_name: `Nha cung cap ${index + 1}`,
+    display_label: `Phuong an ${index + 1}`,
+    model: `Model ${index + 1}`,
+    manufacturer: `Hang ${index + 1}`,
+    option_name: `May ${index + 1}`,
+  }
+}
+
+function createCriterionAxisItem(
+  criterionId: string,
+  criterionIndex: number
+): TechnicalConfigurationResultWorkbookCriterionSource {
+  return {
+    group_id: indexedUuid(60, Math.floor(criterionIndex / 10)),
+    group_name: `Nhom tieu chi ${Math.floor(criterionIndex / 10) + 1}`,
+    group_order: Math.floor(criterionIndex / 10) + 1,
+    criterion_id: criterionId,
+    criterion_code: `TC-${String(criterionIndex + 1).padStart(3, "0")}`,
+    criterion_title: `Tieu chi ${criterionIndex + 1}`,
+    requirement_text: `Yeu cau cau hinh ${criterionIndex + 1}`,
+    criterion_order: criterionIndex + 1,
+  }
+}
+
+function createRankingRow(
+  option: TechnicalConfigurationResultWorkbookOptionSource,
+  index: number
+): TechnicalConfigurationResultWorkbookRankingSourceRow {
+  return {
+    option_id: option.option_id,
+    supplier_id: option.supplier_id,
+    supplier_name: option.supplier_name,
+    display_label: option.display_label,
+    eligibility: "eligible",
+    incomplete_criterion_count: 0,
+    failed_count: 0,
+    insufficient_evidence_count: 0,
+    exceeds_count: 1,
+    rank: index + 1,
+  }
+}
+
+function createMatrixCell(
+  criterion: TechnicalConfigurationResultWorkbookCriterionSource,
+  option: TechnicalConfigurationResultWorkbookOptionSource,
+  criterionIndex: number,
+  optionIndex: number
+): TechnicalConfigurationResultWorkbookMatrixSourceCell {
+  return {
+    ...criterion,
+    ...option,
+    response_text: `Phan hoi ${criterionIndex + 1}-${optionIndex + 1}`,
+    supplementary_information: `Thong tin ${criterionIndex + 1}-${optionIndex + 1}`,
+    document_links: [],
+    technical_axis: "meets",
+    evidence_axis: "complete",
+    assessment_notes: null,
+    conclusion: "meets",
+  }
+}
+
+export function createResultWorkbookFixture({
+  mode = "full",
+  optionCount,
+  criterionCount,
+  selectedOptionIds = null,
+  selectedCriterionIds = null,
+  rankingFactory,
+  matrixFactory,
+}: FixtureOptions): TechnicalConfigurationResultWorkbookBuildInput {
+  const optionIds = Array.from({ length: optionCount }, (_, index) => indexedUuid(30, index))
+  const supplierIds = Array.from({ length: optionCount }, (_, index) => indexedUuid(40, index))
+  const criterionIds = Array.from({ length: criterionCount }, (_, index) => indexedUuid(50, index))
+  const optionAxis = optionIds.map((optionId, index) =>
+    createOptionAxisItem(optionId, supplierIds[index], index)
+  )
+  const criterionAxis = criterionIds.map(createCriterionAxisItem)
+  const ranking = optionAxis.map((option, index) => {
+    const row = createRankingRow(option, index)
+    return rankingFactory?.(row, index) ?? row
+  })
+  const matrix = criterionAxis.flatMap((criterion, criterionIndex) =>
+    optionAxis.map((option, optionIndex) => {
+      const cell = createMatrixCell(criterion, option, criterionIndex, optionIndex)
+      return matrixFactory?.(cell, criterionIndex, optionIndex) ?? cell
+    })
+  )
+  const manifest = {
+    dossier: {
+      id: DOSSIER_ID,
+      device_type_name: "May sieu am",
+      name: "Cau hinh may sieu am",
+    },
+    baseline_version: {
+      id: BASELINE_VERSION_ID,
+      version_number: 3,
+      locked_at: "2026-08-01T02:03:04.000Z",
+    },
+    option_total: optionCount,
+    criterion_total: criterionCount,
+    snapshot_token: "snapshot-v1",
+    ranking_snapshot_token: "ranking-v1",
+  } as const
+  const context = {
+    manifest,
+    optionAxis,
+    criterionAxis,
+    option_ids: selectedOptionIds,
+    criterion_ids: selectedCriterionIds,
+    generated_at: GENERATED_AT,
+    generated_by: GENERATED_BY,
+  } as const
+
+  switch (mode) {
+    case "full":
+      return { ...context, mode, ranking, matrix }
+    case "ranking_only":
+      return { ...context, mode, ranking, matrix: null }
+    case "detailed_matrix_only":
+      return { ...context, mode, ranking: null, matrix }
+  }
+}
+
+export function createNarrowedResultWorkbookFixture() {
+  const fixture = createResultWorkbookFixture({
+    optionCount: 3,
+    criterionCount: 3,
+  })
+  if (fixture.ranking === null || fixture.matrix === null) {
+    throw new Error("Expected a full result workbook fixture.")
+  }
+
+  const optionAxis = [...fixture.optionAxis].filter((_, index) => index !== 1).reverse()
+  const criterionAxis = [...fixture.criterionAxis].filter((_, index) => index !== 1).reverse()
+  const optionIds = optionAxis.map((option) => option.option_id)
+  const criterionIds = criterionAxis.map((criterion) => criterion.criterion_id)
+  const optionIdSet = new Set(optionIds)
+  const criterionIdSet = new Set(criterionIds)
+
+  return {
+    ...fixture,
+    manifest: {
+      ...fixture.manifest,
+      option_total: optionAxis.length,
+      criterion_total: criterionAxis.length,
+    },
+    optionAxis,
+    criterionAxis,
+    option_ids: optionIds,
+    criterion_ids: criterionIds,
+    ranking: fixture.ranking.filter((row) => optionIdSet.has(row.option_id)),
+    matrix: fixture.matrix.filter(
+      (cell) => optionIdSet.has(cell.option_id) && criterionIdSet.has(cell.criterion_id)
+    ),
+  } as const
+}
+
+export function createEmptyResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    optionCount: 0,
+    criterionCount: 0,
+  })
+}
+
+export function createSingleOptionEmptyCriteriaResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    mode: "detailed_matrix_only",
+    optionCount: 1,
+    criterionCount: 0,
+  })
+}
+
+export function createEmptyOptionsSingleCriterionResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    mode: "detailed_matrix_only",
+    optionCount: 0,
+    criterionCount: 1,
+  })
+}
+
+export function createSparseResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    optionCount: 2,
+    criterionCount: 2,
+    matrixFactory: (cell, criterionIndex, optionIndex) =>
+      criterionIndex === 1 && optionIndex === 1
+        ? {
+            ...cell,
+            response_text: null,
+            supplementary_information: null,
+            technical_axis: null,
+            evidence_axis: null,
+            assessment_notes: null,
+            conclusion: "not_evaluated",
+          }
+        : cell,
+  })
+}
+
+export function createTiedRankingResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    optionCount: 2,
+    criterionCount: 1,
+    rankingFactory: (row) => ({ ...row, rank: 1 }),
+  })
+}
+
+export function createMissingDataResultWorkbookFixture() {
+  const fixture = createResultWorkbookFixture({
+    optionCount: 1,
+    criterionCount: 1,
+    rankingFactory: (row) => ({
+      ...row,
+      eligibility: "incomplete",
+      incomplete_criterion_count: 1,
+      exceeds_count: 0,
+      rank: null,
+    }),
+    matrixFactory: (cell) => ({
+      ...cell,
+      response_text: null,
+      supplementary_information: null,
+      technical_axis: null,
+      evidence_axis: null,
+      assessment_notes: null,
+      conclusion: "not_evaluated",
+    }),
+  })
+
+  return {
+    ...fixture,
+    optionAxis: fixture.optionAxis.map((option) => ({
+      ...option,
+      model: null,
+      manufacturer: null,
+      option_name: null,
+    })),
+  } as const
+}
+
+export function createRepresentativeLargeResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    optionCount: 101,
+    criterionCount: 102,
+  })
+}
+
+export function createMatrixBoundaryResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    mode: "detailed_matrix_only",
+    optionCount: 5_460,
+    criterionCount: 1,
+  })
+}
+
+export function createContinuationResultWorkbookFixture() {
+  return createResultWorkbookFixture({
+    mode: "detailed_matrix_only",
+    optionCount: 5_461,
+    criterionCount: 1,
+  })
+}

--- a/src/lib/__tests__/technical-configuration-result-excel-fixtures.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-fixtures.ts
@@ -1,3 +1,5 @@
+import { RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET } from "@/lib/technical-configuration-result-excel-contract"
+
 import type {
   TechnicalConfigurationResultWorkbookBuildInput,
   TechnicalConfigurationResultWorkbookContentMode,
@@ -294,7 +296,7 @@ export function createRepresentativeLargeResultWorkbookFixture() {
 export function createMatrixBoundaryResultWorkbookFixture() {
   return createResultWorkbookFixture({
     mode: "detailed_matrix_only",
-    optionCount: 5_460,
+    optionCount: RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET,
     criterionCount: 1,
   })
 }
@@ -302,7 +304,7 @@ export function createMatrixBoundaryResultWorkbookFixture() {
 export function createContinuationResultWorkbookFixture() {
   return createResultWorkbookFixture({
     mode: "detailed_matrix_only",
-    optionCount: 5_461,
+    optionCount: RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET + 1,
     criterionCount: 1,
   })
 }

--- a/src/lib/technical-configuration-result-excel-contract-types.ts
+++ b/src/lib/technical-configuration-result-excel-contract-types.ts
@@ -48,31 +48,6 @@ export interface TechnicalConfigurationResultWorkbookDocumentLink {
   readonly excerpt: string | null
 }
 
-export interface TechnicalConfigurationResultWorkbookMatrixSourceCell {
-  readonly group_id: string
-  readonly group_name: string
-  readonly group_order: number
-  readonly criterion_id: string
-  readonly criterion_code: string
-  readonly criterion_title: string | null
-  readonly requirement_text: string
-  readonly criterion_order: number
-  readonly option_id: string
-  readonly supplier_id: string
-  readonly supplier_name: string
-  readonly display_label: string
-  readonly model: string | null
-  readonly manufacturer: string | null
-  readonly option_name: string | null
-  readonly response_text: string | null
-  readonly supplementary_information: string | null
-  readonly document_links: readonly TechnicalConfigurationResultWorkbookDocumentLink[]
-  readonly technical_axis: TechnicalConfigurationTechnicalAxis | null
-  readonly evidence_axis: TechnicalConfigurationEvidenceAxis | null
-  readonly assessment_notes: string | null
-  readonly conclusion: TechnicalConfigurationDerivedStatus
-}
-
 /** Ordered supplier-option descriptor from the stable P14A4 export dataset. */
 export interface TechnicalConfigurationResultWorkbookOptionSource {
   readonly option_id: string
@@ -94,6 +69,19 @@ export interface TechnicalConfigurationResultWorkbookCriterionSource {
   readonly criterion_title: string | null
   readonly requirement_text: string
   readonly criterion_order: number
+}
+
+export interface TechnicalConfigurationResultWorkbookMatrixSourceCell
+  extends
+    TechnicalConfigurationResultWorkbookCriterionSource,
+    TechnicalConfigurationResultWorkbookOptionSource {
+  readonly response_text: string | null
+  readonly supplementary_information: string | null
+  readonly document_links: readonly TechnicalConfigurationResultWorkbookDocumentLink[]
+  readonly technical_axis: TechnicalConfigurationTechnicalAxis | null
+  readonly evidence_axis: TechnicalConfigurationEvidenceAxis | null
+  readonly assessment_notes: string | null
+  readonly conclusion: TechnicalConfigurationDerivedStatus
 }
 
 interface TechnicalConfigurationResultWorkbookBuildContext {

--- a/src/lib/technical-configuration-result-excel-contract-types.ts
+++ b/src/lib/technical-configuration-result-excel-contract-types.ts
@@ -1,0 +1,128 @@
+import type {
+  TechnicalConfigurationDerivedStatus,
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+export type TechnicalConfigurationResultWorkbookContentMode =
+  "full" | "ranking_only" | "detailed_matrix_only"
+
+export type TechnicalConfigurationResultWorkbookScope = "all" | "selected"
+
+export interface TechnicalConfigurationResultWorkbookManifestSource {
+  readonly dossier: {
+    readonly id: string
+    readonly device_type_name: string
+    readonly name: string
+  }
+  readonly baseline_version: {
+    readonly id: string
+    readonly version_number: number
+    readonly locked_at: string | null
+  }
+  readonly option_total: number
+  readonly criterion_total: number
+  readonly snapshot_token: string
+  readonly ranking_snapshot_token: string
+}
+
+export interface TechnicalConfigurationResultWorkbookRankingSourceRow {
+  readonly option_id: string
+  readonly supplier_id: string
+  readonly supplier_name: string
+  readonly display_label: string
+  readonly eligibility: "eligible" | "incomplete"
+  readonly incomplete_criterion_count: number
+  readonly failed_count: number
+  readonly insufficient_evidence_count: number
+  readonly exceeds_count: number
+  readonly rank: number | null
+}
+
+export interface TechnicalConfigurationResultWorkbookDocumentLink {
+  readonly document_id: string
+  readonly document_name: string
+  readonly document_url: string
+  readonly citation_id: string
+  readonly page_section: string | null
+  readonly excerpt: string | null
+}
+
+export interface TechnicalConfigurationResultWorkbookMatrixSourceCell {
+  readonly group_id: string
+  readonly group_name: string
+  readonly group_order: number
+  readonly criterion_id: string
+  readonly criterion_code: string
+  readonly criterion_title: string | null
+  readonly requirement_text: string
+  readonly criterion_order: number
+  readonly option_id: string
+  readonly supplier_id: string
+  readonly supplier_name: string
+  readonly display_label: string
+  readonly model: string | null
+  readonly manufacturer: string | null
+  readonly option_name: string | null
+  readonly response_text: string | null
+  readonly supplementary_information: string | null
+  readonly document_links: readonly TechnicalConfigurationResultWorkbookDocumentLink[]
+  readonly technical_axis: TechnicalConfigurationTechnicalAxis | null
+  readonly evidence_axis: TechnicalConfigurationEvidenceAxis | null
+  readonly assessment_notes: string | null
+  readonly conclusion: TechnicalConfigurationDerivedStatus
+}
+
+/** Ordered supplier-option descriptor from the stable P14A4 export dataset. */
+export interface TechnicalConfigurationResultWorkbookOptionSource {
+  readonly option_id: string
+  readonly supplier_id: string
+  readonly supplier_name: string
+  readonly display_label: string
+  readonly model: string | null
+  readonly manufacturer: string | null
+  readonly option_name: string | null
+}
+
+/** Ordered criterion descriptor from the stable P14A4 export dataset. */
+export interface TechnicalConfigurationResultWorkbookCriterionSource {
+  readonly group_id: string
+  readonly group_name: string
+  readonly group_order: number
+  readonly criterion_id: string
+  readonly criterion_code: string
+  readonly criterion_title: string | null
+  readonly requirement_text: string
+  readonly criterion_order: number
+}
+
+interface TechnicalConfigurationResultWorkbookBuildContext {
+  readonly manifest: TechnicalConfigurationResultWorkbookManifestSource
+  readonly optionAxis: readonly TechnicalConfigurationResultWorkbookOptionSource[]
+  readonly criterionAxis: readonly TechnicalConfigurationResultWorkbookCriterionSource[]
+  readonly option_ids: readonly string[] | null
+  readonly criterion_ids: readonly string[] | null
+  readonly generated_at: string
+  readonly generated_by: string
+}
+
+/** Complete stable dataset plus output metadata needed to build the pure workbook model. */
+export type TechnicalConfigurationResultWorkbookBuildInput =
+  TechnicalConfigurationResultWorkbookBuildContext &
+    (
+      | {
+          readonly mode: "full"
+          readonly ranking: readonly TechnicalConfigurationResultWorkbookRankingSourceRow[]
+          readonly matrix: readonly TechnicalConfigurationResultWorkbookMatrixSourceCell[]
+        }
+      | {
+          readonly mode: "ranking_only"
+          readonly ranking: readonly TechnicalConfigurationResultWorkbookRankingSourceRow[]
+          readonly matrix: null
+        }
+      | {
+          readonly mode: "detailed_matrix_only"
+          readonly ranking: null
+          readonly matrix: readonly TechnicalConfigurationResultWorkbookMatrixSourceCell[]
+        }
+    )

--- a/src/lib/technical-configuration-result-excel-contract.ts
+++ b/src/lib/technical-configuration-result-excel-contract.ts
@@ -79,6 +79,17 @@ function createMetadata(input: TechnicalConfigurationResultWorkbookBuildInput) {
   } as const
 }
 
+type MetadataKeysMatchContract = keyof ReturnType<
+  typeof createMetadata
+> extends (typeof RESULT_WORKBOOK_META_KEYS)[number]
+  ? (typeof RESULT_WORKBOOK_META_KEYS)[number] extends keyof ReturnType<typeof createMetadata>
+    ? true
+    : false
+  : false
+
+const METADATA_KEYS_MATCH_CONTRACT: MetadataKeysMatchContract = true
+void METADATA_KEYS_MATCH_CONTRACT
+
 function createOverviewSheet(input: TechnicalConfigurationResultWorkbookBuildInput) {
   const rankingSummary =
     input.ranking === null

--- a/src/lib/technical-configuration-result-excel-contract.ts
+++ b/src/lib/technical-configuration-result-excel-contract.ts
@@ -1,0 +1,233 @@
+import type {
+  TechnicalConfigurationResultWorkbookBuildInput,
+  TechnicalConfigurationResultWorkbookCriterionSource,
+  TechnicalConfigurationResultWorkbookMatrixSourceCell,
+  TechnicalConfigurationResultWorkbookOptionSource,
+  TechnicalConfigurationResultWorkbookRankingSourceRow,
+} from "@/lib/technical-configuration-result-excel-contract-types"
+
+export type * from "@/lib/technical-configuration-result-excel-contract-types"
+
+/** Stable discriminator for final technical-configuration result workbooks. */
+export const RESULT_WORKBOOK_TEMPLATE_KIND = "technical_configuration_result"
+
+/** Supported final-result workbook contract version. */
+export const RESULT_WORKBOOK_TEMPLATE_VERSION = 1
+
+/** Physical column limit for an Excel worksheet. */
+export const EXCEL_WORKSHEET_MAX_COLUMNS = 16_384
+
+/** Exact frozen context columns at the start of every matrix worksheet. */
+export const RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS = [
+  "STT",
+  "Nhóm tiêu chí",
+  "Mã tiêu chí",
+  "Yêu cầu cấu hình cơ sở",
+] as const
+
+/** Exact ordered columns repeated for every option in a matrix worksheet. */
+export const RESULT_WORKBOOK_OPTION_COLUMNS = [
+  "Phản hồi nhà cung cấp",
+  "Thông tin bổ sung / tài liệu",
+  "Kết luận đánh giá",
+] as const
+
+/** Maximum complete option groups that fit on one matrix worksheet. */
+export const RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET = Math.floor(
+  (EXCEL_WORKSHEET_MAX_COLUMNS - RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS.length) /
+    RESULT_WORKBOOK_OPTION_COLUMNS.length
+)
+
+/** Exact ordered keys rendered on the hidden metadata worksheet. */
+export const RESULT_WORKBOOK_META_KEYS = [
+  "template_kind",
+  "template_version",
+  "dossier_id",
+  "baseline_version_id",
+  "snapshot_token",
+  "ranking_snapshot_token",
+  "content_mode",
+  "option_scope",
+  "criterion_scope",
+  "ordered_option_ids",
+  "ordered_criterion_ids",
+  "generated_at",
+  "generated_by",
+] as const
+
+function createScope(input: TechnicalConfigurationResultWorkbookBuildInput) {
+  return {
+    option_scope: input.option_ids === null ? "all" : "selected",
+    criterion_scope: input.criterion_ids === null ? "all" : "selected",
+    ordered_option_ids: input.option_ids === null ? [] : [...input.option_ids],
+    ordered_criterion_ids: input.criterion_ids === null ? [] : [...input.criterion_ids],
+  } as const
+}
+
+function createMetadata(input: TechnicalConfigurationResultWorkbookBuildInput) {
+  return {
+    template_kind: RESULT_WORKBOOK_TEMPLATE_KIND,
+    template_version: RESULT_WORKBOOK_TEMPLATE_VERSION,
+    dossier_id: input.manifest.dossier.id,
+    baseline_version_id: input.manifest.baseline_version.id,
+    snapshot_token: input.manifest.snapshot_token,
+    ranking_snapshot_token: input.manifest.ranking_snapshot_token,
+    content_mode: input.mode,
+    ...createScope(input),
+    generated_at: input.generated_at,
+    generated_by: input.generated_by,
+  } as const
+}
+
+function createOverviewSheet(input: TechnicalConfigurationResultWorkbookBuildInput) {
+  const rankingSummary =
+    input.ranking === null
+      ? null
+      : {
+          eligible_total: input.ranking.filter((row) => row.eligibility === "eligible").length,
+          incomplete_total: input.ranking.filter((row) => row.eligibility === "incomplete").length,
+          reference_ranking_disclaimer: true as const,
+          top_ten: input.ranking.slice(0, 10),
+        }
+
+  return {
+    kind: "overview",
+    name: "Tổng quan",
+    state: "visible",
+    summary: {
+      dossier: input.manifest.dossier,
+      baseline_version: input.manifest.baseline_version,
+      option_total: input.manifest.option_total,
+      criterion_total: input.manifest.criterion_total,
+      generated_at: input.generated_at,
+      generated_by: input.generated_by,
+      scope: createScope(input),
+      ranking_summary: rankingSummary,
+    },
+  } as const
+}
+
+function matrixCellKey(criterionId: string, optionId: string) {
+  return `${criterionId}\u0000${optionId}`
+}
+
+function createMatrixSheets(
+  optionAxis: readonly TechnicalConfigurationResultWorkbookOptionSource[],
+  criterionAxis: readonly TechnicalConfigurationResultWorkbookCriterionSource[],
+  matrix: readonly TechnicalConfigurationResultWorkbookMatrixSourceCell[]
+) {
+  const cells = new Map<string, TechnicalConfigurationResultWorkbookMatrixSourceCell>()
+
+  for (const cell of matrix) {
+    cells.set(matrixCellKey(cell.criterion_id, cell.option_id), cell)
+  }
+
+  const optionPartitions =
+    optionAxis.length === 0
+      ? [[]]
+      : Array.from(
+          {
+            length: Math.ceil(optionAxis.length / RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET),
+          },
+          (_, index) =>
+            optionAxis.slice(
+              index * RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET,
+              (index + 1) * RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET
+            )
+        )
+
+  return optionPartitions.map((partition, partitionIndex) => ({
+    kind: "matrix" as const,
+    name: partitionIndex === 0 ? "Ma trận chi tiết" : `Ma trận chi tiết ${partitionIndex + 1}`,
+    state: "visible" as const,
+    context_columns: RESULT_WORKBOOK_MATRIX_CONTEXT_COLUMNS,
+    option_columns: RESULT_WORKBOOK_OPTION_COLUMNS,
+    option_groups: partition,
+    rows: criterionAxis.map((criterion, criterionIndex) => ({
+      stt: criterionIndex + 1,
+      group_id: criterion.group_id,
+      group_name: criterion.group_name,
+      group_order: criterion.group_order,
+      criterion_id: criterion.criterion_id,
+      criterion_code: criterion.criterion_code,
+      criterion_title: criterion.criterion_title,
+      requirement_text: criterion.requirement_text,
+      criterion_order: criterion.criterion_order,
+      option_values: partition.map((option) => {
+        const cell = cells.get(matrixCellKey(criterion.criterion_id, option.option_id))
+        return {
+          option_id: option.option_id,
+          response_text: cell?.response_text ?? null,
+          supplementary_information: cell?.supplementary_information ?? null,
+          document_links: cell?.document_links ?? [],
+          technical_axis: cell?.technical_axis ?? null,
+          evidence_axis: cell?.evidence_axis ?? null,
+          assessment_notes: cell?.assessment_notes ?? null,
+          conclusion: cell?.conclusion ?? "not_evaluated",
+        }
+      }),
+    })),
+  }))
+}
+
+function createRankingSheet(
+  ranking: readonly TechnicalConfigurationResultWorkbookRankingSourceRow[]
+) {
+  return {
+    kind: "ranking",
+    name: "Xếp hạng",
+    state: "visible",
+    rows: ranking,
+  } as const
+}
+
+function createMetaSheet(input: TechnicalConfigurationResultWorkbookBuildInput) {
+  return {
+    kind: "meta",
+    name: "_meta",
+    state: "hidden",
+    metadata: createMetadata(input),
+  } as const
+}
+
+type ResultWorkbookSheet =
+  | ReturnType<typeof createOverviewSheet>
+  | ReturnType<typeof createRankingSheet>
+  | ReturnType<typeof createMatrixSheets>[number]
+  | ReturnType<typeof createMetaSheet>
+
+/** Build the deterministic output-only workbook model without ExcelJS or side effects. */
+export function createTechnicalConfigurationResultWorkbookModel(
+  input: TechnicalConfigurationResultWorkbookBuildInput
+): {
+  readonly template_kind: typeof RESULT_WORKBOOK_TEMPLATE_KIND
+  readonly template_version: typeof RESULT_WORKBOOK_TEMPLATE_VERSION
+  readonly sheets: readonly ResultWorkbookSheet[]
+} {
+  const sheets: ResultWorkbookSheet[] = [createOverviewSheet(input)]
+
+  if (input.ranking !== null) sheets.push(createRankingSheet(input.ranking))
+  if (input.matrix !== null) {
+    sheets.push(...createMatrixSheets(input.optionAxis, input.criterionAxis, input.matrix))
+  }
+
+  sheets.push(createMetaSheet(input))
+
+  return {
+    template_kind: RESULT_WORKBOOK_TEMPLATE_KIND,
+    template_version: RESULT_WORKBOOK_TEMPLATE_VERSION,
+    sheets,
+  }
+}
+
+export type TechnicalConfigurationResultWorkbookModel = ReturnType<
+  typeof createTechnicalConfigurationResultWorkbookModel
+>
+
+export type TechnicalConfigurationResultWorkbookSheetModel =
+  TechnicalConfigurationResultWorkbookModel["sheets"][number]
+
+export type TechnicalConfigurationResultWorkbookMetadata = Extract<
+  TechnicalConfigurationResultWorkbookSheetModel,
+  { kind: "meta" }
+>["metadata"]


### PR DESCRIPTION
## Summary
- add a versioned output-only result workbook model for all three content modes
- preserve P14A4 ordered axes, selected-scope metadata, asymmetric empty dimensions, and deterministic continuation planning
- add representative in-memory fixtures for empty, sparse, tied, missing-data, narrowed, boundary, continuation, and large datasets
- update P14B1 OpenSpec tasks and execution evidence

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe plus semantic reuse search
- verify:ts-docstrings
- typecheck
- P14 export suite: 8 files, 86 tests
- React Doctor: 100/100
- strict OpenSpec validation
- staged diff and output-only boundary checks

## Scope boundary
- no ExcelJS or workbook rendering
- no Blob/download or UI
- no parser/import/apply
- no seed or live DB access

Closes #842

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a versioned, output-only result workbook model for technical configurations, with hardened contract tests and deterministic fixtures. Supports all three content modes, preserves P14A4 ordered axes and selected scopes, and splits matrix sheets exactly at Excel’s column limit. Closes #842.

- New Features
  - New pure builder `createTechnicalConfigurationResultWorkbookModel` with `RESULT_WORKBOOK_TEMPLATE_KIND = "technical_configuration_result"` and `RESULT_WORKBOOK_TEMPLATE_VERSION = 1`. Adds `technical-configuration-result-excel-contract-types.ts`, re-exports types, and validates the stable P14A4 dataset shape without app dependencies.
  - Locks sheet order per mode and a single hidden `_meta`; freezes 4 context columns and 3 option columns; enforces exact meta keys. Overview now carries scope and a top-ten ranking summary when ranking is present.
  - Deterministic partitioning at `EXCEL_WORKSHEET_MAX_COLUMNS = 16384` with `RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET = 5460` and continuation naming; no truncation.
  - Preserves ordered axes, narrowed scopes, asymmetric empty matrices, dense ties, and explicit missing-data handling. Adds deterministic fixtures (empty, sparse, tied, missing, narrowed, boundary 5,460, continuation 5,461, large 101 x 102) and strict tests for shape, outputs, meta identity/keys, boundary math, and determinism. Pure model only; no ExcelJS, rendering, parser/import/apply, UI, or DB.

<sup>Written for commit 44e5fc1292dc5fe3f2a4a9a108126c1d4fce554f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured workbook model for technical-configuration results, including overview, ranking, matrix, and metadata sheets.
  * Added support for full, ranking-only, and detailed-matrix-only workbook content.
  * Added automatic continuation sheets when matrix data exceeds Excel’s column limits.
  * Added handling for empty, sparse, tied-ranking, missing-data, and large result sets.

* **Tests**
  * Added comprehensive validation covering workbook structure, metadata, ordering, edge cases, and deterministic fixture scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->