### PR TITLE
feat: render approved technical configuration result workbook

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -785,9 +785,13 @@ a three-column group in this exact order:
 2. `Thông tin bổ sung / tài liệu`
 3. `Kết luận đánh giá`
 
-Supplementary/document cells preserve supplier text and render exact HTTP(S)
-document links/citation labels without affecting the conclusion. Conclusion
-cells use the existing seven-status derivation and restrained status fills.
+Supplementary/document cells preserve supplier text and render every exact
+HTTP(S) document URL/citation label in deterministic model order without
+affecting the conclusion. Because one Excel cell supports one hyperlink target,
+the first HTTP(S) document URL is clickable and later links remain complete
+visible text in that same cell; the renderer does not add a column/sheet or
+truncate a citation. Conclusion cells use the existing seven-status derivation
+and restrained status fills.
 
 The approved visual contract is normative:
 

--- a/openspec/changes/add-technical-configuration-comparison/design.md
+++ b/openspec/changes/add-technical-configuration-comparison/design.md
@@ -591,6 +591,12 @@ tiết` freeze hàng header và bốn cột `STT`, `Nhóm tiêu chí`, `Mã tiê
 `Yêu cầu cấu hình cơ sở`; mỗi option dùng ba cột `Phản hồi nhà cung cấp`,
 `Thông tin bổ sung / tài liệu`, `Kết luận đánh giá`.
 
+Nếu một ô `Thông tin bổ sung / tài liệu` có nhiều citation, renderer giữ toàn bộ
+label và HTTP(S) URL theo đúng thứ tự model. Do một ô Excel chỉ có một hyperlink
+target, URL HTTP(S) đầu tiên là clickable; các URL còn lại vẫn hiển thị đầy đủ
+dưới dạng text trong cùng ô. Renderer không thêm cột/sheet và không truncate
+citation để né giới hạn này.
+
 Workbook giữ visual direction từ Stitch: title fill xanh đậm `#166534`, chữ
 trắng, header xanh, border xám mảnh, zebra rows, wrap text, top alignment,
 filter, freeze panes, status fill tiết chế và disclaimer màu amber. OpenSpec và

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3246,27 +3246,36 @@ contract; GREEN adds no ExcelJS, RPC, migration, DB, UI or download behavior.
 ### Planned files
 
 - Create: `src/lib/technical-configuration-result-excel-export.ts`
+- Create: `src/lib/technical-configuration-result-excel-styles.ts`
 - Create:
   `src/lib/__tests__/technical-configuration-result-excel-export.test.ts`
+- Create:
+  `src/lib/__tests__/technical-configuration-result-excel-export-boundary.test.ts`
 - Reuse unchanged unless a proven shared-contract gap exists:
   `src/lib/excel-workbook.ts`
 
 ### Tasks
 
-- [ ] Write RED focused workbook tests that inspect sheets, hidden state,
+- [x] Write RED focused workbook tests that inspect sheets, hidden state,
       merged cells, values, hyperlinks, filters, panes, widths/heights, borders,
       fills and representative continuation sheets.
-- [ ] Reuse `createExcelWorkbook()` and the existing lazy ExcelJS serialization
+- [x] Reuse `createExcelWorkbook()` and the existing lazy ExcelJS serialization
       pattern; do not route the domain workbook through flat `exportToExcel()`.
-- [ ] Render the two approved workbook layouts from Stitch project
-      `1463377740887387448`: overview/ranking
+- [x] Use the two workbook screens from Stitch project `1463377740887387448`
+      as visual guidance while rendering the OpenSpec/P14B1F content contract:
+      overview/ranking
       `d394c0dd25f146cf9423b8acf8eeaa86` and detailed matrix
       `45c3a6f4ac514212ba3259064ef19ea0`. P14C1 separately owns dialog
       `4aaff09e4788412386ea8d4f1baa4da9`.
-- [ ] Lock `#166534` title/header styling, white title text, thin gray borders,
+- [x] Lock `#166534` title/header styling, white title text, thin gray borders,
       zebra rows, wrap/top alignment, filters, frozen panes, amber disclaimer
       and restrained conclusion fills.
-- [ ] Assert no chart, gradient, score, percentage, award decision or truncated
+- [x] Preserve every document citation label/URL in one supplementary cell;
+      make the first HTTP(S) URL clickable and keep later URLs visible text
+      because Excel supports one hyperlink target per cell.
+- [x] Serialize and reload the physical 16,384-column boundary, including the
+      continuation option's values, link fallback, merges and presentation.
+- [x] Assert no chart, gradient, score, percentage, award decision or truncated
       option exists.
 
 ### Exit gate

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -677,8 +677,11 @@ no renderer or production caller.
 ### Planned Files
 
 - Create: `src/lib/technical-configuration-result-excel-export.ts`
+- Create: `src/lib/technical-configuration-result-excel-styles.ts`
 - Create:
   `src/lib/__tests__/technical-configuration-result-excel-export.test.ts`
+- Create:
+  `src/lib/__tests__/technical-configuration-result-excel-export-boundary.test.ts`
 - Reuse unchanged unless a shared-contract gap is proven:
   `src/lib/excel-workbook.ts`
 
@@ -712,6 +715,33 @@ no renderer or production caller.
 
 **Deploy boundary:** workbook API exists but has no mounted production caller or
 download effect.
+
+### P14B2 Execution Evidence - 2026-08-03
+
+- The focused RED suite failed only because
+  `src/lib/technical-configuration-result-excel-export.ts` did not exist.
+- The renderer accepts only the output-only P14B1F workbook model, reuses
+  `createExcelWorkbook()`, returns a workbook or serialized bytes and does not
+  import `downloadBlob()`, UI, caller or orchestration code.
+- Semantic reuse discovery found no matching shared Excel style abstraction.
+  P14-specific visual tokens were extracted locally into
+  `technical-configuration-result-excel-styles.ts` to keep the renderer below
+  the repository's 350-line extraction threshold.
+- Focused renderer tests pass `6/6`; the combined P14/shared workbook,
+  baseline/option workbook and Equipment Excel regression set passes
+  `160 passed / 4 skipped` across `15` files.
+- All three modes serialize and reload before asserting sheet order/state,
+  primary presentation and exact `_meta` values. The physical-column boundary
+  test separately reloads the XFD continuation, preserving exact values, sheet
+  presentation and every ordered citation URL. The first HTTP(S) URL is
+  clickable and remaining URLs stay visible without adding columns/sheets or
+  truncating content.
+- Format, no-explicit-any, diff-only dedupe and typecheck gates pass. React
+  Doctor changed-scope scans the four changed source/test files with no
+  findings. The current React Doctor v0.9.3 full-scan syntax is `--scope full`;
+  its repo-wide baseline findings are outside this renderer-only phase.
+- Strict OpenSpec validation passes for
+  `add-technical-configuration-comparison`.
 
 ## P14C1 - Export Scope Dialog And State Machine
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -927,14 +927,15 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14B2 - Approved ExcelJS Workbook Rendering
 
