### PR TITLE
[P14C2] Activate result export orchestration and download

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -827,6 +827,14 @@ selected options and current criterion page are explicit alternatives with
 live counts; the UI never assumes current-page scope. Confirmation shows the
 resulting option x criterion count and visible-sheet count.
 
+In the evaluation workspace, the active evaluation option is the explicit
+`selected` option scope and the current criterion scope is derived from the
+existing navigator page. The option `current_page` alternative is shown only
+when current visible option IDs are a strict subset of the complete option
+universe; a complete unpaginated option list does not render a redundant
+current-page alternative. P14C2 reads this state at its existing owner and does
+not lift or duplicate navigator ownership.
+
 ## Query And Performance Budgets
 
 - Dossier and entity lists use bounded pagination with a maximum page size of 100.

--- a/openspec/changes/add-technical-configuration-comparison/design.md
+++ b/openspec/changes/add-technical-configuration-comparison/design.md
@@ -569,6 +569,14 @@ workbook; khi dữ liệu có phân trang, dialog bắt buộc cho chọn rõ ph
 và criterion. Giá trị mặc định là `Đầy đủ`, `Tất cả phương án` và `Tất cả tiêu
 chí`, không phải current page.
 
+P14C2 mount action qua một leaf control tại
+`TechnicalConfigurationEvaluationActiveWorkspace`, nơi navigator P12B2 đang sở
+hữu active option và current criterion page. Không lift, duplicate hoặc đồng bộ
+shadow navigator state lên parent workspace. Trong evaluation workspace,
+`selected` nghĩa là active option hiện tại; option `current_page` chỉ xuất hiện
+khi visible option IDs là một tập con thực sự của total option IDs. Criterion
+`current_page` luôn lấy từ `navigator.pageCriteria`.
+
 Ba content mode là:
 
 1. `Đầy đủ`: `Tổng quan`, `Xếp hạng`, `Ma trận chi tiết`;

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -3331,19 +3331,29 @@ workbook or download side effect. Existing workspace UI remains unchanged.
 - Create:
   `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationResultExport.ts`
 - Create:
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx`
+- Create:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx`
 - Modify:
