### PR TITLE
[P14C1] Export scope dialog and state machine

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
@@ -1,0 +1,413 @@
+import "@testing-library/jest-dom"
+import * as React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationResultExportDialog } from "@/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog"
+import {
+  createTechnicalConfigurationResultExportState,
+  getTechnicalConfigurationResultExportValidationError,
+  transitionTechnicalConfigurationResultExport,
+  type TechnicalConfigurationResultExportContext,
+} from "@/app/(app)/technical-configurations/technical-configuration-result-export-state"
+
+function createContext(
+  overrides: Partial<TechnicalConfigurationResultExportContext> = {}
+): TechnicalConfigurationResultExportContext {
+  return {
+    dossierId: "dossier-1",
+    baselineVersionId: "baseline-1",
+    options: {
+      total: 126,
+      page: {
+        currentIds: ["option-1", "option-2", "option-3"],
+        selectedIds: ["option-2", "option-3"],
+      },
+    },
+    criteria: {
+      total: 102,
+      page: {
+        currentIds: ["criterion-1", "criterion-2"],
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe("technical configuration result export state", () => {
+  it("opens every dialog session with the complete universe selected", () => {
+    const initial = createTechnicalConfigurationResultExportState(createContext())
+
+    const result = transitionTechnicalConfigurationResultExport(initial, { type: "open" })
+
+    expect(result.request).toBeNull()
+    expect(result.state).toMatchObject({
+      open: true,
+      mode: "full",
+      optionScope: "all",
+      criterionScope: "all",
+    })
+  })
+
+  it("does not emit a request when confirm is sent to a closed state", () => {
+    const initial = createTechnicalConfigurationResultExportState(createContext())
+
+    const result = transitionTechnicalConfigurationResultExport(initial, { type: "confirm" })
+
+    expect(result.request).toBeNull()
+    expect(result.state).toBe(initial)
+  })
+
+  it("resets changed content and scope choices without closing the dialog", () => {
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(createContext()),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "mode_changed",
+      mode: "ranking_only",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "selected",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "criterion_scope_changed",
+      scope: "current_page",
+    }).state
+
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "reset" })
+
+    expect(result.state).toMatchObject({
+      open: true,
+      mode: "full",
+      optionScope: "all",
+      criterionScope: "all",
+    })
+  })
+
+  it("emits one validated request and closes after confirmation", () => {
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(createContext()),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "mode_changed",
+      mode: "detailed_matrix_only",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "selected",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "criterion_scope_changed",
+      scope: "current_page",
+    }).state
+
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "confirm" })
+
+    expect(result.request).toEqual({
+      mode: "detailed_matrix_only",
+      dossierId: "dossier-1",
+      baselineVersionId: "baseline-1",
+      optionIds: ["option-2", "option-3"],
+      criterionIds: ["criterion-1", "criterion-2"],
+    })
+    expect(result.state).toMatchObject({
+      open: false,
+      mode: "full",
+      optionScope: "all",
+      criterionScope: "all",
+    })
+  })
+
+  it("rejects confirmation when an explicit selected scope is empty", () => {
+    const context = createContext({
+      options: {
+        total: 126,
+        page: {
+          currentIds: ["option-1"],
+          selectedIds: [],
+        },
+      },
+    })
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(context),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "selected",
+    }).state
+
+    expect(getTechnicalConfigurationResultExportValidationError(state)).toBe(
+      "empty_selected_options"
+    )
+
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "confirm" })
+    expect(result.request).toBeNull()
+    expect(result.state.open).toBe(true)
+  })
+
+  it("resets content and scope when dossier or baseline identity changes", () => {
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(createContext()),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "mode_changed",
+      mode: "ranking_only",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "current_page",
+    }).state
+
+    const result = transitionTechnicalConfigurationResultExport(state, {
+      type: "context_changed",
+      context: createContext({
+        dossierId: "dossier-2",
+        baselineVersionId: "baseline-2",
+      }),
+    })
+
+    expect(result.state).toMatchObject({
+      open: true,
+      mode: "full",
+      optionScope: "all",
+      criterionScope: "all",
+      context: {
+        dossierId: "dossier-2",
+        baselineVersionId: "baseline-2",
+      },
+    })
+  })
+
+  it("cancels without a request and resets the next session", () => {
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(createContext()),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "mode_changed",
+      mode: "ranking_only",
+    }).state
+
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "cancel" })
+
+    expect(result.request).toBeNull()
+    expect(result.state).toMatchObject({
+      open: false,
+      mode: "full",
+      optionScope: "all",
+      criterionScope: "all",
+    })
+  })
+})
+
+function DialogHarness({
+  context,
+  onConfirm,
+}: Readonly<{
+  context: TechnicalConfigurationResultExportContext
+  onConfirm: React.ComponentProps<typeof TechnicalConfigurationResultExportDialog>["onConfirm"]
+}>) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Mở xuất kết quả
+      </button>
+      <TechnicalConfigurationResultExportDialog
+        open={open}
+        context={context}
+        onOpenChange={setOpen}
+        onConfirm={onConfirm}
+      />
+    </>
+  )
+}
+
+describe("TechnicalConfigurationResultExportDialog", () => {
+  it("renders the approved choices, defaults to all scope and focuses the first mode", async () => {
+    const user = userEvent.setup()
+    render(<DialogHarness context={createContext()} onConfirm={vi.fn()} />)
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+
+    expect(screen.getByRole("dialog", { name: "Xuất kết quả Excel" })).toBeInTheDocument()
+    const fullMode = screen.getByRole("radio", { name: /Đầy đủ/ })
+    expect(fullMode).toBeChecked()
+    expect(screen.getByRole("radio", { name: "Tất cả 126 phương án" })).toBeChecked()
+    expect(screen.getByRole("radio", { name: "Tất cả 102 tiêu chí" })).toBeChecked()
+    expect(screen.getByText("3 sheet hiển thị")).toBeInTheDocument()
+    expect(fullMode).toHaveAccessibleDescription(/Tổng quan.*Khuyên dùng/)
+    await waitFor(() => expect(fullMode).toHaveFocus())
+  })
+
+  it("confirms deliberate paginated scopes as one request object", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    render(<DialogHarness context={createContext()} onConfirm={onConfirm} />)
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+    await user.click(screen.getByRole("radio", { name: /Chỉ ma trận chi tiết/ }))
+    await user.click(screen.getByRole("radio", { name: "2 phương án đã chọn" }))
+    await user.click(screen.getByRole("radio", { name: "Trang tiêu chí hiện tại · 2 tiêu chí" }))
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm).toHaveBeenCalledWith({
+      mode: "detailed_matrix_only",
+      dossierId: "dossier-1",
+      baselineVersionId: "baseline-1",
+      optionIds: ["option-2", "option-3"],
+      criterionIds: ["criterion-1", "criterion-2"],
+    })
+  })
+
+  it("shows current and selected alternatives only for paginated surfaces", async () => {
+    const user = userEvent.setup()
+    render(
+      <DialogHarness
+        context={createContext({
+          options: { total: 126 },
+          criteria: { total: 102 },
+        })}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+
+    expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("radio", { name: /đã chọn/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("radio", { name: /Trang tiêu chí hiện tại/ })).not.toBeInTheDocument()
+  })
+
+  it("disables confirmation and announces an empty selected scope", async () => {
+    const user = userEvent.setup()
+    render(
+      <DialogHarness
+        context={createContext({
+          options: {
+            total: 126,
+            page: {
+              currentIds: ["option-1"],
+              selectedIds: [],
+            },
+          },
+        })}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+    await user.click(screen.getByRole("radio", { name: "0 phương án đã chọn" }))
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Chưa có phương án nào được chọn.")
+    expect(screen.getByRole("button", { name: "Xuất file .xlsx" })).toBeDisabled()
+  })
+
+  it("tracks same-identity scope updates before confirmation", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const { rerender } = render(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext()}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.click(screen.getByRole("radio", { name: "2 phương án đã chọn" }))
+
+    rerender(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext({
+          options: {
+            total: 127,
+            page: {
+              currentIds: ["option-1", "option-4"],
+              selectedIds: ["option-4"],
+            },
+          },
+        })}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.getByRole("radio", { name: "1 phương án đã chọn" })).toBeChecked()
+    expect(screen.getByText(/Sẽ xuất: 1 phương án x 102 tiêu chí/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+    expect(onConfirm).toHaveBeenCalledWith({
+      mode: "full",
+      dossierId: "dossier-1",
+      baselineVersionId: "baseline-1",
+      optionIds: ["option-4"],
+      criterionIds: null,
+    })
+  })
+
+  it("resets choices and restores focus across cancellation paths", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    render(<DialogHarness context={createContext()} onConfirm={onConfirm} />)
+
+    const opener = screen.getByRole("button", { name: "Mở xuất kết quả" })
+    await user.click(opener)
+    await user.click(screen.getByRole("radio", { name: /Chỉ xếp hạng/ }))
+    await user.click(screen.getByRole("radio", { name: "3 phương án đang hiển thị" }))
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+    await waitFor(() => expect(opener).toHaveFocus())
+
+    await user.click(opener)
+    expect(screen.getByRole("radio", { name: /Đầy đủ/ })).toBeChecked()
+    expect(screen.getByRole("radio", { name: "Tất cả 126 phương án" })).toBeChecked()
+
+    await user.click(screen.getByRole("radio", { name: /Chỉ xếp hạng/ }))
+    await user.click(screen.getByRole("button", { name: "Đóng" }))
+    await waitFor(() => expect(opener).toHaveFocus())
+
+    await user.click(opener)
+    expect(screen.getByRole("radio", { name: /Đầy đủ/ })).toBeChecked()
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it("resets the mounted dialog when dossier and baseline identity change", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const { rerender } = render(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext()}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.click(screen.getByRole("radio", { name: /Chỉ xếp hạng/ }))
+    await user.click(screen.getByRole("radio", { name: "2 phương án đã chọn" }))
+
+    rerender(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext({
+          dossierId: "dossier-2",
+          baselineVersionId: "baseline-2",
+        })}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.getByRole("radio", { name: /Đầy đủ/ })).toBeChecked()
+    expect(screen.getByRole("radio", { name: "Tất cả 126 phương án" })).toBeChecked()
+  })
+})

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
@@ -1,0 +1,335 @@
+"use client"
+
+import * as React from "react"
+import { AlertTriangle, Clock3, Download, RotateCcw, TableProperties } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  createTechnicalConfigurationResultExportState,
+  getTechnicalConfigurationResultExportSelectionSummary,
+  getTechnicalConfigurationResultExportValidationError,
+  transitionTechnicalConfigurationResultExport,
+  type TechnicalConfigurationResultExportContext,
+  type TechnicalConfigurationResultExportCriterionScope,
+  type TechnicalConfigurationResultExportDialogRequest,
+  type TechnicalConfigurationResultExportOptionScope,
+  type TechnicalConfigurationResultExportState,
+  type TechnicalConfigurationResultExportValidationError,
+} from "../../technical-configuration-result-export-state"
+import type { TechnicalConfigurationResultExportMode } from "../../technical-configuration-result-export-types"
+import { TechnicalConfigurationResultExportDialogChoice } from "./TechnicalConfigurationResultExportDialogChoice"
+
+/** Controlled P14C1 dialog props. The parent owns visibility and receives one request intent. */
+export type TechnicalConfigurationResultExportDialogProps = Readonly<{
+  open: boolean
+  context: TechnicalConfigurationResultExportContext
+  onOpenChange: (open: boolean) => void
+  onConfirm: (request: TechnicalConfigurationResultExportDialogRequest) => void
+}>
+
+const VALIDATION_MESSAGES: Record<TechnicalConfigurationResultExportValidationError, string> = {
+  missing_identity: "Không thể xác định hồ sơ hoặc phiên bản cơ sở để xuất.",
+  invalid_totals: "Tổng số phương án hoặc tiêu chí không hợp lệ.",
+  unavailable_option_scope: "Phạm vi phương án này không còn khả dụng.",
+  empty_current_option_page: "Trang hiện tại không có phương án để xuất.",
+  empty_selected_options: "Chưa có phương án nào được chọn.",
+  unavailable_criterion_scope: "Phạm vi tiêu chí này không còn khả dụng.",
+  empty_current_criterion_page: "Trang hiện tại không có tiêu chí để xuất.",
+}
+
+const RESULT_EXPORT_MODES = [
+  "full",
+  "ranking_only",
+  "detailed_matrix_only",
+] as const satisfies readonly TechnicalConfigurationResultExportMode[]
+
+function modeTitle(mode: TechnicalConfigurationResultExportMode): string {
+  if (mode === "ranking_only") return "Chỉ xếp hạng"
+  if (mode === "detailed_matrix_only") return "Chỉ ma trận chi tiết"
+  return "Đầy đủ"
+}
+
+function modeDescription(mode: TechnicalConfigurationResultExportMode): string {
+  if (mode === "ranking_only") return "Danh sách thứ hạng và trạng thái hoàn thiện"
+  if (mode === "detailed_matrix_only") {
+    return "Yêu cầu cơ sở, phản hồi và kết luận đánh giá"
+  }
+  return "Tổng quan, xếp hạng và ma trận chi tiết"
+}
+
+function ResultExportDialogContent({
+  context,
+  onOpenChange,
+  onConfirm,
+  returnFocusRef,
+}: Readonly<{
+  context: TechnicalConfigurationResultExportContext
+  onOpenChange: (open: boolean) => void
+  onConfirm: (request: TechnicalConfigurationResultExportDialogRequest) => void
+  returnFocusRef: React.MutableRefObject<HTMLElement | null>
+}>) {
+  const baseId = React.useId()
+  const firstModeRef = React.useRef<HTMLInputElement>(null)
+  const [storedState, setStoredState] = React.useState<TechnicalConfigurationResultExportState>(
+    () => {
+      const initial = createTechnicalConfigurationResultExportState(context)
+      return transitionTechnicalConfigurationResultExport(initial, { type: "open" }).state
+    }
+  )
+  const state = transitionTechnicalConfigurationResultExport(storedState, {
+    type: "context_changed",
+    context,
+  }).state
+  const validationError = getTechnicalConfigurationResultExportValidationError(state)
+  const summary = getTechnicalConfigurationResultExportSelectionSummary(state)
+
+  function synchronizeContext(current: TechnicalConfigurationResultExportState) {
+    return transitionTechnicalConfigurationResultExport(current, {
+      type: "context_changed",
+      context,
+    }).state
+  }
+
+  function applyEvent(
+    event:
+      | Readonly<{ type: "reset" }>
+      | Readonly<{ type: "mode_changed"; mode: TechnicalConfigurationResultExportMode }>
+      | Readonly<{
+          type: "option_scope_changed"
+          scope: TechnicalConfigurationResultExportOptionScope
+        }>
+      | Readonly<{
+          type: "criterion_scope_changed"
+          scope: TechnicalConfigurationResultExportCriterionScope
+        }>
+  ) {
+    setStoredState(
+      (current) =>
+        transitionTechnicalConfigurationResultExport(synchronizeContext(current), event).state
+    )
+  }
+
+  function handleCancel() {
+    setStoredState(
+      (current) =>
+        transitionTechnicalConfigurationResultExport(synchronizeContext(current), {
+          type: "cancel",
+        }).state
+    )
+    onOpenChange(false)
+  }
+
+  function handleConfirm() {
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "confirm" })
+    if (!result.request) return
+    setStoredState(result.state)
+    onConfirm(result.request)
+    onOpenChange(false)
+  }
+
+  const optionPage = state.context.options.page
+  const criterionPage = state.context.criteria.page
+
+  return (
+    <DialogContent
+      className="max-h-[92vh] overflow-y-auto p-0 sm:max-w-2xl"
+      closeLabel="Đóng"
+      onOpenAutoFocus={(event) => {
+        const activeElement = document.activeElement
+        if (activeElement instanceof HTMLElement && activeElement !== document.body) {
+          returnFocusRef.current = activeElement
+        }
+        event.preventDefault()
+        firstModeRef.current?.focus()
+      }}
+      onCloseAutoFocus={(event) => {
+        const returnTarget = returnFocusRef.current
+        if (!returnTarget?.isConnected) return
+        event.preventDefault()
+        returnTarget.focus()
+        returnFocusRef.current = null
+      }}
+    >
+      <DialogHeader className="border-b px-6 py-5 pr-12 text-left">
+        <DialogTitle className="flex items-center gap-2 text-lg">
+          <Download className="size-5 text-emerald-700" aria-hidden="true" />
+          Xuất kết quả Excel
+        </DialogTitle>
+        <DialogDescription>
+          Chọn nội dung và phạm vi dữ liệu sẽ được đưa vào workbook.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-5 px-6 py-1">
+        <fieldset className="space-y-2">
+          <legend className="mb-2 text-sm font-semibold">Nội dung workbook</legend>
+          <div className="overflow-hidden border">
+            {RESULT_EXPORT_MODES.map((mode, index) => (
+              <TechnicalConfigurationResultExportDialogChoice
+                key={mode}
+                id={`${baseId}-mode-${mode}`}
+                name={`${baseId}-mode`}
+                value={mode}
+                checked={state.mode === mode}
+                title={modeTitle(mode)}
+                description={modeDescription(mode)}
+                recommended={mode === "full"}
+                inputRef={index === 0 ? firstModeRef : undefined}
+                onChange={() => applyEvent({ type: "mode_changed", mode })}
+              />
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="mb-2 text-sm font-semibold">Phạm vi phương án</legend>
+          <div className="overflow-hidden border">
+            <TechnicalConfigurationResultExportDialogChoice
+              id={`${baseId}-options-all`}
+              name={`${baseId}-options`}
+              value="all"
+              checked={state.optionScope === "all"}
+              title={`Tất cả ${state.context.options.total} phương án`}
+              onChange={() => applyEvent({ type: "option_scope_changed", scope: "all" })}
+            />
+            {optionPage ? (
+              <>
+                <TechnicalConfigurationResultExportDialogChoice
+                  id={`${baseId}-options-current`}
+                  name={`${baseId}-options`}
+                  value="current_page"
+                  checked={state.optionScope === "current_page"}
+                  title={`${optionPage.currentIds.length} phương án đang hiển thị`}
+                  onChange={() =>
+                    applyEvent({ type: "option_scope_changed", scope: "current_page" })
+                  }
+                />
+                <TechnicalConfigurationResultExportDialogChoice
+                  id={`${baseId}-options-selected`}
+                  name={`${baseId}-options`}
+                  value="selected"
+                  checked={state.optionScope === "selected"}
+                  title={`${optionPage.selectedIds.length} phương án đã chọn`}
+                  onChange={() => applyEvent({ type: "option_scope_changed", scope: "selected" })}
+                />
+              </>
+            ) : null}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="mb-2 text-sm font-semibold">Phạm vi tiêu chí</legend>
+          <div className="overflow-hidden border">
+            <TechnicalConfigurationResultExportDialogChoice
+              id={`${baseId}-criteria-all`}
+              name={`${baseId}-criteria`}
+              value="all"
+              checked={state.criterionScope === "all"}
+              title={`Tất cả ${state.context.criteria.total} tiêu chí`}
+              onChange={() => applyEvent({ type: "criterion_scope_changed", scope: "all" })}
+            />
+            {criterionPage ? (
+              <TechnicalConfigurationResultExportDialogChoice
+                id={`${baseId}-criteria-current`}
+                name={`${baseId}-criteria`}
+                value="current_page"
+                checked={state.criterionScope === "current_page"}
+                title={`Trang tiêu chí hiện tại · ${criterionPage.currentIds.length} tiêu chí`}
+                onChange={() =>
+                  applyEvent({ type: "criterion_scope_changed", scope: "current_page" })
+                }
+              />
+            ) : null}
+          </div>
+        </fieldset>
+
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 border-y bg-muted/30 px-3 py-3 text-sm"
+          aria-label="Tóm tắt phạm vi xuất"
+        >
+          <TableProperties className="size-4 text-emerald-700" aria-hidden="true" />
+          <span>
+            Sẽ xuất: {summary.optionCount} phương án x {summary.criterionCount} tiêu chí
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>{summary.visibleSheetCount} sheet hiển thị</span>
+        </div>
+
+        {validationError ? (
+          <div
+            role="alert"
+            className="flex items-start gap-2 border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+          >
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <span>{VALIDATION_MESSAGES[validationError]}</span>
+          </div>
+        ) : null}
+
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>Dữ liệu được tải lại theo cùng một snapshot trước khi tạo file.</p>
+          {state.mode !== "detailed_matrix_only" ? (
+            <p className="flex items-start gap-2 text-amber-800">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+              <span>
+                Xếp hạng chỉ mang tính tham khảo, không phải quyết định lựa chọn nhà cung cấp.
+              </span>
+            </p>
+          ) : null}
+          <p className="flex items-center gap-2">
+            <Clock3 className="size-4 shrink-0" aria-hidden="true" />
+            Có thể mất vài giây với phạm vi lớn.
+          </p>
+        </div>
+      </div>
+
+      <DialogFooter className="border-t px-6 py-4 sm:justify-between">
+        <Button type="button" variant="ghost" onClick={() => applyEvent({ type: "reset" })}>
+          <RotateCcw className="mr-2 size-4" aria-hidden="true" />
+          Đặt lại
+        </Button>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row">
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            Hủy
+          </Button>
+          <Button type="button" onClick={handleConfirm} disabled={validationError !== null}>
+            <Download className="mr-2 size-4" aria-hidden="true" />
+            Xuất file .xlsx
+          </Button>
+        </div>
+      </DialogFooter>
+    </DialogContent>
+  )
+}
+
+/** Renders the isolated P14C1 result-export dialog without mounting any export side effect. */
+export function TechnicalConfigurationResultExportDialog({
+  open,
+  context,
+  onOpenChange,
+  onConfirm,
+}: TechnicalConfigurationResultExportDialogProps) {
+  const returnFocusRef = React.useRef<HTMLElement | null>(null)
+  const identityKey = JSON.stringify([context.dossierId, context.baselineVersionId])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <ResultExportDialogContent
+          key={identityKey}
+          context={context}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+          returnFocusRef={returnFocusRef}
+        />
+      ) : null}
+    </Dialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
@@ -23,8 +23,8 @@ import {
   type TechnicalConfigurationResultExportOptionScope,
   type TechnicalConfigurationResultExportState,
   type TechnicalConfigurationResultExportValidationError,
-} from "../../technical-configuration-result-export-state"
-import type { TechnicalConfigurationResultExportMode } from "../../technical-configuration-result-export-types"
+} from "@/app/(app)/technical-configurations/technical-configuration-result-export-state"
+import type { TechnicalConfigurationResultExportMode } from "@/app/(app)/technical-configurations/technical-configuration-result-export-types"
 import { TechnicalConfigurationResultExportDialogChoice } from "./TechnicalConfigurationResultExportDialogChoice"
 
 /** Controlled P14C1 dialog props. The parent owns visibility and receives one request intent. */