-- [ ] P14B2.1 Khóa values, hidden state, links, filters, panes, dimensions,
-      borders/fills và continuation sheets bằng focused workbook tests.
-- [ ] P14B2.2 Reuse `createExcelWorkbook()` và lazy ExcelJS serialization;
+- [x] P14B2.1 Khóa values, exact `_meta`, hidden state, multi-link fallback,
+      filters, panes, dimensions, borders/fills và continuation round-trip bằng
+      focused workbook tests.
+- [x] P14B2.2 Reuse `createExcelWorkbook()` và lazy ExcelJS serialization;
       không thêm cờ domain vào flat `exportToExcel()`.
-- [ ] P14B2.3 Render đúng hai workbook mockup đã duyệt với màu `#166534`,
-      zebra, wrap/top alignment, amber disclaimer và restrained conclusion
-      fills.
-- [ ] P14B2.4 Xác minh không chart, gradient, score, percentage, award decision,
+- [x] P14B2.3 Dùng hai workbook screen Stitch làm visual guidance, giữ
+      OpenSpec/P14B1F làm chuẩn nội dung, với màu `#166534`, zebra, wrap/top
+      alignment, amber disclaimer và restrained conclusion fills.
+- [x] P14B2.4 Xác minh không chart, gradient, score, percentage, award decision,
       mounted trigger hoặc download side effect.
 
 ## Phase P14C1 - Export Scope Dialog And State Machine

--- a/src/lib/__tests__/technical-configuration-result-excel-export-boundary.test.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-export-boundary.test.ts
@@ -1,0 +1,122 @@
+import type { Fill } from "exceljs"
+import { describe, expect, it } from "vitest"
+
+import { createExcelWorkbook } from "@/lib/excel-workbook"
+import {
+  RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET,
+  createTechnicalConfigurationResultWorkbookModel,
+} from "@/lib/technical-configuration-result-excel-contract"
+import { serializeTechnicalConfigurationResultWorkbook } from "@/lib/technical-configuration-result-excel-export"
+import { createResultWorkbookFixture } from "@/lib/__tests__/technical-configuration-result-excel-fixtures"
+
+const HEADER_FILL = "FF2E7D32"
+const BORDER_COLOR = "FFD1D5DB"
+const FAILS_FILL = "FFFEE2E2"
+const FIRST_DOCUMENT_URL = "https://example.com/final-option-a.pdf"
+const SECOND_DOCUMENT_URL = "https://example.com/final-option-b.pdf"
+
+function getPatternFill(fill: Fill) {
+  if (fill.type !== "pattern") throw new Error("Expected a pattern fill.")
+  return fill
+}
+
+describe("technical configuration result ExcelJS renderer boundary", () => {
+  it("serializes and reloads the physical-column continuation without truncating values or presentation", async () => {
+    const finalOptionIndex = RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET
+    const input = createResultWorkbookFixture({
+      mode: "detailed_matrix_only",
+      optionCount: finalOptionIndex + 1,
+      criterionCount: 1,
+      matrixFactory: (cell, _criterionIndex, optionIndex) =>
+        optionIndex === finalOptionIndex
+          ? {
+              ...cell,
+              response_text: "Phản hồi phương án cuối",
+              supplementary_information: "Tài liệu phương án cuối",
+              document_links: [
+                {
+                  document_id: "document-a",
+                  document_name: "Tài liệu A",
+                  document_url: FIRST_DOCUMENT_URL,
+                  citation_id: "CIT-A",
+                  page_section: "trang 1",
+                  excerpt: "Trích đoạn A",
+                },
+                {
+                  document_id: "document-b",
+                  document_name: "Tài liệu B",
+                  document_url: SECOND_DOCUMENT_URL,
+                  citation_id: "CIT-B",
+                  page_section: "trang 2",
+                  excerpt: "Trích đoạn B",
+                },
+              ],
+              conclusion: "fails",
+            }
+          : cell,
+    })
+    const model = createTechnicalConfigurationResultWorkbookModel(input)
+
+    const bytes = await serializeTechnicalConfigurationResultWorkbook(model)
+    const loaded = await createExcelWorkbook()
+    await loaded.xlsx.load(bytes)
+
+    expect(bytes.byteLength).toBeGreaterThan(0)
+    expect(loaded.worksheets.map((sheet) => sheet.name)).toEqual([
+      "Tổng quan",
+      "Ma trận chi tiết",
+      "Ma trận chi tiết 2",
+      "_meta",
+    ])
+
+    const first = loaded.getWorksheet("Ma trận chi tiết")
+    const second = loaded.getWorksheet("Ma trận chi tiết 2")
+    if (!first || !second) throw new Error("Expected both matrix worksheets.")
+
+    expect(first.columnCount).toBe(16_384)
+    expect(second.columnCount).toBe(7)
+    expect(first.model.merges).toEqual(
+      expect.arrayContaining(["A1:XFD1", "A2:XFD2", "A3:XFD3", "A4:D4"])
+    )
+    expect(second.model.merges).toEqual(
+      expect.arrayContaining(["A1:G1", "A2:G2", "A3:G3", "A4:D4", "E4:G4"])
+    )
+    expect(first.getCell(4, 16_382).value).toContain(
+      `Phuong an ${RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET}`
+    )
+    expect(first.getCell(6, 16_382).value).toBe(
+      `Phan hoi 1-${RESULT_WORKBOOK_MAX_OPTIONS_PER_MATRIX_SHEET}`
+    )
+    expect(second.getCell("E4").value).toContain(`Phuong an ${finalOptionIndex + 1}`)
+    expect(second.getCell("E6").value).toBe("Phản hồi phương án cuối")
+    expect(second.getCell("F6").value).toEqual({
+      text:
+        `Tài liệu phương án cuối\n[CIT-A] Tài liệu A (trang 1) - ${FIRST_DOCUMENT_URL}` +
+        `\n[CIT-B] Tài liệu B (trang 2) - ${SECOND_DOCUMENT_URL}`,
+      hyperlink: FIRST_DOCUMENT_URL,
+    })
+    expect(second.getCell("G6").value).toBe("Không đạt")
+
+    for (const worksheet of [first, second]) {
+      expect(worksheet.views[0]).toMatchObject({ state: "frozen", xSplit: 4, ySplit: 5 })
+      expect(worksheet.autoFilter).toBeDefined()
+      expect(getPatternFill(worksheet.getCell("A5").fill).fgColor).toEqual({
+        argb: HEADER_FILL,
+      })
+      expect(worksheet.getCell("A6").border.bottom).toMatchObject({
+        style: "thin",
+        color: { argb: BORDER_COLOR },
+      })
+      expect(worksheet.getCell("A6").alignment).toMatchObject({
+        vertical: "top",
+        wrapText: true,
+      })
+    }
+    expect(second.getColumn(6).width).toBe(40)
+    expect(second.getRow(6).height).toBe(60)
+    expect(getPatternFill(second.getCell("G6").fill).fgColor).toEqual({
+      argb: FAILS_FILL,
+    })
+    expect(loaded.getWorksheet("_meta")?.state).toBe("hidden")
+  }, 120_000)
+})