-  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx`
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx`
 - Modify:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx`
 
 ### Tasks
 
 - [ ] Write RED React integration tests for mounted trigger, scope confirmation,
       loading/success/error/retry, changed-snapshot abort, context switch,
       requested-surface fetch suppression and no partial download.
-- [ ] Mount one `Xuất kết quả Excel` action in the evaluation workspace without
-      changing current matrix/ranking ownership or pagination behavior.
+- [ ] Mount one `Xuất kết quả Excel` action at the active evaluation state owner
+      through an extracted leaf control, without lifting or duplicating
+      navigator state or changing current matrix/ranking ownership and
+      pagination behavior.
 - [ ] Orchestrate P14A3 collection then P14B2 rendering, serialize through the
       existing ExcelJS pattern and call shared `downloadBlob()` exactly once
       only after successful final manifest revalidation.

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -791,11 +791,19 @@ or download side effect.
 - Create:
   `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationResultExport.ts`
 - Create:
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx`
+- Create:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx`
 - Modify:
-  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx`
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx`
 - Modify:
   `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx`
 
 ### RED
 
@@ -815,7 +823,9 @@ or download side effect.
 
 1. Implement one orchestration hook over P14A3 and P14B2.
 2. Mount one `Xuất kết quả Excel` action and the P14C1 dialog in
-   `TechnicalConfigurationEvaluationWorkspace`.
+   `TechnicalConfigurationEvaluationActiveWorkspace` through one extracted
+   leaf control so the active option and current criterion page remain owned by
+   the existing P12B2 navigator.
 3. Cancel or ignore obsolete work after context changes.
 4. Download only after complete collection, final manifest revalidation and
    successful serialization.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -951,13 +951,13 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14C2 - Export Orchestration, Download And Workspace Activation
 
-- [ ] P14C2.1 Mount một action `Xuất kết quả Excel` trong evaluation workspace và
-      giữ nguyên ownership/pagination hiện tại.
-- [ ] P14C2.2 Orchestrate collector -> renderer -> shared `downloadBlob()`; chỉ
+- [x] P14C2.1 Mount một action `Xuất kết quả Excel` tại active evaluation state
+      owner qua leaf control riêng và giữ nguyên ownership/pagination hiện tại.
+- [x] P14C2.2 Orchestrate collector -> renderer -> shared `downloadBlob()`; chỉ
       download một lần sau final manifest revalidation.
-- [ ] P14C2.3 Abort stale/context-switched work, không partial download và cho
+- [x] P14C2.3 Abort stale/context-switched work, không partial download và cho
       retry explicit.
-- [ ] P14C2.4 Chạy standard TS/React gates, focused Excel/Equipment,
+- [x] P14C2.4 Chạy standard TS/React gates, focused Excel/Equipment,
       evaluation/ranking regressions, React Doctor và strict OpenSpec; không
       thêm P13B real-browser gate.
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -37,7 +37,10 @@ const mocks = vi.hoisted(() => ({
   refetchEvaluationCriteria: vi.fn(),
   refetchAssessment: vi.fn(),
   refetchComparisonSet: vi.fn(),
+  resetResultExport: vi.fn(),
+  retryResultExport: vi.fn(),
   save: vi.fn(),
+  startResultExport: vi.fn(),
   synchronizeVersion: vi.fn(),
 }))
 
@@ -87,6 +90,30 @@ vi.mock("../_hooks/useTechnicalConfigurationOptionListQuery", () => ({
       isError: false,
       refetch: vi.fn(),
     },
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationResultExport", () => ({
+  useTechnicalConfigurationResultExport: () => ({
+    status: "idle",
+    error: null,
+    startExport: mocks.startResultExport,
+    retry: mocks.retryResultExport,
+    reset: mocks.resetResultExport,
+  }),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: {
+        id: "user-1",
+        username: "admin",
+        full_name: "Nguyễn Văn A",
+        role: "admin",
+      },
+    },
+    status: "authenticated",
   }),
 }))
 
@@ -329,6 +356,38 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     expect(screen.getByText("0 / 2")).toBeInTheDocument()
     expect(screen.getByText("1 / 1")).toBeInTheDocument()
     expect(screen.queryByText("Đã đánh giá 2 / 3 tiêu chí")).not.toBeInTheDocument()
+  })
+
+  it("exports the active option and current criterion page without changing navigator state", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    expect(mocks.startResultExport).not.toHaveBeenCalled()
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
+    await user.click(screen.getByRole("button", { name: "Trang tiếp theo" }))
+
+    expect(await screen.findByText("Trang 2/2")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Xuất kết quả Excel" }))
+
+    expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
+    await user.click(screen.getByRole("radio", { name: "1 phương án đã chọn" }))
+    await user.click(screen.getByRole("radio", { name: "Trang tiêu chí hiện tại · 1 tiêu chí" }))
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+
+    expect(mocks.startResultExport).toHaveBeenCalledWith({
+      mode: "full",
+      dossierId: "dossier-1",
+      baselineVersionId: "baseline-1",
+      optionIds: ["option-2"],
+      criterionIds: ["criterion-3"],
+    })
+    expect(screen.getByLabelText("Phương án đánh giá")).toHaveTextContent(
+      "Nhà cung cấp B · Model B"
+    )
+    expect(screen.getByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
   })
 
   it("does not render false progress counters while complete assessments are loading", () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
@@ -150,6 +150,38 @@ describe("technical configuration result export state", () => {
     expect(result.state.open).toBe(true)
   })
 
+  it("rejects a redundant current option page while preserving the selected scope", () => {
+    const context = createContext({
+      options: {
+        total: 2,
+        page: {
+          currentIds: ["option-1", "option-2"],
+          selectedIds: ["option-2"],
+        },
+      },
+    })
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(context),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "current_page",
+    }).state
+
+    expect(getTechnicalConfigurationResultExportValidationError(state)).toBe(
+      "unavailable_option_scope"
+    )
+
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "selected",
+    }).state
+    const result = transitionTechnicalConfigurationResultExport(state, { type: "confirm" })
+
+    expect(result.request?.optionIds).toEqual(["option-2"])
+  })
+
   it("resets content and scope when dossier or baseline identity changes", () => {
     let state = transitionTechnicalConfigurationResultExport(
       createTechnicalConfigurationResultExportState(createContext()),
@@ -285,6 +317,29 @@ describe("TechnicalConfigurationResultExportDialog", () => {
     expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("radio", { name: /đã chọn/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("radio", { name: /Trang tiêu chí hiện tại/ })).not.toBeInTheDocument()
+  })
+
+  it("hides a redundant current option page while keeping the active selected option", async () => {
+    const user = userEvent.setup()
+    render(
+      <DialogHarness
+        context={createContext({
+          options: {
+            total: 2,
+            page: {
+              currentIds: ["option-1", "option-2"],
+              selectedIds: ["option-2"],
+            },
+          },
+        })}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+
+    expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "1 phương án đã chọn" })).toBeInTheDocument()
   })
 
   it("disables confirmation and announces an empty selected scope", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
@@ -216,6 +216,34 @@ describe("technical configuration result export state", () => {
     })
   })
 
+  it("falls back from page-bound scopes when same-identity context removes their pages", () => {
+    let state = transitionTechnicalConfigurationResultExport(
+      createTechnicalConfigurationResultExportState(createContext()),
+      { type: "open" }
+    ).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "option_scope_changed",
+      scope: "selected",
+    }).state
+    state = transitionTechnicalConfigurationResultExport(state, {
+      type: "criterion_scope_changed",
+      scope: "current_page",
+    }).state
+
+    const result = transitionTechnicalConfigurationResultExport(state, {
+      type: "context_changed",
+      context: createContext({
+        options: { total: 126 },
+        criteria: { total: 102 },
+      }),
+    })
+
+    expect(result.state).toMatchObject({
+      optionScope: "all",
+      criterionScope: "all",
+    })
+  })
+
   it("cancels without a request and resets the next session", () => {
     let state = transitionTechnicalConfigurationResultExport(
       createTechnicalConfigurationResultExportState(createContext()),

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-dialog.test.tsx
@@ -342,6 +342,29 @@ describe("TechnicalConfigurationResultExportDialog", () => {
     expect(screen.getByRole("radio", { name: "1 phương án đã chọn" })).toBeInTheDocument()
   })
 
+  it("hides an empty current option page while keeping the active selected option", async () => {
+    const user = userEvent.setup()
+    render(
+      <DialogHarness
+        context={createContext({
+          options: {
+            total: 2,
+            page: {
+              currentIds: [],
+              selectedIds: ["option-2"],
+            },
+          },
+        })}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở xuất kết quả" }))
+
+    expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "1 phương án đã chọn" })).toBeInTheDocument()
+  })
+
   it("disables confirmation and announces an empty selected scope", async () => {
     const user = userEvent.setup()
     render(
@@ -406,6 +429,70 @@ describe("TechnicalConfigurationResultExportDialog", () => {
       dossierId: "dossier-1",
       baselineVersionId: "baseline-1",
       optionIds: ["option-4"],
+      criterionIds: null,
+    })
+  })
+
+  it("keeps the all-options fallback after a redundant current page becomes paginated again", async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const { rerender } = render(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext()}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    await user.click(screen.getByRole("radio", { name: "3 phương án đang hiển thị" }))
+
+    rerender(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext({
+          options: {
+            total: 3,
+            page: {
+              currentIds: ["option-1", "option-2", "option-3"],
+              selectedIds: ["option-2"],
+            },
+          },
+        })}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.queryByRole("radio", { name: /đang hiển thị/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Tất cả 3 phương án" })).toBeChecked()
+
+    rerender(
+      <TechnicalConfigurationResultExportDialog
+        open
+        context={createContext({
+          options: {
+            total: 4,
+            page: {
+              currentIds: ["option-1", "option-2", "option-3"],
+              selectedIds: ["option-2"],
+            },
+          },
+        })}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+
+    expect(screen.getByRole("radio", { name: "Tất cả 4 phương án" })).toBeChecked()
+    expect(screen.getByRole("radio", { name: "3 phương án đang hiển thị" })).not.toBeChecked()
+
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+    expect(onConfirm).toHaveBeenCalledWith({
+      mode: "full",
+      dossierId: "dossier-1",
+      baselineVersionId: "baseline-1",
+      optionIds: null,
       criterionIds: null,
     })
   })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-source-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export-source-contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { expect, it } from "vitest"
+
+it("uses commit-synchronous cleanup for keyed result-export identity remounts", () => {
+  const hookSource = readFileSync(
+    resolve(
+      process.cwd(),
+      "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationResultExport.ts"
+    ),
+    "utf8"
+  )
+
+  expect(hookSource).toContain("React.useLayoutEffect(")
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx
@@ -1,0 +1,348 @@
+import "@testing-library/jest-dom"
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationResultExportControl } from "../_components/evaluation/TechnicalConfigurationResultExportControl"
+import { useTechnicalConfigurationResultExport } from "../_hooks/useTechnicalConfigurationResultExport"
+import { TechnicalConfigurationResultExportError } from "../technical-configuration-result-export-decoders"
+import type { TechnicalConfigurationResultExportDialogRequest } from "../technical-configuration-result-export-state"
+import type { TechnicalConfigurationResultExportDataset } from "../technical-configuration-result-export-types"
+import {
+  createBaselineGroups,
+  createOption,
+} from "./technical-configuration-evaluation-workspace.test-support"
+
+const mocks = vi.hoisted(() => ({
+  collectDataset: vi.fn(),
+  createModel: vi.fn(),
+  downloadBlob: vi.fn(),
+  serializeWorkbook: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-result-export-data", () => ({
+  collectTechnicalConfigurationResultExportDataset: mocks.collectDataset,
+}))
+
+vi.mock("@/lib/technical-configuration-result-excel-contract", () => ({
+  createTechnicalConfigurationResultWorkbookModel: mocks.createModel,
+}))
+
+vi.mock("@/lib/technical-configuration-result-excel-export", () => ({
+  serializeTechnicalConfigurationResultWorkbook: mocks.serializeWorkbook,
+}))
+
+vi.mock("@/lib/excel-workbook", () => ({
+  downloadBlob: mocks.downloadBlob,
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: {
+      user: {
+        id: "user-1",
+        username: "admin",
+        full_name: "Nguyễn Văn A",
+        role: "admin",
+      },
+    },
+    status: "authenticated",
+  }),
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function createDataset(
+  deviceTypeName = "Máy siêu âm / Doppler"
+): TechnicalConfigurationResultExportDataset {
+  return {
+    mode: "full",
+    manifest: {
+      dossier: {
+        id: "dossier-1",
+        device_type_name: deviceTypeName,
+        name: "Hồ sơ siêu âm",
+        revision: 5,
+        archived_at: null,
+      },
+      baseline_version: {
+        id: "baseline-1",
+        dossier_id: "dossier-1",
+        version_number: 2,
+        status: "locked",
+        revision: 3,
+        locked_at: "2026-08-01T08:00:00.000Z",
+      },
+      option_total: 1,
+      criterion_total: 1,
+      snapshot_token: "snapshot-1",
+      ranking_snapshot_token: "ranking-snapshot-1",
+    },
+    optionAxis: [],
+    criterionAxis: [],
+    ranking: [],
+    matrix: [],
+  }
+}
+
+const request: TechnicalConfigurationResultExportDialogRequest = {
+  mode: "full",
+  dossierId: "dossier-1",
+  baselineVersionId: "baseline-1",
+  optionIds: ["option-2"],
+  criterionIds: ["criterion-3"],
+}
+
+describe("useTechnicalConfigurationResultExport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createModel.mockReturnValue({
+      template_kind: "technical_configuration_result",
+      template_version: 1,
+      sheets: [],
+    })
+    mocks.serializeWorkbook.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+  })
+
+  it("does no work on mount, then serializes and downloads one complete stable dataset", async () => {
+    const deferred = createDeferred<TechnicalConfigurationResultExportDataset>()
+    mocks.collectDataset.mockReturnValue(deferred.promise)
+    const { result } = renderHook(() =>
+      useTechnicalConfigurationResultExport({
+        dossierId: "dossier-1",
+        baselineVersionId: "baseline-1",
+        generatedBy: "Nguyễn Văn A",
+      })
+    )
+
+    expect(mocks.collectDataset).not.toHaveBeenCalled()
+
+    let exportPromise: Promise<void> | undefined
+    act(() => {
+      exportPromise = result.current.startExport(request)
+    })
+    expect(result.current.status).toBe("loading")
+
+    deferred.resolve(createDataset())
+    await act(async () => {
+      await exportPromise
+    })
+
+    expect(mocks.collectDataset).toHaveBeenCalledWith({
+      ...request,
+      signal: expect.any(AbortSignal),
+    })
+    expect(mocks.createModel).toHaveBeenCalledWith({
+      ...createDataset(),
+      option_ids: ["option-2"],
+      criterion_ids: ["criterion-3"],
+      generated_at: expect.any(String),
+      generated_by: "Nguyễn Văn A",
+    })
+    expect(mocks.serializeWorkbook).toHaveBeenCalledTimes(1)
+    expect(mocks.downloadBlob).toHaveBeenCalledTimes(1)
+    const generatedAt = mocks.createModel.mock.calls[0]?.[0]?.generated_at
+    expect(mocks.downloadBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      `Ket_qua_so_sanh_cau_hinh_May_sieu_am_Doppler_${generatedAt.slice(0, 10)}.xlsx`
+    )
+    expect(result.current.status).toBe("success")
+  })
+
+  it("keeps the filesystem-safe filename within the common 255-byte limit", async () => {
+    mocks.collectDataset.mockResolvedValue(createDataset("Thiết bị siêu âm ".repeat(80)))
+    const { result } = renderHook(() =>
+      useTechnicalConfigurationResultExport({
+        dossierId: "dossier-1",
+        baselineVersionId: "baseline-1",
+        generatedBy: "Nguyễn Văn A",
+      })
+    )
+
+    await act(async () => {
+      await result.current.startExport(request)
+    })
+
+    const filename = mocks.downloadBlob.mock.calls[0]?.[1]
+    expect(filename).toMatch(
+      /^Ket_qua_so_sanh_cau_hinh_Thiet_bi_sieu_am_[A-Za-z0-9_]+_\d{4}-\d{2}-\d{2}\.xlsx$/
+    )
+    expect(new TextEncoder().encode(filename).byteLength).toBeLessThanOrEqual(255)
+  })
+
+  it("keeps a typed failure retryable and reuses the exact confirmed request", async () => {
+    mocks.collectDataset
+      .mockRejectedValueOnce(
+        new TechnicalConfigurationResultExportError("transport", "Result export RPC failed.")
+      )
+      .mockResolvedValueOnce(createDataset())
+    const { result } = renderHook(() =>
+      useTechnicalConfigurationResultExport({
+        dossierId: "dossier-1",
+        baselineVersionId: "baseline-1",
+        generatedBy: "Nguyễn Văn A",
+      })
+    )
+
+    await act(async () => {
+      await result.current.startExport(request)
+    })
+
+    expect(result.current.status).toBe("error")
+    expect(result.current.error?.kind).toBe("transport")
+
+    await act(async () => {
+      await result.current.retry()
+    })
+
+    expect(mocks.collectDataset).toHaveBeenNthCalledWith(2, {
+      ...request,
+      signal: expect.any(AbortSignal),
+    })
+    expect(mocks.downloadBlob).toHaveBeenCalledTimes(1)
+    expect(result.current.status).toBe("success")
+  })
+
+  it("never serializes or downloads when final manifest revalidation reports a change", async () => {
+    mocks.collectDataset.mockRejectedValue(
+      new TechnicalConfigurationResultExportError(
+        "snapshot_changed",
+        "Result export snapshot changed."
+      )
+    )
+    const { result } = renderHook(() =>
+      useTechnicalConfigurationResultExport({
+        dossierId: "dossier-1",
+        baselineVersionId: "baseline-1",
+        generatedBy: "Nguyễn Văn A",
+      })
+    )
+
+    await act(async () => {
+      await result.current.startExport(request)
+    })
+
+    expect(result.current.error?.kind).toBe("snapshot_changed")
+    expect(mocks.createModel).not.toHaveBeenCalled()
+    expect(mocks.serializeWorkbook).not.toHaveBeenCalled()
+    expect(mocks.downloadBlob).not.toHaveBeenCalled()
+  })
+
+  it("aborts and ignores obsolete work after dossier or baseline identity changes", async () => {
+    const deferred = createDeferred<TechnicalConfigurationResultExportDataset>()
+    let signal: AbortSignal | undefined
+    mocks.collectDataset.mockImplementation(
+      (
+        exportRequest: TechnicalConfigurationResultExportDialogRequest & { signal?: AbortSignal }
+      ) => {
+        signal = exportRequest.signal
+        return deferred.promise
+      }
+    )
+    const { result, rerender } = renderHook(
+      ({ dossierId, baselineVersionId }) =>
+        useTechnicalConfigurationResultExport({
+          dossierId,
+          baselineVersionId,
+          generatedBy: "Nguyễn Văn A",
+        }),
+      {
+        initialProps: {
+          dossierId: "dossier-1",
+          baselineVersionId: "baseline-1",
+        },
+      }
+    )
+
+    let exportPromise: Promise<void> | undefined
+    act(() => {
+      exportPromise = result.current.startExport(request)
+    })
+    rerender({ dossierId: "dossier-2", baselineVersionId: "baseline-2" })
+
+    expect(signal?.aborted).toBe(true)
+    expect(result.current.status).toBe("idle")
+
+    deferred.resolve(createDataset())
+    await act(async () => {
+      await exportPromise
+    })
+    await waitFor(() => expect(mocks.downloadBlob).not.toHaveBeenCalled())
+    expect(mocks.createModel).not.toHaveBeenCalled()
+    expect(mocks.serializeWorkbook).not.toHaveBeenCalled()
+  })
+})
+
+describe("TechnicalConfigurationResultExportControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createModel.mockReturnValue({
+      template_kind: "technical_configuration_result",
+      template_version: 1,
+      sheets: [],
+    })
+    mocks.serializeWorkbook.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+  })
+
+  function renderControl() {
+    return render(
+      <TechnicalConfigurationResultExportControl
+        dossierId="dossier-1"
+        baselineVersionId="baseline-1"
+        options={[createOption("option-1", "Nhà cung cấp A · Model A")]}
+        baselineGroups={createBaselineGroups()}
+        activeOptionId="option-1"
+        currentCriteria={[{ criterion: { id: "criterion-1" } }]}
+      />
+    )
+  }
+
+  it("does not collect data on mount or dialog cancellation", async () => {
+    const user = userEvent.setup()
+    renderControl()
+
+    expect(mocks.collectDataset).not.toHaveBeenCalled()
+    await user.click(screen.getByRole("button", { name: "Xuất kết quả Excel" }))
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+
+    expect(mocks.collectDataset).not.toHaveBeenCalled()
+  })
+
+  it("shows loading and a typed error before an explicit successful retry", async () => {
+    const user = userEvent.setup()
+    const deferred = createDeferred<TechnicalConfigurationResultExportDataset>()
+    mocks.collectDataset
+      .mockReturnValueOnce(deferred.promise)
+      .mockResolvedValueOnce(createDataset())
+    renderControl()
+
+    await user.click(screen.getByRole("button", { name: "Xuất kết quả Excel" }))
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+
+    const loadingTrigger = screen.getByRole("button", { name: "Đang xuất kết quả..." })
+    expect(loadingTrigger).toHaveFocus()
+    expect(loadingTrigger).not.toBeDisabled()
+    expect(loadingTrigger).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByRole("status")).toHaveTextContent("Đang tạo tệp Excel")
+
+    await act(async () => {
+      deferred.reject(
+        new TechnicalConfigurationResultExportError("transport", "Result export RPC failed.")
+      )
+    })
+
+    expect(await screen.findByText("Không thể tải dữ liệu xuất")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+    await waitFor(() => expect(mocks.downloadBlob).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole("status")).toHaveTextContent("Đã tải tệp Excel")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-result-export.test.tsx
@@ -17,6 +17,15 @@ const mocks = vi.hoisted(() => ({
   collectDataset: vi.fn(),
   createModel: vi.fn(),
   downloadBlob: vi.fn(),
+  session: {
+    user: {
+      id: "user-1",
+      username: "admin" as string | null,
+      full_name: "Nguyễn Văn A" as string | null,
+      name: null as string | null,
+      role: "admin",
+    },
+  },
   serializeWorkbook: vi.fn(),
 }))
 
@@ -38,14 +47,7 @@ vi.mock("@/lib/excel-workbook", () => ({
 
 vi.mock("next-auth/react", () => ({
   useSession: () => ({
-    data: {
-      user: {
-        id: "user-1",
-        username: "admin",
-        full_name: "Nguyễn Văn A",
-        role: "admin",
-      },
-    },
+    data: mocks.session,
     status: "authenticated",
   }),
 }))
@@ -63,6 +65,29 @@ function createDeferred<T>() {
 function createDataset(
   deviceTypeName = "Máy siêu âm / Doppler"
 ): TechnicalConfigurationResultExportDataset {
+  const optionIdentity = {
+    option_id: "option-2",
+    supplier_id: "supplier-2",
+    supplier_name: "Nhà cung cấp A",
+    display_label: "Nhà cung cấp A · Model A",
+  } as const
+  const optionAxisItem = {
+    ...optionIdentity,
+    model: "Model A",
+    manufacturer: "Hãng A",
+    option_name: "Máy siêu âm",
+  } as const
+  const criterionAxisItem = {
+    group_id: "group-1",
+    group_name: "Nhóm tiêu chí 1",
+    group_order: 1,
+    criterion_id: "criterion-3",
+    criterion_code: "TC-003",
+    criterion_title: "Tiêu chí 3",
+    requirement_text: "Yêu cầu cấu hình 3",
+    criterion_order: 3,
+  } as const
+
   return {
     mode: "full",
     manifest: {
@@ -86,10 +111,32 @@ function createDataset(
       snapshot_token: "snapshot-1",
       ranking_snapshot_token: "ranking-snapshot-1",
     },
-    optionAxis: [],
-    criterionAxis: [],
-    ranking: [],
-    matrix: [],
+    optionAxis: [optionAxisItem],
+    criterionAxis: [criterionAxisItem],
+    ranking: [
+      {
+        ...optionIdentity,
+        eligibility: "eligible",
+        incomplete_criterion_count: 0,
+        failed_count: 0,
+        insufficient_evidence_count: 0,
+        exceeds_count: 1,
+        rank: 1,
+      },
+    ],
+    matrix: [
+      {
+        ...criterionAxisItem,
+        ...optionAxisItem,
+        response_text: "Đáp ứng",
+        supplementary_information: null,
+        document_links: [],
+        technical_axis: "meets",
+        evidence_axis: "complete",
+        assessment_notes: null,
+        conclusion: "meets",
+      },
+    ],
   }
 }
 
@@ -110,6 +157,19 @@ describe("useTechnicalConfigurationResultExport", () => {
       sheets: [],
     })
     mocks.serializeWorkbook.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+  })
+
+  it("uses an internally complete dataset for the successful export path", () => {
+    const dataset = createDataset()
+
+    expect(dataset.optionAxis.map((option) => option.option_id)).toEqual(["option-2"])
+    expect(dataset.criterionAxis.map((criterion) => criterion.criterion_id)).toEqual([
+      "criterion-3",
+    ])
+    expect(dataset.ranking.map((row) => row.option_id)).toEqual(["option-2"])
+    expect(dataset.matrix.map((cell) => [cell.option_id, cell.criterion_id])).toEqual([
+      ["option-2", "criterion-3"],
+    ])
   })
 
   it("does no work on mount, then serializes and downloads one complete stable dataset", async () => {
@@ -284,6 +344,9 @@ describe("useTechnicalConfigurationResultExport", () => {
 describe("TechnicalConfigurationResultExportControl", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.session.user.username = "admin"
+    mocks.session.user.full_name = "Nguyễn Văn A"
+    mocks.session.user.name = null
     mocks.createModel.mockReturnValue({
       template_kind: "technical_configuration_result",
       template_version: 1,
@@ -304,6 +367,21 @@ describe("TechnicalConfigurationResultExportControl", () => {
       />
     )
   }
+
+  it("falls back safely when every session display-name field is null", async () => {
+    const user = userEvent.setup()
+    mocks.session.user.username = null
+    mocks.session.user.full_name = null
+    mocks.session.user.name = null
+    mocks.collectDataset.mockResolvedValue(createDataset())
+    renderControl()
+
+    await user.click(screen.getByRole("button", { name: "Xuất kết quả Excel" }))
+    await user.click(screen.getByRole("button", { name: "Xuất file .xlsx" }))
+
+    await waitFor(() => expect(mocks.createModel).toHaveBeenCalledTimes(1))
+    expect(mocks.createModel.mock.calls[0]?.[0]?.generated_by).toBe("Không xác định")
+  })
 
   it("does not collect data on mount or dialog cancellation", async () => {
     const user = userEvent.setup()

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -29,6 +29,7 @@ import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurat
 import { TechnicalConfigurationEvaluationNavigatorPane } from "./TechnicalConfigurationEvaluationNavigatorPane"
 import { TechnicalConfigurationEvaluationPanel } from "./TechnicalConfigurationEvaluationPanel"
 import { TechnicalConfigurationProgressSummary } from "./TechnicalConfigurationProgressSummary"
+import { TechnicalConfigurationResultExportControl } from "./TechnicalConfigurationResultExportControl"
 import { toTechnicalConfigurationSaveErrorMessage } from "./TechnicalConfigurationEvaluationWorkspaceUtils"
 
 type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
@@ -207,6 +208,16 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
 
   return (
     <section className="min-w-0 space-y-4" aria-label="Không gian đánh giá cấu hình kỹ thuật">
+      <TechnicalConfigurationResultExportControl
+        key={`${dossier.id}:${baselineVersionId}`}
+        dossierId={dossier.id}
+        baselineVersionId={baselineVersionId}
+        options={options}
+        baselineGroups={baselineGroups}
+        activeOptionId={navigator.activeSelectedOptionId}
+        currentCriteria={navigator.pageCriteria}
+      />
+
       <div className="flex flex-col gap-2 border-y py-3 sm:flex-row sm:items-center sm:justify-between">
         <Label htmlFor="technical-configuration-evaluation-option">Phương án đánh giá</Label>
         <Select

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import * as React from "react"
+import { AlertCircle, CheckCircle2, Download, Loader2, RefreshCw } from "lucide-react"
+import { useSession } from "next-auth/react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import {
+  useTechnicalConfigurationResultExport,
+  type TechnicalConfigurationResultExportOrchestrationError,
+} from "../../_hooks/useTechnicalConfigurationResultExport"
+import type {
+  TechnicalConfigurationResultExportContext,
+  TechnicalConfigurationResultExportDialogRequest,
+} from "../../technical-configuration-result-export-state"
+import { TechnicalConfigurationResultExportDialog } from "./TechnicalConfigurationResultExportDialog"
+
+type CurrentCriterion = Readonly<{
+  criterion: Readonly<{ id: string }>
+}>
+
+type TechnicalConfigurationResultExportControlProps = Readonly<{
+  dossierId: string
+  baselineVersionId: string
+  options: readonly TechnicalConfigurationOptionWire[]
+  baselineGroups: readonly TechnicalConfigurationBaselineGroupWire[]
+  activeOptionId: string
+  currentCriteria: readonly CurrentCriterion[]
+}>
+
+function errorCopy(
+  kind: TechnicalConfigurationResultExportOrchestrationError["kind"]
+): Readonly<{ title: string; description: string }> {
+  if (kind === "permission_denied") {
+    return {
+      title: "Không có quyền xuất kết quả",
+      description: "Phiên đăng nhập hiện tại không được phép đọc dữ liệu xuất.",
+    }
+  }
+  if (kind === "not_found") {
+    return {
+      title: "Không còn dữ liệu để xuất",
+      description: "Hồ sơ hoặc phiên bản cấu hình không còn tồn tại.",
+    }
+  }
+  if (kind === "conflict" || kind === "snapshot_changed") {
+    return {
+      title: "Dữ liệu đã thay đổi",
+      description: "Không tạo tệp từ dữ liệu cũ. Hãy thử xuất lại snapshot mới nhất.",
+    }
+  }
+  if (kind === "validation" || kind === "invalid_response") {
+    return {
+      title: "Dữ liệu xuất không hợp lệ",
+      description: "Máy chủ trả về dữ liệu không khớp contract của tệp kết quả.",
+    }
+  }
+  if (kind === "server" || kind === "transport") {
+    return {
+      title: "Không thể tải dữ liệu xuất",
+      description: "Kết nối hoặc máy chủ đang gặp sự cố. Hãy thử lại.",
+    }
+  }
+  return {
+    title: "Không thể tạo tệp Excel",
+    description: "Dữ liệu đã tải nhưng không thể tạo workbook hoàn chỉnh.",
+  }
+}
+
+/** Mounts the P14C1 dialog beside the P12B2 state that defines its live scopes. */
+export function TechnicalConfigurationResultExportControl({
+  dossierId,
+  baselineVersionId,
+  options,
+  baselineGroups,
+  activeOptionId,
+  currentCriteria,
+}: TechnicalConfigurationResultExportControlProps) {
+  const { data: session } = useSession()
+  const [open, setOpen] = React.useState(false)
+  const context = React.useMemo<TechnicalConfigurationResultExportContext>(() => {
+    const optionIds = options.map((option) => option.id)
+    return {
+      dossierId,
+      baselineVersionId,
+      options: {
+        total: optionIds.length,
+        page: {
+          currentIds: optionIds,
+          selectedIds: activeOptionId ? [activeOptionId] : [],
+        },
+      },
+      criteria: {
+        total: baselineGroups.reduce((total, group) => total + group.criteria.length, 0),
+        page: {
+          currentIds: currentCriteria.map((item) => item.criterion.id),
+        },
+      },
+    }
+  }, [activeOptionId, baselineGroups, baselineVersionId, currentCriteria, dossierId, options])
+  const generatedBy =
+    session?.user.full_name?.trim() ||
+    session?.user.name?.trim() ||
+    session?.user.username.trim() ||
+    "Không xác định"
+  const resultExport = useTechnicalConfigurationResultExport({
+    dossierId,
+    baselineVersionId,
+    generatedBy,
+  })
+  const isLoading = resultExport.status === "loading"
+  const copy = resultExport.error ? errorCopy(resultExport.error.kind) : null
+
+  function handleOpen() {
+    if (isLoading) return
+    resultExport.reset()
+    setOpen(true)
+  }
+
+  function handleConfirm(request: TechnicalConfigurationResultExportDialogRequest) {
+    void resultExport.startExport(request)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleOpen}
+          aria-busy={isLoading}
+          aria-disabled={isLoading}
+        >
+          {isLoading ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="size-4" aria-hidden="true" />
+          )}
+          {isLoading ? "Đang xuất kết quả..." : "Xuất kết quả Excel"}
+        </Button>
+        {isLoading ? (
+          <span className="sr-only" role="status" aria-live="polite">
+            Đang tạo tệp Excel
+          </span>
+        ) : null}
+      </div>
+
+      <TechnicalConfigurationResultExportDialog
+        open={open}
+        context={context}
+        onOpenChange={setOpen}
+        onConfirm={handleConfirm}
+      />
+
+      {copy ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>{copy.title}</AlertTitle>
+          <AlertDescription className="flex flex-wrap items-center gap-3">
+            <span>{copy.description}</span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void resultExport.retry()}
+            >
+              <RefreshCw className="size-4" aria-hidden="true" />
+              Thử lại
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {resultExport.status === "success" ? (
+        <Alert role="status">
+          <CheckCircle2 className="size-4" aria-hidden="true" />
+          <AlertTitle>Đã tải tệp Excel</AlertTitle>
+        </Alert>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportControl.tsx
@@ -105,7 +105,7 @@ export function TechnicalConfigurationResultExportControl({
   const generatedBy =
     session?.user.full_name?.trim() ||
     session?.user.name?.trim() ||
-    session?.user.username.trim() ||
+    session?.user.username?.trim() ||
     "Không xác định"
   const resultExport = useTechnicalConfigurationResultExport({
     dossierId,

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
@@ -16,6 +16,7 @@ import {
   createTechnicalConfigurationResultExportState,
   getTechnicalConfigurationResultExportSelectionSummary,
   getTechnicalConfigurationResultExportValidationError,
+  hasTechnicalConfigurationResultExportCurrentOptionPage,
   transitionTechnicalConfigurationResultExport,
   type TechnicalConfigurationResultExportContext,
   type TechnicalConfigurationResultExportCriterionScope,
@@ -90,6 +91,7 @@ function ResultExportDialogContent({
   }).state
   const validationError = getTechnicalConfigurationResultExportValidationError(state)
   const summary = getTechnicalConfigurationResultExportSelectionSummary(state)
+  const hasCurrentOptionPage = hasTechnicalConfigurationResultExportCurrentOptionPage(state.context)
 
   function synchronizeContext(current: TechnicalConfigurationResultExportState) {
     return transitionTechnicalConfigurationResultExport(current, {
@@ -200,27 +202,25 @@ function ResultExportDialogContent({
               title={`Tất cả ${state.context.options.total} phương án`}
               onChange={() => applyEvent({ type: "option_scope_changed", scope: "all" })}
             />
+            {hasCurrentOptionPage && optionPage ? (
+              <TechnicalConfigurationResultExportDialogChoice
+                id={`${baseId}-options-current`}
+                name={`${baseId}-options`}
+                value="current_page"
+                checked={state.optionScope === "current_page"}
+                title={`${optionPage.currentIds.length} phương án đang hiển thị`}
+                onChange={() => applyEvent({ type: "option_scope_changed", scope: "current_page" })}
+              />
+            ) : null}
             {optionPage ? (
-              <>
-                <TechnicalConfigurationResultExportDialogChoice
-                  id={`${baseId}-options-current`}
-                  name={`${baseId}-options`}
-                  value="current_page"
-                  checked={state.optionScope === "current_page"}
-                  title={`${optionPage.currentIds.length} phương án đang hiển thị`}
-                  onChange={() =>
-                    applyEvent({ type: "option_scope_changed", scope: "current_page" })
-                  }
-                />
-                <TechnicalConfigurationResultExportDialogChoice
-                  id={`${baseId}-options-selected`}
-                  name={`${baseId}-options`}
-                  value="selected"
-                  checked={state.optionScope === "selected"}
-                  title={`${optionPage.selectedIds.length} phương án đã chọn`}
-                  onChange={() => applyEvent({ type: "option_scope_changed", scope: "selected" })}
-                />
-              </>
+              <TechnicalConfigurationResultExportDialogChoice
+                id={`${baseId}-options-selected`}
+                name={`${baseId}-options`}
+                value="selected"
+                checked={state.optionScope === "selected"}
+                title={`${optionPage.selectedIds.length} phương án đã chọn`}
+                onChange={() => applyEvent({ type: "option_scope_changed", scope: "selected" })}
+              />
             ) : null}
           </div>
         </fieldset>

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationResultExportDialog.tsx
@@ -89,6 +89,15 @@ function ResultExportDialogContent({
     type: "context_changed",
     context,
   }).state
+  React.useLayoutEffect(() => {
+    setStoredState((current) => {
+      if (current.context === context) return current
+      return transitionTechnicalConfigurationResultExport(current, {
+        type: "context_changed",
+        context,
+      }).state
+    })
+  }, [context])
   const validationError = getTechnicalConfigurationResultExportValidationError(state)
   const summary = getTechnicalConfigurationResultExportSelectionSummary(state)
   const hasCurrentOptionPage = hasTechnicalConfigurationResultExportCurrentOptionPage(state.context)

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationResultExport.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationResultExport.ts
@@ -1,0 +1,181 @@
+"use client"
+
+import * as React from "react"
+
+import { collectTechnicalConfigurationResultExportDataset } from "../technical-configuration-result-export-data"
+import {
+  TechnicalConfigurationResultExportError,
+  type TechnicalConfigurationResultExportErrorKind,
+} from "../technical-configuration-result-export-decoders"
+import type { TechnicalConfigurationResultExportDialogRequest } from "../technical-configuration-result-export-state"
+import { downloadBlob } from "@/lib/excel-workbook"
+import {
+  createTechnicalConfigurationResultWorkbookModel,
+  type TechnicalConfigurationResultWorkbookBuildInput,
+} from "@/lib/technical-configuration-result-excel-contract"
+import { serializeTechnicalConfigurationResultWorkbook } from "@/lib/technical-configuration-result-excel-export"
+
+const RESULT_WORKBOOK_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+const RESULT_FILENAME_SEGMENT_MAX_LENGTH = 120
+
+export type TechnicalConfigurationResultExportStatus = "idle" | "loading" | "success" | "error"
+
+export type TechnicalConfigurationResultExportOrchestrationError = Readonly<{
+  kind: TechnicalConfigurationResultExportErrorKind | "serialization"
+  message: string
+}>
+
+type ResultExportState = Readonly<{
+  identityKey: string
+  status: TechnicalConfigurationResultExportStatus
+  error: TechnicalConfigurationResultExportOrchestrationError | null
+}>
+
+type LastRequest = Readonly<{
+  identityKey: string
+  request: TechnicalConfigurationResultExportDialogRequest
+}>
+
+function idleState(identityKey: string): ResultExportState {
+  return { identityKey, status: "idle", error: null }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError"
+}
+
+function toOrchestrationError(
+  error: unknown
+): TechnicalConfigurationResultExportOrchestrationError {
+  if (error instanceof TechnicalConfigurationResultExportError) {
+    return { kind: error.kind, message: error.message }
+  }
+  return {
+    kind: "serialization",
+    message: error instanceof Error ? error.message : "Result workbook serialization failed.",
+  }
+}
+
+function toFilesystemSafeSegment(value: string): string {
+  const normalized = value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/đ/g, "d")
+    .replace(/Đ/g, "D")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+  const bounded = normalized.slice(0, RESULT_FILENAME_SEGMENT_MAX_LENGTH).replace(/_+$/g, "")
+  return bounded || "Ho_so"
+}
+
+function createResultWorkbookFilename(
+  input: TechnicalConfigurationResultWorkbookBuildInput
+): string {
+  const dossierLabel =
+    input.manifest.dossier.device_type_name ||
+    input.manifest.dossier.name ||
+    input.manifest.dossier.id
+  return `Ket_qua_so_sanh_cau_hinh_${toFilesystemSafeSegment(dossierLabel)}_${input.generated_at.slice(0, 10)}.xlsx`
+}
+
+/** Orchestrates one stable P14 dataset into exactly one downloaded result workbook. */
+export function useTechnicalConfigurationResultExport({
+  dossierId,
+  baselineVersionId,
+  generatedBy,
+}: Readonly<{
+  dossierId: string
+  baselineVersionId: string
+  generatedBy: string
+}>) {
+  const identityKey = JSON.stringify([dossierId, baselineVersionId])
+  const [storedState, setStoredState] = React.useState<ResultExportState>(() =>
+    idleState(identityKey)
+  )
+  const abortControllerRef = React.useRef<AbortController | null>(null)
+  const lastRequestRef = React.useRef<LastRequest | null>(null)
+  const runIdRef = React.useRef(0)
+  const state = storedState.identityKey === identityKey ? storedState : idleState(identityKey)
+
+  React.useLayoutEffect(
+    () => () => {
+      runIdRef.current += 1
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+    },
+    [identityKey]
+  )
+
+  const execute = React.useCallback(
+    async (request: TechnicalConfigurationResultExportDialogRequest) => {
+      const runId = runIdRef.current + 1
+      runIdRef.current = runId
+      abortControllerRef.current?.abort()
+      const abortController = new AbortController()
+      abortControllerRef.current = abortController
+      lastRequestRef.current = { identityKey, request }
+      setStoredState({ identityKey, status: "loading", error: null })
+
+      try {
+        const dataset = await collectTechnicalConfigurationResultExportDataset({
+          ...request,
+          signal: abortController.signal,
+        })
+        if (runIdRef.current !== runId || abortController.signal.aborted) return
+
+        const generatedAt = new Date().toISOString()
+        const modelInput: TechnicalConfigurationResultWorkbookBuildInput = {
+          ...dataset,
+          option_ids: request.optionIds,
+          criterion_ids: request.criterionIds,
+          generated_at: generatedAt,
+          generated_by: generatedBy,
+        }
+        const model = createTechnicalConfigurationResultWorkbookModel(modelInput)
+        if (runIdRef.current !== runId || abortController.signal.aborted) return
+
+        const buffer = await serializeTechnicalConfigurationResultWorkbook(model)
+
+        if (runIdRef.current !== runId || abortController.signal.aborted) return
+        downloadBlob(
+          new Blob([buffer], { type: RESULT_WORKBOOK_MIME_TYPE }),
+          createResultWorkbookFilename(modelInput)
+        )
+        setStoredState({ identityKey, status: "success", error: null })
+      } catch (error) {
+        if (runIdRef.current !== runId || abortController.signal.aborted || isAbortError(error)) {
+          return
+        }
+        setStoredState({
+          identityKey,
+          status: "error",
+          error: toOrchestrationError(error),
+        })
+      } finally {
+        if (runIdRef.current === runId) {
+          abortControllerRef.current = null
+        }
+      }
+    },
+    [generatedBy, identityKey]
+  )
+
+  const retry = React.useCallback(() => {
+    const lastRequest = lastRequestRef.current
+    if (!lastRequest || lastRequest.identityKey !== identityKey) return Promise.resolve()
+    return execute(lastRequest.request)
+  }, [execute, identityKey])
+
+  const reset = React.useCallback(() => {
+    setStoredState(idleState(identityKey))
+  }, [identityKey])
+
+  return {
+    status: state.status,
+    error: state.error,
+    startExport: execute,
+    retry,
+    reset,
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
@@ -138,6 +138,14 @@ function selectedOptionIds(
   return normalizedIds(state.optionScope === "current_page" ? page.currentIds : page.selectedIds)
 }
 
+/** Returns whether the current visible option IDs are a meaningful subset of the universe. */
+export function hasTechnicalConfigurationResultExportCurrentOptionPage(
+  context: TechnicalConfigurationResultExportContext
+): boolean {
+  const page = context.options.page
+  return Boolean(page && normalizedIds(page.currentIds).length < context.options.total)
+}
+
 function selectedCriterionIds(
   state: TechnicalConfigurationResultExportState
 ): readonly string[] | null {
@@ -168,7 +176,13 @@ export function getTechnicalConfigurationResultExportValidationError(
     return "invalid_totals"
   }
 
-  if (state.optionScope !== "all" && !state.context.options.page) {
+  if (
+    state.optionScope === "current_page" &&
+    !hasTechnicalConfigurationResultExportCurrentOptionPage(state.context)
+  ) {
+    return "unavailable_option_scope"
+  }
+  if (state.optionScope === "selected" && !state.context.options.page) {
     return "unavailable_option_scope"
   }
   if (state.optionScope === "current_page" && selectedOptionIds(state)?.length === 0) {

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
@@ -143,7 +143,8 @@ export function hasTechnicalConfigurationResultExportCurrentOptionPage(
   context: TechnicalConfigurationResultExportContext
 ): boolean {
   const page = context.options.page
-  return Boolean(page && normalizedIds(page.currentIds).length < context.options.total)
+  const currentIdCount = page ? normalizedIds(page.currentIds).length : 0
+  return currentIdCount > 0 && currentIdCount < context.options.total
 }
 
 function selectedCriterionIds(
@@ -243,10 +244,23 @@ export function transitionTechnicalConfigurationResultExport(
     return { state: { ...state, criterionScope: event.scope }, request: null }
   }
   if (event.type === "context_changed") {
+    if (sameIdentity(state.context, event.context)) {
+      return {
+        state: {
+          ...state,
+          context: event.context,
+          optionScope:
+            state.optionScope === "current_page" &&
+            !hasTechnicalConfigurationResultExportCurrentOptionPage(event.context)
+              ? "all"
+              : state.optionScope,
+        },
+        request: null,
+      }
+    }
+
     return {
-      state: sameIdentity(state.context, event.context)
-        ? { ...state, context: event.context }
-        : defaultState(event.context, state.open),
+      state: defaultState(event.context, state.open),
       request: null,
     }
   }

--- a/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-result-export-state.ts
@@ -245,15 +245,26 @@ export function transitionTechnicalConfigurationResultExport(
   }
   if (event.type === "context_changed") {
     if (sameIdentity(state.context, event.context)) {
+      let optionScope = state.optionScope
+      if (
+        (optionScope === "current_page" &&
+          !hasTechnicalConfigurationResultExportCurrentOptionPage(event.context)) ||
+        (optionScope === "selected" && !event.context.options.page)
+      ) {
+        optionScope = "all"
+      }
+
+      const criterionScope =
+        state.criterionScope === "current_page" && !event.context.criteria.page
+          ? "all"
+          : state.criterionScope
+
       return {
         state: {
           ...state,
           context: event.context,
-          optionScope:
-            state.optionScope === "current_page" &&
-            !hasTechnicalConfigurationResultExportCurrentOptionPage(event.context)
-              ? "all"
-              : state.optionScope,
+          optionScope,
+          criterionScope,
         },
         request: null,
       }


### PR DESCRIPTION
## Summary
- mount the P14C1 export dialog at `TechnicalConfigurationEvaluationActiveWorkspace`, where the existing navigator owns the active option and current criterion page
- orchestrate the existing P14A collector, P14B model/serializer, and shared `downloadBlob()` into one snapshot-stable workbook download
- add typed loading/error/retry/success UI, stale-run cancellation, deterministic bounded filenames, and focused OpenSpec/TDD coverage

## Boundary
- preserves existing evaluation, ranking, pagination, and persistence ownership
- does not lift or duplicate navigator state
- does not expand into P13C or add the deferred P13B browser gate
- #855 remains non-blocking
- no database changes

## TDD and review
- RED locked redundant option current-page scope, workspace live-scope mapping, no work on mount/cancel, retry, final manifest rejection, context-switch cancellation, stale model/serialization suppression, focus restoration, and filesystem-safe filename length
- final `mix-gpt-5.6` review at `xhigh` reasoning: P1 0, P2 0, P3 0 across the complete 14-file snapshot
- Code Review Graph risk: medium at the existing evaluation composition boundary; GitNexus affected only existing P12 evaluation processes
- semantic dedup reused the existing collector, model builder, serializer, and shared download primitive

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- P14 app regressions: 64 passed
- P14 Excel/shared workbook regressions: 25 passed
- Equipment/evaluation/ranking regressions: 104 passed
- P14 RPC contract regressions: 34 passed
- React Doctor: 100/100, no findings
- `openspec validate add-technical-configuration-comparison --strict`
- `git diff --check`
- Lefthook pre-commit and pre-push gates

Closes #845

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates Excel result export in the technical configuration evaluation workspace. Implements P14C2 (#845) by mounting a leaf control at the active workspace and orchestrating one snapshot‑stable workbook download.

- **New Features**
  - Mounted `TechnicalConfigurationResultExportControl` in `TechnicalConfigurationEvaluationActiveWorkspace`; derives `generated_by` from `next-auth` with a safe fallback.
  - Added `useTechnicalConfigurationResultExport` to collect P14 data, build and serialize the workbook, and call `downloadBlob()` once after final manifest revalidation; cancels stale runs on dossier/baseline changes with commit‑synchronous cleanup.
  - UX/tests: loading and typed alerts with retry; filesystem‑safe, deterministic filenames within 255 bytes; preserved navigator state while exporting the selected option and current criterion page; no work on mount/cancel.

- **Bug Fixes**
  - Hide and block a redundant “current option page” scope; reset unavailable scopes to “All” when pagination changes or page scopes disappear while identity stays the same, keeping an all‑options fallback.

<sup>Written for commit 83b81d82884ffbe13bb1a4ea4f4d6d08370a7f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added result export controls to technical configuration evaluations.
  * Export results for the selected option, all options, or the current criteria page.
  * Track export progress, completion, cancellation, errors, and retries.
  * Download results with generated, filesystem-safe filenames.

* **Bug Fixes**
  * Prevented redundant current-page export options when all options are visible.
  * Automatically falls back to all options when page context changes.

* **Tests**
  * Added coverage for export workflows, navigation preservation, failures, retries, cancellation, and downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->