@@ -74,7 +74,7 @@ function ResultExportDialogContent({
   context: TechnicalConfigurationResultExportContext
   onOpenChange: (open: boolean) => void
   onConfirm: (request: TechnicalConfigurationResultExportDialogRequest) => void
-  returnFocusRef: React.MutableRefObject<HTMLElement | null>
+  returnFocusRef: React.RefObject<HTMLElement | null>
 }>) {
   const baseId = React.useId()
   const firstModeRef = React.useRef<HTMLInputElement>(null)

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialogChoice.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialogChoice.tsx
@@ -1,0 +1,72 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+/** Renders one accessible native-radio row without adding a shared UI dependency. */
+export function TechnicalConfigurationResultExportDialogChoice({
+  id,
+  name,
+  value,
+  checked,
+  title,
+  description,
+  recommended = false,
+  inputRef,
+  onChange,
+}: Readonly<{
+  id: string
+  name: string
+  value: string
+  checked: boolean
+  title: string
+  description?: string
+  recommended?: boolean
+  inputRef?: React.Ref<HTMLInputElement>
+  onChange: () => void
+}>) {
+  const titleId = `${id}-title`
+  const descriptionId = description ? `${id}-description` : null
+  const recommendedId = recommended ? `${id}-recommended` : null
+  const describedBy = [descriptionId, recommendedId].filter(Boolean).join(" ") || undefined
+
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "flex cursor-pointer items-start gap-3 border px-3 py-3 transition-colors",
+        checked ? "border-emerald-700 bg-emerald-50/60" : "border-border hover:bg-muted/40"
+      )}
+    >
+      <input
+        ref={inputRef}
+        id={id}
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        aria-labelledby={titleId}
+        aria-describedby={describedBy}
+        onChange={onChange}
+        className="mt-0.5 size-4 shrink-0 accent-emerald-700"
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm font-medium">
+          <span id={titleId}>{title}</span>
+          {recommended ? (
+            <span id={recommendedId ?? undefined} className="text-xs font-medium text-emerald-700">
+              Khuyên dùng
+            </span>
+          ) : null}
+        </span>
+        {description ? (
+          <span
+            id={descriptionId ?? undefined}
+            className="mt-1 block text-sm text-muted-foreground"
+          >
+            {description}
+          </span>
+        ) : null}
+      </span>
+    </label>
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
@@ -1,0 +1,258 @@
+import type {
+  TechnicalConfigurationResultExportMode,
+  TechnicalConfigurationResultExportRequest,
+} from "./technical-configuration-result-export-types"
+
+/** UI-owned export request before P14C2 adds orchestration concerns such as AbortSignal. */
+export type TechnicalConfigurationResultExportDialogRequest = Omit<
+  TechnicalConfigurationResultExportRequest,
+  "signal"
+>
+
+/** Option scopes exposed by the result-export dialog. */
+export type TechnicalConfigurationResultExportOptionScope = "all" | "current_page" | "selected"
+
+/** Criterion scopes exposed by the result-export dialog. */
+export type TechnicalConfigurationResultExportCriterionScope = "all" | "current_page"
+
+type TechnicalConfigurationResultExportOptionContext = Readonly<{
+  total: number
+  page?: Readonly<{
+    currentIds: readonly string[]
+    selectedIds: readonly string[]
+  }>
+}>
+
+type TechnicalConfigurationResultExportCriterionContext = Readonly<{
+  total: number
+  page?: Readonly<{
+    currentIds: readonly string[]
+  }>
+}>
+
+/** Immutable source identity and explicit paginated alternatives available to the dialog. */
+export type TechnicalConfigurationResultExportContext = Readonly<{
+  dossierId: string
+  baselineVersionId: string
+  options: TechnicalConfigurationResultExportOptionContext
+  criteria: TechnicalConfigurationResultExportCriterionContext
+}>
+
+/** Pure P14C1 dialog state. */
+export type TechnicalConfigurationResultExportState = Readonly<{
+  open: boolean
+  context: TechnicalConfigurationResultExportContext
+  mode: TechnicalConfigurationResultExportMode
+  optionScope: TechnicalConfigurationResultExportOptionScope
+  criterionScope: TechnicalConfigurationResultExportCriterionScope
+}>
+
+/** Validation failures that prevent a result-export request from being emitted. */
+export type TechnicalConfigurationResultExportValidationError =
+  | "missing_identity"
+  | "invalid_totals"
+  | "unavailable_option_scope"
+  | "empty_current_option_page"
+  | "empty_selected_options"
+  | "unavailable_criterion_scope"
+  | "empty_current_criterion_page"
+
+/** Events accepted by the pure P14C1 state machine. */
+export type TechnicalConfigurationResultExportEvent =
+  | Readonly<{ type: "open" }>
+  | Readonly<{ type: "reset" }>
+  | Readonly<{ type: "cancel" }>
+  | Readonly<{ type: "confirm" }>
+  | Readonly<{
+      type: "mode_changed"
+      mode: TechnicalConfigurationResultExportMode
+    }>
+  | Readonly<{
+      type: "option_scope_changed"
+      scope: TechnicalConfigurationResultExportOptionScope
+    }>
+  | Readonly<{
+      type: "criterion_scope_changed"
+      scope: TechnicalConfigurationResultExportCriterionScope
+    }>
+  | Readonly<{
+      type: "context_changed"
+      context: TechnicalConfigurationResultExportContext
+    }>
+
+/** Pure transition result with an optional validated request effect. */
+export type TechnicalConfigurationResultExportTransition = Readonly<{
+  state: TechnicalConfigurationResultExportState
+  request: TechnicalConfigurationResultExportDialogRequest | null
+}>
+
+/** Counts rendered in the dialog summary for the current state. */
+export type TechnicalConfigurationResultExportSelectionSummary = Readonly<{
+  optionCount: number
+  criterionCount: number
+  visibleSheetCount: number
+}>
+
+function defaultState(
+  context: TechnicalConfigurationResultExportContext,
+  open: boolean
+): TechnicalConfigurationResultExportState {
+  return {
+    open,
+    context,
+    mode: "full",
+    optionScope: "all",
+    criterionScope: "all",
+  }
+}
+
+function sameIdentity(
+  current: TechnicalConfigurationResultExportContext,
+  next: TechnicalConfigurationResultExportContext
+): boolean {
+  return (
+    current.dossierId === next.dossierId && current.baselineVersionId === next.baselineVersionId
+  )
+}
+
+function normalizedIds(ids: readonly string[]): readonly string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+
+  for (const id of ids) {
+    const normalized = id.trim()
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    result.push(normalized)
+  }
+
+  return result
+}
+
+function selectedOptionIds(
+  state: TechnicalConfigurationResultExportState
+): readonly string[] | null {
+  if (state.optionScope === "all") return null
+  const page = state.context.options.page
+  if (!page) return []
+  return normalizedIds(state.optionScope === "current_page" ? page.currentIds : page.selectedIds)
+}
+
+function selectedCriterionIds(
+  state: TechnicalConfigurationResultExportState
+): readonly string[] | null {
+  if (state.criterionScope === "all") return null
+  return normalizedIds(state.context.criteria.page?.currentIds ?? [])
+}
+
+/** Creates a closed dialog state with the complete universe selected. */
+export function createTechnicalConfigurationResultExportState(
+  context: TechnicalConfigurationResultExportContext
+): TechnicalConfigurationResultExportState {
+  return defaultState(context, false)
+}
+
+/** Returns the first validation failure for the current state, or null when confirm is valid. */
+export function getTechnicalConfigurationResultExportValidationError(
+  state: TechnicalConfigurationResultExportState
+): TechnicalConfigurationResultExportValidationError | null {
+  if (!state.context.dossierId.trim() || !state.context.baselineVersionId.trim()) {
+    return "missing_identity"
+  }
+  if (
+    !Number.isSafeInteger(state.context.options.total) ||
+    state.context.options.total < 0 ||
+    !Number.isSafeInteger(state.context.criteria.total) ||
+    state.context.criteria.total < 0
+  ) {
+    return "invalid_totals"
+  }
+
+  if (state.optionScope !== "all" && !state.context.options.page) {
+    return "unavailable_option_scope"
+  }
+  if (state.optionScope === "current_page" && selectedOptionIds(state)?.length === 0) {
+    return "empty_current_option_page"
+  }
+  if (state.optionScope === "selected" && selectedOptionIds(state)?.length === 0) {
+    return "empty_selected_options"
+  }
+
+  if (state.criterionScope === "current_page" && !state.context.criteria.page) {
+    return "unavailable_criterion_scope"
+  }
+  if (state.criterionScope === "current_page" && selectedCriterionIds(state)?.length === 0) {
+    return "empty_current_criterion_page"
+  }
+
+  return null
+}
+
+/** Returns the selected row counts and visible sheet count for dialog presentation. */
+export function getTechnicalConfigurationResultExportSelectionSummary(
+  state: TechnicalConfigurationResultExportState
+): TechnicalConfigurationResultExportSelectionSummary {
+  return {
+    optionCount:
+      state.optionScope === "all"
+        ? state.context.options.total
+        : (selectedOptionIds(state)?.length ?? 0),
+    criterionCount:
+      state.criterionScope === "all"
+        ? state.context.criteria.total
+        : (selectedCriterionIds(state)?.length ?? 0),
+    visibleSheetCount: state.mode === "full" ? 3 : 2,
+  }
+}
+
+/** Applies one deterministic state transition and emits a request only on valid confirm. */
+export function transitionTechnicalConfigurationResultExport(
+  state: TechnicalConfigurationResultExportState,
+  event: TechnicalConfigurationResultExportEvent
+): TechnicalConfigurationResultExportTransition {
+  if (event.type === "open") {
+    return { state: defaultState(state.context, true), request: null }
+  }
+  if (event.type === "reset") {
+    return { state: defaultState(state.context, state.open), request: null }
+  }
+  if (event.type === "cancel") {
+    return { state: defaultState(state.context, false), request: null }
+  }
+  if (event.type === "mode_changed") {
+    return { state: { ...state, mode: event.mode }, request: null }
+  }
+  if (event.type === "option_scope_changed") {
+    return { state: { ...state, optionScope: event.scope }, request: null }
+  }
+  if (event.type === "criterion_scope_changed") {
+    return { state: { ...state, criterionScope: event.scope }, request: null }
+  }
+  if (event.type === "context_changed") {
+    return {
+      state: sameIdentity(state.context, event.context)
+        ? { ...state, context: event.context }
+        : defaultState(event.context, state.open),
+      request: null,
+    }
+  }
+
+  if (!state.open) {
+    return { state, request: null }
+  }
+
+  if (getTechnicalConfigurationResultExportValidationError(state)) {
+    return { state, request: null }
+  }
+
+  return {
+    state: defaultState(state.context, false),
+    request: {
+      mode: state.mode,
+      dossierId: state.context.dossierId,
+      baselineVersionId: state.context.baselineVersionId,
+      optionIds: selectedOptionIds(state),
+      criterionIds: selectedCriterionIds(state),
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add a pure result-export dialog state machine for open/reset/cancel/confirm, identity changes, validation, and paginated scope selection
- add the approved unmounted Stitch-aligned dialog with accessible native radios, focus restoration, and one validated request intent
- keep P14C2 boundaries intact: no workspace mount, RPC collection, ExcelJS, Blob/download, or orchestration

## TDD Evidence
- RED: focused test failed only because the P14C1 state/dialog modules were missing
- review RED: 3 focused failures reproduced closed-state confirm, stale same-identity scope, and missing radio descriptions
- GREEN: 14/14 dialog/state tests pass

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- focused P14/export/focus regressions: 7 files, 77 tests passed
- React Doctor changed scope: 100/100, no issues
- `npx openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- final `mix-gpt-5.6` xhigh review approved after findings were fixed and re-reviewed

## Scope Notes
- #855 remains a non-blocking compatibility follow-up and is unchanged by this PR.
- P14C2 / #845 remains responsible for workspace mounting, collection, rendering, download, retry, and cancellation orchestration.

Closes #844

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the P14C1 result export scope dialog and a pure state machine so users can pick workbook content and option/criterion scope with validation, then emit a single request. Prepares #844 for P14C2; no export side effects are wired.

- **New Features**
  - Pure state machine for open/reset/cancel/confirm and context changes; validates totals/scopes; emits one request with {mode, dossierId, baselineVersionId, optionIds|null, criterionIds|null}.
  - Accessible dialog with native radios, a reset action, and focus restoration; supports all/current page/selected scopes; shows a live summary with row counts and visible sheet count; inline errors disable confirm.
  - Resets on dossier/baseline identity change and syncs scopes with same-identity pagination/selection updates; copy clarifies snapshot reload, adds a ranking disclaimer, and shows time hints; tests cover transitions and UI.
  - Out of scope for P14C1: workspace mount, RPC collection, `ExcelJS`, Blob/download, orchestration (handled in P14C2).

<sup>Written for commit 244b5abd6aa067e4696e8a1125c604e07d3cf32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