--- a/src/lib/__tests__/technical-configuration-result-excel-export.test.ts
+++ b/src/lib/__tests__/technical-configuration-result-excel-export.test.ts
@@ -1,0 +1,319 @@
+import type { Cell, Fill, Workbook } from "exceljs"
+import { describe, expect, it } from "vitest"
+
+import { createExcelWorkbook } from "@/lib/excel-workbook"
+import { createTechnicalConfigurationResultWorkbookModel } from "@/lib/technical-configuration-result-excel-contract"
+import {
+  createTechnicalConfigurationResultWorkbook,
+  serializeTechnicalConfigurationResultWorkbook,
+} from "@/lib/technical-configuration-result-excel-export"
+import { createResultWorkbookFixture } from "@/lib/__tests__/technical-configuration-result-excel-fixtures"
+
+const TITLE_FILL = "FF166534"
+const HEADER_FILL = "FF2E7D32"
+const BORDER_COLOR = "FFD1D5DB"
+const ZEBRA_FILL = "FFF3F4F6"
+const AMBER_FILL = "FFFFF3CD"
+const MEETS_FILL = "FFD1FAE5"
+
+function getWorksheet(workbook: Workbook, name: string) {
+  const worksheet = workbook.getWorksheet(name)
+  if (!worksheet) throw new Error(`Expected worksheet ${name}.`)
+  return worksheet
+}
+
+function getPatternFill(cell: Cell) {
+  const fill = cell.fill as Fill
+  if (fill.type !== "pattern") throw new Error(`Expected pattern fill at ${cell.address}.`)
+  return fill
+}
+
+function getCellText(cell: Cell): string {
+  const value = cell.value
+  if (value === null || value === undefined) return ""
+  if (typeof value === "object" && "text" in value) return value.text
+  if (typeof value === "object" && "richText" in value) {
+    return value.richText.map((part) => part.text).join("")
+  }
+  return String(value)
+}
+
+function getWorkbookText(workbook: Workbook) {
+  const values: string[] = []
+  workbook.eachSheet((worksheet) => {
+    worksheet.eachRow((row) => {
+      row.eachCell({ includeEmpty: false }, (cell) => values.push(getCellText(cell)))
+    })
+  })
+  return values.join("\n")
+}
+
+function expectThinGrayBorder(cell: Cell) {
+  for (const edge of ["top", "left", "bottom", "right"] as const) {
+    expect(cell.border[edge]).toMatchObject({
+      style: "thin",
+      color: { argb: BORDER_COLOR },
+    })
+  }
+}
+
+function expectStandardDataCell(cell: Cell) {
+  expectThinGrayBorder(cell)
+  expect(cell.alignment).toMatchObject({
+    vertical: "top",
+    wrapText: true,
+  })
+}
+
+function expectNoForbiddenWorkbookContent(workbook: Workbook) {
+  const workbookText = getWorkbookText(workbook)
+  expect(workbookText).not.toMatch(/\b(chart|score|percentage)\b/i)
+  expect(workbookText).not.toMatch(/(điểm số|tỷ lệ|quyết định trao thầu)/i)
+  expect(JSON.stringify(workbook.model)).not.toMatch(/gradient|chart/i)
+}
+
+describe("technical configuration result ExcelJS renderer", () => {
+  it("renders the full overview and ranking sheets with exact values and presentation", async () => {
+    const input = createResultWorkbookFixture({
+      mode: "full",
+      optionCount: 2,
+      criterionCount: 3,
+      rankingFactory: (row, index) =>
+        index === 0
+          ? {
+              ...row,
+              eligibility: "incomplete",
+              incomplete_criterion_count: 1,
+              failed_count: 1,
+              insufficient_evidence_count: 2,
+              exceeds_count: 0,
+              rank: null,
+            }
+          : row,
+    })
+    const model = createTechnicalConfigurationResultWorkbookModel(input)
+
+    const workbook = await createTechnicalConfigurationResultWorkbook(model)
+
+    expect(workbook.worksheets.map((sheet) => [sheet.name, sheet.state])).toEqual([
+      ["Tổng quan", "visible"],
+      ["Xếp hạng", "visible"],
+      ["Ma trận chi tiết", "visible"],
+      ["_meta", "hidden"],
+    ])
+
+    const overview = getWorksheet(workbook, "Tổng quan")
+    expect(overview.model.merges).toEqual(expect.arrayContaining(["A1:H2", "A3:H3", "A13:H13"]))
+    expect(overview.getCell("A1").value).toBe("KẾT QUẢ SO SÁNH CẤU HÌNH KỸ THUẬT")
+    expect(overview.getCell("A3").value).toBe("Cau hinh may sieu am")
+    expect(overview.getCell("A5").value).toBe("Mã hồ sơ")
+    expect(overview.getCell("B5").value).toBe(input.manifest.dossier.id)
+    expect(overview.getCell("A6").value).toBe("Phiên bản cấu hình cơ sở")
+    expect(overview.getCell("B6").value).toBe(3)
+    expect(overview.getCell("A7").value).toBe("Khóa lúc")
+    expect(overview.getCell("B7").value).toBe("2026-08-01T02:03:04.000Z")
+    expect(overview.getCell("D5").value).toBe("Tổng phương án")
+    expect(overview.getCell("E5").value).toBe(2)
+    expect(overview.getCell("D6").value).toBe("Tổng tiêu chí")
+    expect(overview.getCell("E6").value).toBe(3)
+    expect(overview.getCell("D7").value).toBe("Đủ điều kiện")
+    expect(overview.getCell("E7").value).toBe(1)
+    expect(overview.getCell("D8").value).toBe("Chưa hoàn thiện")
+    expect(overview.getCell("E8").value).toBe(1)
+    expect(String(overview.getCell("A13").value)).toMatch(/xếp hạng chỉ mang tính tham khảo/i)
+    expect(getPatternFill(overview.getCell("A13")).fgColor).toEqual({ argb: AMBER_FILL })
+    expect(overview.getRow(16).values).toEqual([
+      undefined,
+      "Hạng",
+      "Mã PA",
+      "Nhà cung cấp",
+      "Model",
+      "Trạng thái",
+      "Đã hoàn thiện",
+      "Chưa hoàn thiện",
+      "Ghi chú",
+    ])
+    expect(overview.getRow(17).values).toEqual([
+      undefined,
+      "",
+      "Phuong an 1",
+      "Nha cung cap 1",
+      "Model 1",
+      "Chưa hoàn thiện",
+      2,
+      1,
+      "Không đạt: 1; Thiếu bằng chứng: 2",
+    ])
+
+    const ranking = getWorksheet(workbook, "Xếp hạng")
+    expect(ranking.model.merges).toEqual(expect.arrayContaining(["A1:H2", "A3:H3"]))
+    expect(ranking.getRow(5).values).toEqual(overview.getRow(16).values)
+    expect(ranking.getRow(6).values).toEqual(overview.getRow(17).values)
+    expect(ranking.getRow(7).values).toEqual([
+      undefined,
+      2,
+      "Phuong an 2",
+      "Nha cung cap 2",
+      "Model 2",
+      "Đủ điều kiện",
+      3,
+      0,
+      "Vượt yêu cầu: 1",
+    ])
+    expect(ranking.autoFilter).toEqual({ from: "A5", to: "H7" })
+    expect(ranking.views[0]).toMatchObject({ state: "frozen", ySplit: 5 })
+    expect(ranking.getColumn(3).width).toBe(28)
+    expect(ranking.getColumn(8).width).toBe(32)
+    expect(ranking.getRow(1).height).toBe(30)
+    expect(ranking.getRow(5).height).toBe(36)
+    expect(getPatternFill(ranking.getCell("A1")).fgColor).toEqual({ argb: TITLE_FILL })
+    expect(ranking.getCell("A1").font).toMatchObject({ bold: true, color: { argb: "FFFFFFFF" } })
+    expect(getPatternFill(ranking.getCell("A5")).fgColor).toEqual({ argb: HEADER_FILL })
+    expect(getPatternFill(ranking.getCell("A7")).fgColor).toEqual({ argb: ZEBRA_FILL })
+    expectStandardDataCell(ranking.getCell("C6"))
+    expectNoForbiddenWorkbookContent(workbook)
+  })
+
+  it("renders the detailed matrix with frozen headers, dimensions, status fills and hyperlinks", async () => {
+    const input = createResultWorkbookFixture({
+      mode: "detailed_matrix_only",
+      optionCount: 1,
+      criterionCount: 1,
+      matrixFactory: (cell) => ({
+        ...cell,
+        supplementary_information: "Phiếu thông số kỹ thuật",
+        document_links: [
+          {
+            document_id: "document-1",
+            document_name: "Thông số máy",
+            document_url: "https://example.com/spec.pdf",
+            citation_id: "CIT-001",
+            page_section: "trang 4",
+            excerpt: "Dải tần đầu dò",
+          },
+        ],
+      }),
+    })
+    const model = createTechnicalConfigurationResultWorkbookModel(input)
+
+    const workbook = await createTechnicalConfigurationResultWorkbook(model)
+
+    expect(workbook.worksheets.map((sheet) => [sheet.name, sheet.state])).toEqual([
+      ["Tổng quan", "visible"],
+      ["Ma trận chi tiết", "visible"],
+      ["_meta", "hidden"],
+    ])
+    const overviewText = getWorkbookText(workbook)
+    expect(overviewText).not.toContain("XẾP HẠNG THAM KHẢO")
+    expect(overviewText).not.toContain("xếp hạng chỉ mang tính tham khảo")
+
+    const matrix = getWorksheet(workbook, "Ma trận chi tiết")
+    expect(matrix.model.merges).toEqual(
+      expect.arrayContaining(["A1:G1", "A2:G2", "A3:G3", "A4:D4", "E4:G4"])
+    )
+    expect(matrix.getCell("A1").value).toBe("MA TRẬN SO SÁNH CHI TIẾT")
+    expect(matrix.getCell("A2").value).toBe("Cau hinh may sieu am")
+    expect(matrix.getCell("E4").value).toBe("Phuong an 1 - Nha cung cap 1 - Model 1")
+    expect(matrix.getRow(5).values).toEqual([
+      undefined,
+      "STT",
+      "Nhóm tiêu chí",
+      "Mã tiêu chí",
+      "Yêu cầu cấu hình cơ sở",
+      "Phản hồi nhà cung cấp",
+      "Thông tin bổ sung / tài liệu",
+      "Kết luận đánh giá",
+    ])
+    expect(matrix.getRow(6).values).toEqual([
+      undefined,
+      1,
+      "Nhom tieu chi 1",
+      "TC-001",
+      "Yeu cau cau hinh 1",
+      "Phan hoi 1-1",
+      {
+        text: "Phiếu thông số kỹ thuật\n[CIT-001] Thông số máy (trang 4) - https://example.com/spec.pdf",
+        hyperlink: "https://example.com/spec.pdf",
+        tooltip: "Dải tần đầu dò",
+      },
+      "Đạt",
+    ])
+    expect(matrix.views[0]).toMatchObject({ state: "frozen", xSplit: 4, ySplit: 5 })
+    expect(matrix.autoFilter).toEqual({ from: "A5", to: "G6" })
+    expect(matrix.getColumn(1).width).toBe(8)
+    expect(matrix.getColumn(4).width).toBe(42)
+    expect(matrix.getColumn(6).width).toBe(40)
+    expect(matrix.getRow(1).height).toBe(30)
+    expect(matrix.getRow(5).height).toBe(36)
+    expect(matrix.getRow(6).height).toBe(60)
+    expect(getPatternFill(matrix.getCell("A1")).fgColor).toEqual({ argb: TITLE_FILL })
+    expect(getPatternFill(matrix.getCell("A5")).fgColor).toEqual({ argb: HEADER_FILL })
+    expect(getPatternFill(matrix.getCell("G6")).fgColor).toEqual({ argb: MEETS_FILL })
+    expectStandardDataCell(matrix.getCell("F6"))
+    expectNoForbiddenWorkbookContent(workbook)
+  })
+
+  it.each([
+    ["full", ["Tổng quan", "Xếp hạng", "Ma trận chi tiết", "_meta"]],
+    ["ranking_only", ["Tổng quan", "Xếp hạng", "_meta"]],
+    ["detailed_matrix_only", ["Tổng quan", "Ma trận chi tiết", "_meta"]],
+  ] as const)(
+    "preserves exact sheet order and hidden state for %s",
+    async (mode, expectedNames) => {
+      const input = createResultWorkbookFixture({ mode, optionCount: 1, criterionCount: 1 })
+      const model = createTechnicalConfigurationResultWorkbookModel(input)
+
+      const bytes = await serializeTechnicalConfigurationResultWorkbook(model)
+      const workbook = await createExcelWorkbook()
+      await workbook.xlsx.load(bytes)
+
+      expect(workbook.worksheets.map((sheet) => sheet.name)).toEqual(expectedNames)
+      const overview = getWorksheet(workbook, "Tổng quan")
+      expect(overview.model.merges).toEqual(expect.arrayContaining(["A1:H2", "A3:H3"]))
+      expect(overview.getCell("A1").value).toBe("KẾT QUẢ SO SÁNH CẤU HÌNH KỸ THUẬT")
+      expect(getPatternFill(overview.getCell("A1")).fgColor).toEqual({ argb: TITLE_FILL })
+      expect(overview.getRow(1).height).toBe(30)
+
+      if (expectedNames.includes("Xếp hạng")) {
+        const ranking = getWorksheet(workbook, "Xếp hạng")
+        expect(ranking.model.merges).toEqual(expect.arrayContaining(["A1:H2", "A3:H3"]))
+        expect(ranking.views[0]).toMatchObject({ state: "frozen", ySplit: 5 })
+        expect(ranking.autoFilter).toBe("A5:H6")
+        expect(getPatternFill(ranking.getCell("A5")).fgColor).toEqual({ argb: HEADER_FILL })
+        expectStandardDataCell(ranking.getCell("C6"))
+      }
+
+      if (expectedNames.includes("Ma trận chi tiết")) {
+        const matrix = getWorksheet(workbook, "Ma trận chi tiết")
+        expect(matrix.model.merges).toEqual(
+          expect.arrayContaining(["A1:G1", "A2:G2", "A3:G3", "A4:D4", "E4:G4"])
+        )
+        expect(matrix.views[0]).toMatchObject({ state: "frozen", xSplit: 4, ySplit: 5 })
+        expect(matrix.autoFilter).toBe("A5:G6")
+        expect(matrix.getColumn(6).width).toBe(40)
+        expectStandardDataCell(matrix.getCell("F6"))
+      }
+
+      const meta = getWorksheet(workbook, "_meta")
+      expect(meta.state).toBe("hidden")
+      expect(
+        meta.getRows(1, 14)?.map((row) => [row.getCell(1).value, row.getCell(2).value])
+      ).toEqual([
+        ["key", "value"],
+        ["template_kind", "technical_configuration_result"],
+        ["template_version", 1],
+        ["dossier_id", input.manifest.dossier.id],
+        ["baseline_version_id", input.manifest.baseline_version.id],
+        ["snapshot_token", "snapshot-v1"],
+        ["ranking_snapshot_token", "ranking-v1"],
+        ["content_mode", mode],
+        ["option_scope", "all"],
+        ["criterion_scope", "all"],
+        ["ordered_option_ids", "[]"],
+        ["ordered_criterion_ids", "[]"],
+        ["generated_at", "2026-08-02T12:34:56.000Z"],
+        ["generated_by", "Nguyen Van A"],
+      ])
+    }
+  )
+})

--- a/src/lib/technical-configuration-result-excel-export.ts
+++ b/src/lib/technical-configuration-result-excel-export.ts
@@ -1,0 +1,333 @@
+import type { Workbook, Worksheet } from "exceljs"
+
+import { createExcelWorkbook } from "@/lib/excel-workbook"
+import {
+  RESULT_WORKBOOK_META_KEYS,
+  type TechnicalConfigurationResultWorkbookModel,
+  type TechnicalConfigurationResultWorkbookSheetModel,
+} from "@/lib/technical-configuration-result-excel-contract"
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+import {
+  RESULT_EXCEL_COLORS,
+  RESULT_EXCEL_RANKING_HEADERS,
+  RESULT_EXCEL_REFERENCE_RANKING_DISCLAIMER,
+  applyResultExcelDataCell,
+  applyResultExcelHeader,
+  configureResultExcelRankingColumns,
+  resultExcelPatternFill,
+  setResultExcelMergedHeading,
+} from "@/lib/technical-configuration-result-excel-styles"
+
+type OverviewSheetModel = Extract<
+  TechnicalConfigurationResultWorkbookSheetModel,
+  { kind: "overview" }
+>
+type RankingSheetModel = Extract<
+  TechnicalConfigurationResultWorkbookSheetModel,
+  { kind: "ranking" }
+>
+type MatrixSheetModel = Extract<TechnicalConfigurationResultWorkbookSheetModel, { kind: "matrix" }>
+type MetaSheetModel = Extract<TechnicalConfigurationResultWorkbookSheetModel, { kind: "meta" }>
+type RankingRow = RankingSheetModel["rows"][number]
+
+const STATUS_FILLS = {
+  not_evaluated: RESULT_EXCEL_COLORS.gray,
+  not_applicable: RESULT_EXCEL_COLORS.gray,
+  fails: RESULT_EXCEL_COLORS.red,
+  unclear: RESULT_EXCEL_COLORS.amber,
+  insufficient_evidence: RESULT_EXCEL_COLORS.amber,
+  exceeds: RESULT_EXCEL_COLORS.green,
+  meets: RESULT_EXCEL_COLORS.green,
+} as const satisfies Record<TechnicalConfigurationDerivedStatus, string>
+
+function formatScope(scope: "all" | "selected", orderedIds: readonly string[]) {
+  return scope === "all" ? "Tất cả" : `Đã chọn (${orderedIds.length})`
+}
+
+function formatRankingNotes(row: RankingRow) {
+  const notes = [
+    ["Không đạt", row.failed_count],
+    ["Thiếu bằng chứng", row.insufficient_evidence_count],
+    ["Vượt yêu cầu", row.exceeds_count],
+  ] as const
+  return notes
+    .filter(([, count]) => count > 0)
+    .map(([label, count]) => `${label}: ${count}`)
+    .join("; ")
+}
+
+function rankingRowValues(row: RankingRow, criterionTotal: number) {
+  return [
+    row.rank ?? "",
+    row.display_label,
+    row.supplier_name,
+    row.model ?? "",
+    row.eligibility === "eligible" ? "Đủ điều kiện" : "Chưa hoàn thiện",
+    criterionTotal - row.incomplete_criterion_count,
+    row.incomplete_criterion_count,
+    formatRankingNotes(row),
+  ]
+}
+
+function styleRankingTable(worksheet: Worksheet, headerRowNumber: number, rowCount: number) {
+  const headerRow = worksheet.getRow(headerRowNumber)
+  headerRow.height = 36
+  headerRow.eachCell((cell) => applyResultExcelHeader(cell))
+
+  for (let index = 0; index < rowCount; index += 1) {
+    const row = worksheet.getRow(headerRowNumber + index + 1)
+    row.height = 36
+    row.eachCell({ includeEmpty: true }, (cell) => applyResultExcelDataCell(cell, index % 2 === 1))
+    row.getCell(5).fill = resultExcelPatternFill(
+      row.getCell(5).value === "Đủ điều kiện"
+        ? RESULT_EXCEL_COLORS.green
+        : RESULT_EXCEL_COLORS.amber
+    )
+  }
+}
+
+function renderOverview(workbook: Workbook, sheet: OverviewSheetModel) {
+  const worksheet = workbook.addWorksheet(sheet.name)
+  worksheet.state = sheet.state
+  setResultExcelMergedHeading(worksheet, "A1:H2", "KẾT QUẢ SO SÁNH CẤU HÌNH KỸ THUẬT", "title")
+  setResultExcelMergedHeading(worksheet, "A3:H3", sheet.summary.dossier.name, "header")
+  worksheet.getRow(1).height = 30
+  worksheet.getRow(3).height = 24
+
+  const summaryRows = [
+    ["Mã hồ sơ", sheet.summary.dossier.id],
+    ["Phiên bản cấu hình cơ sở", sheet.summary.baseline_version.version_number],
+    ["Khóa lúc", sheet.summary.baseline_version.locked_at ?? ""],
+    [
+      "Phạm vi phương án",
+      formatScope(sheet.summary.scope.option_scope, sheet.summary.scope.ordered_option_ids),
+    ],
+    [
+      "Phạm vi tiêu chí",
+      formatScope(sheet.summary.scope.criterion_scope, sheet.summary.scope.ordered_criterion_ids),
+    ],
+    ["Thời điểm xuất", sheet.summary.generated_at],
+    ["Người xuất", sheet.summary.generated_by],
+  ] as const
+  summaryRows.forEach(([label, value], index) => {
+    const rowNumber = index + 5
+    worksheet.getCell(rowNumber, 1).value = label
+    worksheet.getCell(rowNumber, 2).value = value
+    applyResultExcelHeader(worksheet.getCell(rowNumber, 1))
+    applyResultExcelDataCell(worksheet.getCell(rowNumber, 2), false)
+  })
+
+  const totals = [
+    ["Tổng phương án", sheet.summary.option_total],
+    ["Tổng tiêu chí", sheet.summary.criterion_total],
+  ]
+  if (sheet.summary.ranking_summary) {
+    totals.push(
+      ["Đủ điều kiện", sheet.summary.ranking_summary.eligible_total],
+      ["Chưa hoàn thiện", sheet.summary.ranking_summary.incomplete_total]
+    )
+  }
+  totals.forEach(([label, value], index) => {
+    const rowNumber = index + 5
+    worksheet.getCell(rowNumber, 4).value = label
+    worksheet.getCell(rowNumber, 5).value = value
+    applyResultExcelHeader(worksheet.getCell(rowNumber, 4))
+    applyResultExcelDataCell(worksheet.getCell(rowNumber, 5), false)
+  })
+
+  if (sheet.summary.ranking_summary) {
+    setResultExcelMergedHeading(
+      worksheet,
+      "A13:H13",
+      RESULT_EXCEL_REFERENCE_RANKING_DISCLAIMER,
+      "header"
+    )
+    worksheet.getCell("A13").fill = resultExcelPatternFill(RESULT_EXCEL_COLORS.amber)
+    worksheet.getCell("A13").font = { bold: true, color: { argb: "FF7C2D12" } }
+    setResultExcelMergedHeading(worksheet, "A15:H15", "XẾP HẠNG THAM KHẢO - TOP 10", "header")
+    worksheet.addRow([])
+    worksheet.getRow(16).values = [...RESULT_EXCEL_RANKING_HEADERS]
+    sheet.summary.ranking_summary.top_ten.forEach((row) => {
+      worksheet.addRow(rankingRowValues(row, sheet.summary.criterion_total))
+    })
+    styleRankingTable(worksheet, 16, sheet.summary.ranking_summary.top_ten.length)
+    worksheet.autoFilter = {
+      from: "A16",
+      to: `H${Math.max(16, 16 + sheet.summary.ranking_summary.top_ten.length)}`,
+    }
+  }
+
+  configureResultExcelRankingColumns(worksheet)
+  return worksheet
+}
+
+function renderRanking(workbook: Workbook, sheet: RankingSheetModel, overview: OverviewSheetModel) {
+  const worksheet = workbook.addWorksheet(sheet.name)
+  worksheet.state = sheet.state
+  setResultExcelMergedHeading(worksheet, "A1:H2", "XẾP HẠNG PHƯƠNG ÁN", "title")
+  setResultExcelMergedHeading(worksheet, "A3:H3", overview.summary.dossier.name, "header")
+  worksheet.getRow(1).height = 30
+  worksheet.getRow(5).values = [...RESULT_EXCEL_RANKING_HEADERS]
+  sheet.rows.forEach((row) => worksheet.addRow(rankingRowValues(row, sheet.criterion_total)))
+  styleRankingTable(worksheet, 5, sheet.rows.length)
+  configureResultExcelRankingColumns(worksheet)
+  worksheet.autoFilter = { from: "A5", to: `H${Math.max(5, 5 + sheet.rows.length)}` }
+  worksheet.views = [{ state: "frozen", ySplit: 5, topLeftCell: "A6", activeCell: "A6" }]
+  return worksheet
+}
+
+function formatOptionGroup(option: MatrixSheetModel["option_groups"][number]) {
+  return [option.display_label, option.supplier_name, option.model]
+    .filter((value): value is string => Boolean(value))
+    .join(" - ")
+}
+
+function formatSupplementaryCell(row: MatrixSheetModel["rows"][number], optionIndex: number) {
+  const value = row.option_values[optionIndex]
+  const linkLines = value.document_links.map((link) => {
+    const location = link.page_section ? ` (${link.page_section})` : ""
+    return `[${link.citation_id}] ${link.document_name}${location} - ${link.document_url}`
+  })
+  const text = [value.supplementary_information, ...linkLines].filter(Boolean).join("\n")
+  const hyperlink = value.document_links.find((link) => /^https?:\/\//i.test(link.document_url))
+  return hyperlink
+    ? {
+        text,
+        hyperlink: hyperlink.document_url,
+        tooltip: hyperlink.excerpt ?? hyperlink.document_name,
+      }
+    : text
+}
+
+function renderMatrix(workbook: Workbook, sheet: MatrixSheetModel, overview: OverviewSheetModel) {
+  const worksheet = workbook.addWorksheet(sheet.name)
+  worksheet.state = sheet.state
+  const lastColumn = 4 + sheet.option_groups.length * 3
+  const lastColumnLetter = worksheet.getColumn(lastColumn).letter
+  setResultExcelMergedHeading(
+    worksheet,
+    `A1:${lastColumnLetter}1`,
+    "MA TRẬN SO SÁNH CHI TIẾT",
+    "title"
+  )
+  setResultExcelMergedHeading(
+    worksheet,
+    `A2:${lastColumnLetter}2`,
+    overview.summary.dossier.name,
+    "header"
+  )
+  setResultExcelMergedHeading(
+    worksheet,
+    `A3:${lastColumnLetter}3`,
+    `${sheet.option_groups.length} phương án | ${sheet.rows.length} tiêu chí`,
+    "header"
+  )
+  setResultExcelMergedHeading(worksheet, "A4:D4", "TIÊU CHÍ CƠ SỞ", "header")
+
+  const headerValues: string[] = [...sheet.context_columns]
+  sheet.option_groups.forEach((option, index) => {
+    const startColumn = 5 + index * 3
+    const endColumn = startColumn + 2
+    const range = `${worksheet.getColumn(startColumn).letter}4:${worksheet.getColumn(endColumn).letter}4`
+    setResultExcelMergedHeading(worksheet, range, formatOptionGroup(option), "header")
+    headerValues.push(...sheet.option_columns)
+  })
+  worksheet.getRow(5).values = headerValues
+  worksheet.getRow(5).eachCell((cell) => applyResultExcelHeader(cell))
+
+  sheet.rows.forEach((row, rowIndex) => {
+    const values: Array<number | string | { text: string; hyperlink: string; tooltip: string }> = [
+      row.stt,
+      row.group_name,
+      row.criterion_code,
+      row.requirement_text,
+    ]
+    row.option_values.forEach((optionValue, optionIndex) => {
+      values.push(
+        optionValue.response_text ?? "",
+        formatSupplementaryCell(row, optionIndex),
+        TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[optionValue.conclusion]
+      )
+    })
+    const worksheetRow = worksheet.addRow(values)
+    worksheetRow.height = 60
+    worksheetRow.eachCell({ includeEmpty: true }, (cell) =>
+      applyResultExcelDataCell(cell, rowIndex % 2 === 1)
+    )
+    row.option_values.forEach((optionValue, optionIndex) => {
+      worksheetRow.getCell(7 + optionIndex * 3).fill = resultExcelPatternFill(
+        STATUS_FILLS[optionValue.conclusion]
+      )
+    })
+  })
+
+  ;[8, 24, 16, 42].forEach((width, index) => {
+    worksheet.getColumn(index + 1).width = width
+  })
+  sheet.option_groups.forEach((_, index) => {
+    worksheet.getColumn(5 + index * 3).width = 32
+    worksheet.getColumn(6 + index * 3).width = 40
+    worksheet.getColumn(7 + index * 3).width = 22
+  })
+  worksheet.getRow(1).height = 30
+  worksheet.getRow(4).height = 24
+  worksheet.getRow(5).height = 36
+  worksheet.autoFilter = {
+    from: "A5",
+    to: `${lastColumnLetter}${Math.max(5, 5 + sheet.rows.length)}`,
+  }
+  worksheet.views = [{ state: "frozen", xSplit: 4, ySplit: 5, topLeftCell: "E6", activeCell: "E6" }]
+  return worksheet
+}
+
+function renderMeta(workbook: Workbook, sheet: MetaSheetModel) {
+  const worksheet = workbook.addWorksheet(sheet.name)
+  worksheet.state = sheet.state
+  worksheet.addRow(["key", "value"])
+  RESULT_WORKBOOK_META_KEYS.forEach((key) => {
+    const value = sheet.metadata[key]
+    worksheet.addRow([key, Array.isArray(value) ? JSON.stringify(value) : value])
+  })
+  worksheet.getColumn(1).width = 28
+  worksheet.getColumn(2).width = 64
+}
+
+/** Renders an output-only P14B1F workbook model without mounting download behavior. */
+export async function createTechnicalConfigurationResultWorkbook(
+  model: TechnicalConfigurationResultWorkbookModel
+): Promise<Workbook> {
+  const workbook = await createExcelWorkbook()
+  const overview = model.sheets.find(
+    (sheet): sheet is OverviewSheetModel => sheet.kind === "overview"
+  )
+  if (!overview) throw new Error("Technical configuration result workbook is missing overview.")
+
+  model.sheets.forEach((sheet) => {
+    switch (sheet.kind) {
+      case "overview":
+        renderOverview(workbook, sheet)
+        break
+      case "ranking":
+        renderRanking(workbook, sheet, overview)
+        break
+      case "matrix":
+        renderMatrix(workbook, sheet, overview)
+        break
+      case "meta":
+        renderMeta(workbook, sheet)
+        break
+    }
+  })
+  return workbook
+}
+
+/** Serializes the rendered workbook lazily without creating a Blob or triggering download. */
+export async function serializeTechnicalConfigurationResultWorkbook(
+  model: TechnicalConfigurationResultWorkbookModel
+) {
+  const workbook = await createTechnicalConfigurationResultWorkbook(model)
+  return workbook.xlsx.writeBuffer()
+}

--- a/src/lib/technical-configuration-result-excel-styles.ts
+++ b/src/lib/technical-configuration-result-excel-styles.ts
@@ -1,0 +1,87 @@
+import type { Cell, FillPattern, Worksheet } from "exceljs"
+
+/** Approved P14B2 workbook colors expressed as ExcelJS ARGB values. */
+export const RESULT_EXCEL_COLORS = {
+  title: "FF166534",
+  header: "FF2E7D32",
+  border: "FFD1D5DB",
+  zebra: "FFF3F4F6",
+  amber: "FFFFF3CD",
+  green: "FFD1FAE5",
+  red: "FFFEE2E2",
+  gray: "FFF3F4F6",
+} as const
+
+/** Ordered column labels shared by overview and ranking tables. */
+export const RESULT_EXCEL_RANKING_HEADERS = [
+  "Hạng",
+  "Mã PA",
+  "Nhà cung cấp",
+  "Model",
+  "Trạng thái",
+  "Đã hoàn thiện",
+  "Chưa hoàn thiện",
+  "Ghi chú",
+] as const
+
+/** Required disclaimer for reference-only ranking surfaces. */
+export const RESULT_EXCEL_REFERENCE_RANKING_DISCLAIMER =
+  "Xếp hạng chỉ mang tính tham khảo theo dữ liệu đánh giá hiện có, không phải quyết định lựa chọn nhà cung cấp."
+
+/** Creates the solid pattern fill used by P14B2 workbook cells. */
+export function resultExcelPatternFill(color: string): FillPattern {
+  return {
+    type: "pattern",
+    pattern: "solid",
+    fgColor: { argb: color },
+  }
+}
+
+/** Applies the standard thin gray border to every cell edge. */
+export function applyResultExcelThinGrayBorder(cell: Cell) {
+  const edge = { style: "thin" as const, color: { argb: RESULT_EXCEL_COLORS.border } }
+  cell.border = { top: edge, left: edge, bottom: edge, right: edge }
+}
+
+/** Applies the approved header fill, font, alignment and border. */
+export function applyResultExcelHeader(cell: Cell) {
+  cell.fill = resultExcelPatternFill(RESULT_EXCEL_COLORS.header)
+  cell.font = { bold: true, color: { argb: "FFFFFFFF" } }
+  cell.alignment = { horizontal: "center", vertical: "middle", wrapText: true }
+  applyResultExcelThinGrayBorder(cell)
+}
+
+/** Applies standard data-cell presentation with optional zebra fill. */
+export function applyResultExcelDataCell(cell: Cell, zebra: boolean) {
+  cell.fill = resultExcelPatternFill(zebra ? RESULT_EXCEL_COLORS.zebra : "FFFFFFFF")
+  cell.alignment = { vertical: "top", wrapText: true }
+  applyResultExcelThinGrayBorder(cell)
+}
+
+/** Merges a range and applies the approved title or header presentation. */
+export function setResultExcelMergedHeading(
+  worksheet: Worksheet,
+  range: string,
+  value: string,
+  style: "title" | "header"
+) {
+  worksheet.mergeCells(range)
+  const cell = worksheet.getCell(range.split(":")[0])
+  cell.value = value
+
+  if (style === "header") {
+    applyResultExcelHeader(cell)
+    return
+  }
+
+  cell.fill = resultExcelPatternFill(RESULT_EXCEL_COLORS.title)
+  cell.font = { bold: true, color: { argb: "FFFFFFFF" }, size: 16 }
+  cell.alignment = { horizontal: "center", vertical: "middle", wrapText: true }
+}
+
+/** Configures the fixed widths for ranking table columns. */
+export function configureResultExcelRankingColumns(worksheet: Worksheet) {
+  ;[10, 20, 28, 20, 18, 16, 18, 32].forEach((width, index) => {
+    worksheet.getColumn(index + 1).width = width
+  })
+}


### PR DESCRIPTION
## Summary
- add the renderer-only P14B2 ExcelJS workbook API over the output-only P14B1F model
- render full, ranking-only, detailed-matrix, hidden metadata, and XFD continuation sheets with locked values and presentation
- preserve every ordered citation URL while making the first HTTP(S) URL clickable, without truncation or extra sheets/columns
- update the OpenSpec contract, implementation plan, tasks, and TDD evidence

## Verification
- `format:check`, `verify:no-explicit-any`, `verify:dedupe`, `verify:ts-docstrings`, and `typecheck`
- focused renderer tests: 6 passed
- P14/shared Excel regressions: 160 passed, 4 skipped across 15 files
- React Doctor changed scope: 100/100, no findings across 4 files
- strict OpenSpec validation passed
- `mix-gpt-5.6` xhigh final review: zero findings

## Scope
Renderer only. No UI, caller, Blob/download, orchestration, database, parser/import/apply, chart, gradient, score, percentage, award decision, truncation, or P14C1+ work.

Closes #843

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a renderer-only Excel workbook for technical configuration results that implements the approved P14B2 contract using the P14B1F model. Builds overview/ranking/detailed matrix, hidden `_meta`, and XFD continuation sheets with locked presentation and preserved citation URLs; aligns with #843.

- **New Features**
  - New APIs: `createTechnicalConfigurationResultWorkbook` and `serializeTechnicalConfigurationResultWorkbook`.
  - Renders overview, ranking, detailed matrix, hidden `_meta`, and continuation sheets with frozen panes, filters, zebra rows, thin borders, and approved colors.
  - Preserves all citation labels/URLs in a single cell; first HTTP(S) URL is clickable; no extra columns/sheets and no truncation.
  - Supports the 16,384-column boundary (XFD) with correct merges, widths, heights, and status fills.
  - Enforces renderer-only scope: no UI, Blob/download, orchestration, database, charts, gradients, scores, percentages, or award decisions.

<sup>Written for commit 3e88d2b396bb3159531ec3509a21b11a3bf0893f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Excel export for technical configuration results, including overview, rankings, comparison matrix, and metadata sheets.
  * Included localized labels, filters, frozen panes, status formatting, hyperlinks, and workbook metadata.
  * Preserved all document URLs and citation labels, making only the first URL clickable.
  * Added support for large comparison matrices spanning Excel’s column limit.

* **Bug Fixes**
  * Ensured exported workbooks retain formatting, hidden metadata, merged cells, and continuation-sheet content after reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->