### PR TITLE
feat(technical-configurations): unify comparison and evaluation matrix

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
@@ -415,17 +415,11 @@ describe("P10B2 pinned matrix columns", () => {
     expect(evaluationButton).toHaveTextContent("Đánh giá")
     await user.click(evaluationButton)
 
-    expect(onOpenEvaluation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        optionId: "option-b",
-        criterionId: "criterion-2",
-        detail: expect.objectContaining({
-          criterionCode: "TS-02",
-          optionLabel: "Nhà cung cấp B · Phương án B",
-        }),
-        trigger: evaluationButton,
-      })
-    )
+    expect(onOpenEvaluation).toHaveBeenCalledWith({
+      optionId: "option-b",
+      criterionId: "criterion-2",
+      trigger: evaluationButton,
+    })
   })
 
   it("renders only the focused option while preserving stable desktop dimensions", () => {

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
@@ -364,6 +364,70 @@ describe("P10B2 pinned matrix columns", () => {
     )
   })
 
+  it("opens supplier cells as evaluation targets and marks the active filtered criterion", async () => {
+    const user = userEvent.setup()
+    const result = createComparisonResult()
+    const onOpenEvaluation = vi.fn()
+
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={result}
+        visibleOptionIds={result.data.options.map((option) => option.id)}
+        pinnedOptionIds={[]}
+        focusedOptionId={null}
+        activeEvaluationOptionId="option-b"
+        activeEvaluationCriterionId="criterion-2"
+        assessmentStatusByCriterionId={new Map([["criterion-2", "meets"]])}
+        matchingEvaluationCriterionIds={new Set(["criterion-2"])}
+        onOpenDetail={vi.fn()}
+        onOpenEvaluation={onOpenEvaluation}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    const evaluationCell = screen
+      .getAllByTestId("comparison-option-cell")
+      .find(
+        (cell) => cell.dataset.optionId === "option-b" && cell.dataset.criterionId === "criterion-2"
+      )
+    expect(evaluationCell).toHaveAttribute("data-evaluation-active", "true")
+    expect(evaluationCell).toHaveAttribute("data-filter-match", "true")
+    expect(evaluationCell).toHaveTextContent("Đạt")
+
+    const unmatchedEvaluationCell = screen
+      .getAllByTestId("comparison-option-cell")
+      .find(
+        (cell) => cell.dataset.optionId === "option-b" && cell.dataset.criterionId === "criterion-1"
+      )
+    expect(unmatchedEvaluationCell).toHaveAttribute("data-filter-match", "false")
+    expect(
+      screen.getByRole("button", {
+        name: "Đánh giá TS-01 · Nhà cung cấp B · Phương án B",
+      })
+    ).toBeEnabled()
+
+    const evaluationButton = screen.getByRole("button", {
+      name: "Đánh giá TS-02 · Nhà cung cấp B · Phương án B",
+    })
+    expect(evaluationButton).toHaveAttribute("data-testid", "matrix-evaluation-action")
+    expect(evaluationButton).toHaveTextContent("Đánh giá")
+    await user.click(evaluationButton)
+
+    expect(onOpenEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        optionId: "option-b",
+        criterionId: "criterion-2",
+        detail: expect.objectContaining({
+          criterionCode: "TS-02",
+          optionLabel: "Nhà cung cấp B · Phương án B",
+        }),
+        trigger: evaluationButton,
+      })
+    )
+  })
+
   it("renders only the focused option while preserving stable desktop dimensions", () => {
     const result = createManyOptionResult()
     render(

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
@@ -364,10 +364,8 @@ describe("P10B2 pinned matrix columns", () => {
     )
   })
 
-  it("opens supplier cells as evaluation targets and marks the active filtered criterion", async () => {
-    const user = userEvent.setup()
+  it("marks the active filtered criterion and exposes evaluation actions", () => {
     const result = createComparisonResult()
-    const onOpenEvaluation = vi.fn()
 
     render(
       <TechnicalConfigurationMatrix
@@ -381,7 +379,7 @@ describe("P10B2 pinned matrix columns", () => {
         assessmentStatusByCriterionId={new Map([["criterion-2", "meets"]])}
         matchingEvaluationCriterionIds={new Set(["criterion-2"])}
         onOpenDetail={vi.fn()}
-        onOpenEvaluation={onOpenEvaluation}
+        onOpenEvaluation={vi.fn()}
         onPageChange={vi.fn()}
         onRetry={vi.fn()}
       />
@@ -407,19 +405,6 @@ describe("P10B2 pinned matrix columns", () => {
         name: "Đánh giá TS-01 · Nhà cung cấp B · Phương án B",
       })
     ).toBeEnabled()
-
-    const evaluationButton = screen.getByRole("button", {
-      name: "Đánh giá TS-02 · Nhà cung cấp B · Phương án B",
-    })
-    expect(evaluationButton).toHaveAttribute("data-testid", "matrix-evaluation-action")
-    expect(evaluationButton).toHaveTextContent("Đánh giá")
-    await user.click(evaluationButton)
-
-    expect(onOpenEvaluation).toHaveBeenCalledWith({
-      optionId: "option-b",
-      criterionId: "criterion-2",
-      trigger: evaluationButton,
-    })
   })
 
   it("renders only the focused option while preserving stable desktop dimensions", () => {

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
@@ -1,8 +1,10 @@
 import "@testing-library/jest-dom"
+import type { ReactNode } from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationEvaluationActiveWorkspace } from "../_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace"
+import type { TechnicalConfigurationComparisonResult } from "../comparison-types"
 import {
   createComparisonResult,
   createOption,
@@ -13,9 +15,54 @@ type MatrixState = ReturnType<
   typeof import("../_hooks/useTechnicalConfigurationComparisonMatrix").useTechnicalConfigurationComparisonMatrix
 >
 
-const mocks = vi.hoisted(() => ({
-  comparisonRequests: [] as Array<{ optionIds: string[]; page: number }>,
-}))
+type ComparisonRequest = { optionIds: string[]; page: number }
+
+const mocks = vi.hoisted(() => {
+  let comparisonRequests: ComparisonRequest[] = []
+  let page = 1
+  let panelResult: TechnicalConfigurationComparisonResult | undefined
+  let isTransitionPending = false
+  let isSaving = false
+
+  return {
+    recordComparisonRequest(request: ComparisonRequest) {
+      comparisonRequests = [...comparisonRequests, request]
+    },
+    getComparisonRequests() {
+      return comparisonRequests
+    },
+    getPage() {
+      return page
+    },
+    getPanelResult() {
+      return panelResult
+    },
+    getIsTransitionPending() {
+      return isTransitionPending
+    },
+    getIsSaving() {
+      return isSaving
+    },
+    setScenario(scenario: {
+      page?: number
+      panelResult?: TechnicalConfigurationComparisonResult
+      isTransitionPending?: boolean
+      isSaving?: boolean
+    }) {
+      page = scenario.page ?? page
+      if ("panelResult" in scenario) panelResult = scenario.panelResult
+      isTransitionPending = scenario.isTransitionPending ?? isTransitionPending
+      isSaving = scenario.isSaving ?? isSaving
+    },
+    reset() {
+      comparisonRequests = []
+      page = 1
+      panelResult = undefined
+      isTransitionPending = false
+      isSaving = false
+    },
+  }
+})
 
 vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
   useTechnicalConfigurationComparison: ({
@@ -25,10 +72,10 @@ vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
     optionIds: readonly string[]
     page: number
   }) => {
-    mocks.comparisonRequests.push({ optionIds: [...optionIds], page })
+    mocks.recordComparisonRequest({ optionIds: [...optionIds], page })
     return {
       comparisonQuery: {
-        data: undefined,
+        data: optionIds[0] ? mocks.getPanelResult() : undefined,
         isLoading: false,
         isError: false,
         error: null,
@@ -41,12 +88,12 @@ vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
 vi.mock("../_hooks/useTechnicalConfigurationEvaluationNavigator", () => ({
   useTechnicalConfigurationEvaluationNavigator: () => ({
     activeSelectedOptionId: "option-1",
-    currentCriterion: { canonicalPage: 1 },
-    criterionId: "criterion-1",
+    currentCriterion: { canonicalPage: mocks.getPage() },
+    criterionId: mocks.getPage() === 1 ? "criterion-1" : "criterion-3",
     selectedOption: createOption("option-1", "Nhà cung cấp A · Model A"),
     projection: [],
     statusFilter: "all",
-    isTransitionPending: false,
+    isTransitionPending: mocks.getIsTransitionPending(),
     criteriaQuery: {
       isLoading: false,
       isError: false,
@@ -65,7 +112,7 @@ vi.mock("../_hooks/useTechnicalConfigurationEvaluationDraft", () => ({
     comparisonSetQuery: { isLoading: false, isError: false, error: null },
     assessmentsByCriterionId: {},
     draft: null,
-    isSaving: false,
+    isSaving: mocks.getIsSaving(),
     isReady: false,
     error: null,
     discard: vi.fn(),
@@ -118,25 +165,35 @@ vi.mock("../_components/evaluation/TechnicalConfigurationResultExportControl", (
   TechnicalConfigurationResultExportControl: () => null,
 }))
 vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationSaveActions", () => ({
-  TechnicalConfigurationEvaluationSaveActions: () => null,
+  TechnicalConfigurationEvaluationSaveActions: ({ saving }: { saving: boolean }) => (
+    <div data-testid="save-actions-probe" data-saving={saving ? "true" : "false"} />
+  ),
 }))
 vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationPanel", () => ({
   TechnicalConfigurationEvaluationPanel: ({
     detail,
+    actions,
   }: {
     detail: { criterionCode: string } | null
-  }) => <div data-testid="evaluation-panel-probe">{detail?.criterionCode ?? "none"}</div>,
+    actions: ReactNode
+  }) => (
+    <>
+      <div data-testid="evaluation-panel-probe">{detail?.criterionCode ?? "none"}</div>
+      {actions}
+    </>
+  ),
 }))
 
 describe("technical configuration evaluation active workspace regressions", () => {
   beforeEach(() => {
-    mocks.comparisonRequests = []
+    mocks.reset()
   })
 
-  function renderWorkspace(matrixOptionId: string) {
-    const result = createComparisonResult(1, matrixOptionId)
+  function renderWorkspace(matrixOptionId: string, page = 2): void {
+    mocks.setScenario({ page })
+    const result = createComparisonResult(page, matrixOptionId)
     const matrix = {
-      page: 1,
+      page,
       comparison: {
         comparisonQuery: {
           data: result,
@@ -170,14 +227,29 @@ describe("technical configuration evaluation active workspace regressions", () =
   it("reuses the active matrix page for the open evaluation criterion", () => {
     renderWorkspace("option-1")
 
-    expect(mocks.comparisonRequests).toContainEqual({ optionIds: [], page: 1 })
-    expect(mocks.comparisonRequests).not.toContainEqual({ optionIds: ["option-1"], page: 1 })
-    expect(screen.getByTestId("evaluation-panel-probe")).toHaveTextContent("TC-01")
+    expect(mocks.getComparisonRequests()).toContainEqual({ optionIds: [], page: 2 })
+    expect(mocks.getComparisonRequests()).not.toContainEqual({
+      optionIds: ["option-1"],
+      page: 2,
+    })
+    expect(screen.getByTestId("evaluation-panel-probe")).toHaveTextContent("TC-03")
   })
 
   it("loads panel comparison data when the active supplier is not in the matrix result", () => {
+    mocks.setScenario({
+      page: 2,
+      panelResult: createComparisonResult(2, "option-1"),
+    })
     renderWorkspace("option-2")
 
-    expect(mocks.comparisonRequests).toContainEqual({ optionIds: ["option-1"], page: 1 })
+    expect(mocks.getComparisonRequests()).toContainEqual({ optionIds: ["option-1"], page: 2 })
+    expect(screen.getByTestId("evaluation-panel-probe")).toHaveTextContent("TC-03")
+  })
+
+  it("does not announce saving for a navigation-only transition", () => {
+    mocks.setScenario({ page: 2, isTransitionPending: true })
+    renderWorkspace("option-1")
+
+    expect(screen.getByTestId("save-actions-probe")).toHaveAttribute("data-saving", "false")
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
@@ -1,0 +1,183 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationEvaluationActiveWorkspace } from "../_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace"
+import {
+  createComparisonResult,
+  createOption,
+  dossier,
+} from "./technical-configuration-evaluation-workspace.test-support"
+
+type MatrixState = ReturnType<
+  typeof import("../_hooks/useTechnicalConfigurationComparisonMatrix").useTechnicalConfigurationComparisonMatrix
+>
+
+const mocks = vi.hoisted(() => ({
+  comparisonRequests: [] as Array<{ optionIds: string[]; page: number }>,
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
+  useTechnicalConfigurationComparison: ({
+    optionIds,
+    page,
+  }: {
+    optionIds: readonly string[]
+    page: number
+  }) => {
+    mocks.comparisonRequests.push({ optionIds: [...optionIds], page })
+    return {
+      comparisonQuery: {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    }
+  },
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationEvaluationNavigator", () => ({
+  useTechnicalConfigurationEvaluationNavigator: () => ({
+    activeSelectedOptionId: "option-1",
+    currentCriterion: { canonicalPage: 1 },
+    criterionId: "criterion-1",
+    selectedOption: createOption("option-1", "Nhà cung cấp A · Model A"),
+    projection: [],
+    statusFilter: "all",
+    isTransitionPending: false,
+    criteriaQuery: {
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    },
+    isCurrentCriterionFilteredOut: false,
+    hasNoMoreMatches: false,
+    isPanelOpen: true,
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationEvaluationDraft", () => ({
+  useTechnicalConfigurationEvaluationDraft: () => ({
+    assessmentQuery: { isLoading: false, isError: false, error: null },
+    comparisonSetQuery: { isLoading: false, isError: false, error: null },
+    assessmentsByCriterionId: {},
+    draft: null,
+    isSaving: false,
+    isReady: false,
+    error: null,
+    discard: vi.fn(),
+    setTechnicalAxis: vi.fn(),
+    setEvidenceAxis: vi.fn(),
+    setNotes: vi.fn(),
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationGuardedNavigation", () => ({
+  useTechnicalConfigurationGuardedNavigation: () => ({
+    requestNavigation: vi.fn(),
+    discardConfirmationDialog: null,
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationEvaluationWorkspaceActions", () => ({
+  useTechnicalConfigurationEvaluationWorkspaceActions: () => ({
+    handleOptionChange: vi.fn(),
+    handleFilterChange: vi.fn(),
+    handleOpenEvaluation: vi.fn(),
+    handleMatrixPageChange: vi.fn(),
+    handleSave: vi.fn(),
+    handleSaveAndContinue: vi.fn(),
+    handleRetryEvaluationData: vi.fn(),
+    closeEvaluationPanel: vi.fn(),
+    runMatrixContextChange: vi.fn(),
+  }),
+}))
+
+vi.mock("../_components/comparison/TechnicalConfigurationCriterionPanel", () => ({
+  TechnicalConfigurationCriterionPanel: () => null,
+}))
+vi.mock("../_components/comparison/TechnicalConfigurationMatrix", () => ({
+  TechnicalConfigurationMatrix: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationFeedback", () => ({
+  TechnicalConfigurationEvaluationFeedback: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationMatrixControls", () => ({
+  TechnicalConfigurationEvaluationMatrixControls: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar", () => ({
+  TechnicalConfigurationEvaluationMatrixToolbar: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationProgressSummary", () => ({
+  TechnicalConfigurationProgressSummary: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationResultExportControl", () => ({
+  TechnicalConfigurationResultExportControl: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationSaveActions", () => ({
+  TechnicalConfigurationEvaluationSaveActions: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationPanel", () => ({
+  TechnicalConfigurationEvaluationPanel: ({
+    detail,
+  }: {
+    detail: { criterionCode: string } | null
+  }) => <div data-testid="evaluation-panel-probe">{detail?.criterionCode ?? "none"}</div>,
+}))
+
+describe("technical configuration evaluation active workspace regressions", () => {
+  beforeEach(() => {
+    mocks.comparisonRequests = []
+  })
+
+  function renderWorkspace(matrixOptionId: string) {
+    const result = createComparisonResult(1, matrixOptionId)
+    const matrix = {
+      page: 1,
+      comparison: {
+        comparisonQuery: {
+          data: result,
+          isLoading: false,
+          isError: false,
+          error: null,
+          refetch: vi.fn(),
+        },
+      },
+      baselineVersionId: "baseline-1",
+      selectedOptionIds: ["option-1"],
+      visibleOptionIds: ["option-1"],
+      pinnedOptionIds: [],
+      focusedOptionId: null,
+      selectedOptions: result.data.options,
+    } as unknown as MatrixState
+
+    render(
+      <TechnicalConfigurationEvaluationActiveWorkspace
+        dossier={dossier}
+        baselineVersionId="baseline-1"
+        baselineGroups={[]}
+        options={[createOption("option-1", "Nhà cung cấp A · Model A")]}
+        matrix={matrix}
+        onDirtyChange={vi.fn()}
+        onNavigationBlockedChange={vi.fn()}
+      />
+    )
+  }
+
+  it("reuses the active matrix page for the open evaluation criterion", () => {
+    renderWorkspace("option-1")
+
+    expect(mocks.comparisonRequests).toContainEqual({ optionIds: [], page: 1 })
+    expect(mocks.comparisonRequests).not.toContainEqual({ optionIds: ["option-1"], page: 1 })
+    expect(screen.getByTestId("evaluation-panel-probe")).toHaveTextContent("TC-01")
+  })
+
+  it("loads panel comparison data when the active supplier is not in the matrix result", () => {
+    renderWorkspace("option-2")
+
+    expect(mocks.comparisonRequests).toContainEqual({ optionIds: ["option-1"], page: 1 })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
@@ -228,6 +228,7 @@ describe("P12A1 evaluation core composition", () => {
         "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx",
         "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx",
         "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts",
+        "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts",
       ].sort()
     )
   })

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-feedback-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-feedback-regressions.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationEvaluationFeedback } from "../_components/evaluation/TechnicalConfigurationEvaluationFeedback"
+import { TechnicalConfigurationEvaluationMatrixControls } from "../_components/evaluation/TechnicalConfigurationEvaluationMatrixControls"
+import { TechnicalConfigurationEvaluationSaveActions } from "../_components/evaluation/TechnicalConfigurationEvaluationSaveActions"
+
+describe("technical configuration evaluation feedback regressions", () => {
+  it("announces panel loading and keeps panel errors scoped to an open panel", () => {
+    const props = {
+      isPanelLoading: true,
+      isPanelError: true,
+      panelError: new Error("panel failed"),
+      onRetryPanel: vi.fn(),
+      hasEvaluationReadError: false,
+      evaluationReadError: null,
+      onRetryEvaluation: vi.fn(),
+    }
+    const { rerender } = render(
+      <TechnicalConfigurationEvaluationFeedback {...props} isPanelOpen={false} />
+    )
+
+    expect(screen.queryByText("Đang tải tiêu chí...")).not.toBeInTheDocument()
+    expect(screen.queryByText("Không thể tải tiêu chí đánh giá")).not.toBeInTheDocument()
+
+    rerender(<TechnicalConfigurationEvaluationFeedback {...props} isPanelOpen />)
+
+    expect(screen.getByRole("status")).toHaveTextContent("Đang tải tiêu chí...")
+    expect(screen.getByText("Không thể tải tiêu chí đánh giá")).toBeInTheDocument()
+  })
+
+  it("explains an empty evaluation flow and only offers reset for an active filter", () => {
+    const props = {
+      options: [],
+      activeOptionId: "",
+      onOptionChange: vi.fn(),
+      onStatusFilterChange: vi.fn(),
+      disabled: false,
+      isLoading: false,
+      isError: false,
+      error: null,
+      onRetry: vi.fn(),
+      totalMatches: 0,
+      isCurrentCriterionFilteredOut: false,
+      hasNoMoreMatches: false,
+    }
+    const { rerender } = render(
+      <TechnicalConfigurationEvaluationMatrixControls {...props} statusFilter="all" />
+    )
+
+    expect(
+      screen.getByText("Phiên bản cấu hình này chưa có tiêu chí để đánh giá.")
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Xóa bộ lọc" })).not.toBeInTheDocument()
+
+    rerender(<TechnicalConfigurationEvaluationMatrixControls {...props} statusFilter="fails" />)
+
+    expect(screen.getByText("Không có tiêu chí nào khớp bộ lọc đang chọn.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Xóa bộ lọc" })).toBeEnabled()
+  })
+
+  it("announces the pending save state", () => {
+    render(
+      <TechnicalConfigurationEvaluationSaveActions
+        disabled
+        saving
+        onSave={vi.fn()}
+        onSaveAndContinue={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent("Đang lưu đánh giá...")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-matrix-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-matrix-regressions.test.tsx
@@ -58,11 +58,11 @@ describe("technical configuration evaluation matrix regressions", () => {
       />
     )
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "Xem chi tiết TS-02 · Nhà cung cấp B · Phương án B",
-      })
-    )
+    const detailButton = screen.getByRole("button", {
+      name: "Xem chi tiết TS-02 · Nhà cung cấp B · Phương án B",
+    })
+    expect(detailButton.querySelector("div, p")).toBeNull()
+    await user.click(detailButton)
     expect(onOpenDetail).toHaveBeenCalledWith(
       expect.objectContaining({
         criterionCode: "TS-02",

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-matrix-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-matrix-regressions.test.tsx
@@ -1,0 +1,84 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+import { createComparisonResult } from "./comparison-matrix-test-fixtures"
+
+describe("technical configuration evaluation matrix regressions", () => {
+  it("disables the empty-page previous action while evaluation navigation is blocked", () => {
+    const result = createComparisonResult()
+
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={{
+          ...result,
+          page: 2,
+          data: {
+            ...result.data,
+            criteria: [],
+          },
+        }}
+        visibleOptionIds={result.data.options.map((option) => option.id)}
+        pinnedOptionIds={[]}
+        focusedOptionId={null}
+        evaluationDisabled
+        onOpenDetail={vi.fn()}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Trang trước" })).toBeDisabled()
+  })
+
+  it("keeps read-only detail and evaluation as separate supplier-cell actions", async () => {
+    const user = userEvent.setup()
+    const result = createComparisonResult()
+    const onOpenDetail = vi.fn()
+    const onOpenEvaluation = vi.fn()
+
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={result}
+        visibleOptionIds={result.data.options.map((option) => option.id)}
+        pinnedOptionIds={[]}
+        focusedOptionId={null}
+        activeEvaluationOptionId="option-b"
+        activeEvaluationCriterionId="criterion-2"
+        assessmentStatusByCriterionId={new Map([["criterion-2", "meets"]])}
+        matchingEvaluationCriterionIds={new Set(["criterion-2"])}
+        onOpenDetail={onOpenDetail}
+        onOpenEvaluation={onOpenEvaluation}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Xem chi tiết TS-02 · Nhà cung cấp B · Phương án B",
+      })
+    )
+    expect(onOpenDetail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        criterionCode: "TS-02",
+        optionLabel: "Nhà cung cấp B · Phương án B",
+      })
+    )
+
+    const evaluationButton = screen.getByRole("button", {
+      name: "Đánh giá TS-02 · Nhà cung cấp B · Phương án B",
+    })
+    await user.click(evaluationButton)
+
+    expect(onOpenEvaluation).toHaveBeenCalledWith({
+      optionId: "option-b",
+      criterionId: "criterion-2",
+      trigger: evaluationButton,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-navigation-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-navigation-regressions.test.tsx
@@ -1,0 +1,82 @@
+import "@testing-library/jest-dom"
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationEvaluationMatrixToolbar } from "../_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar"
+import { useTechnicalConfigurationEvaluationTransition } from "../_hooks/useTechnicalConfigurationEvaluationTransition"
+
+type MatrixState = ReturnType<
+  typeof import("../_hooks/useTechnicalConfigurationComparisonMatrix").useTechnicalConfigurationComparisonMatrix
+>
+
+vi.mock("../_components/comparison/TechnicalConfigurationMatrixToolbar", () => ({
+  TechnicalConfigurationMatrixToolbar: ({ onExitFocus }: { onExitFocus: () => void }) => (
+    <button type="button" onClick={onExitFocus}>
+      Thoát chế độ tập trung
+    </button>
+  ),
+}))
+
+describe("technical configuration evaluation navigation regressions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("logs a rejected transition and allows the same navigation to be retried", async () => {
+    const transitionError = new Error("candidate load failed")
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const transition = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(transitionError)
+      .mockResolvedValueOnce()
+    const { result } = renderHook(() => useTechnicalConfigurationEvaluationTransition())
+
+    await act(async () => {
+      await result.current.startTransition(transition)
+    })
+    await act(async () => {
+      await result.current.startTransition(transition)
+    })
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Technical configuration evaluation transition failed.",
+      transitionError
+    )
+    expect(transition).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(result.current.isTransitionPending).toBe(false))
+  })
+
+  it("guards focus exit when restoring columns would hide the active supplier", async () => {
+    const user = userEvent.setup()
+    const exitFocusMode = vi.fn()
+    const runContextChange = vi.fn((change: () => void) => change())
+    const matrix = {
+      baselineVersionId: "baseline-1",
+      versions: [],
+      versionsQuery: {},
+      options: [],
+      optionsQuery: {},
+      selectedOptions: [],
+      visibleOptionIds: ["option-1"],
+      pinnedOptionIds: [],
+      focusedOptionId: "option-2",
+      isSelectionLimitReached: false,
+      exitFocusMode,
+    } as unknown as MatrixState
+
+    render(
+      <TechnicalConfigurationEvaluationMatrixToolbar
+        matrix={matrix}
+        activeOptionId="option-2"
+        navigationBlocked
+        runContextChange={runContextChange}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Thoát chế độ tập trung" }))
+
+    expect(runContextChange).toHaveBeenCalledTimes(1)
+    expect(exitFocusMode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
@@ -126,7 +126,6 @@ describe("technical configuration unified comparison and evaluation workspace", 
 
     await user.click(screen.getByRole("button", { name: "Mark evaluation pending" }))
     await waitFor(() => expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
-    expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { TechnicalConfigurationDossierWire } from "../types"
 import { TechnicalConfigurationComparisonTab } from "../_components/comparison/TechnicalConfigurationComparisonTab"
-import type { TechnicalConfigurationCriterionDetail } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
 
 const mocks = vi.hoisted(() => ({
   onDirtyChange: vi.fn(),
@@ -48,53 +47,6 @@ vi.mock("../_hooks/useTechnicalConfigurationComparisonMatrix", () => ({
   }),
 }))
 
-vi.mock("../_components/comparison/TechnicalConfigurationMatrixToolbar", () => ({
-  TechnicalConfigurationMatrixToolbar: () => <div>Matrix toolbar</div>,
-}))
-
-vi.mock("../_components/comparison/TechnicalConfigurationMatrix", () => ({
-  TechnicalConfigurationMatrix: ({
-    onOpenDetail,
-  }: {
-    onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
-  }) => (
-    <div>
-      <span>Matrix view</span>
-      <button
-        type="button"
-        onClick={() =>
-          onOpenDetail({
-            criterionCode: "TS-01",
-            criterionTitle: "Cấu hình chung",
-            optionLabel: null,
-            requirementText: "Yêu cầu cấu hình.",
-            responseText: null,
-            supplementaryInformation: null,
-            evidence: {
-              documentCount: 0,
-              citationCount: 0,
-              hasEvidence: false,
-            },
-            evidenceTarget: {
-              kind: "baseline",
-              baselineVersionId: "baseline-1",
-              criterionId: "criterion-1",
-            },
-          })
-        }
-      >
-        Mở chi tiết ma trận
-      </button>
-    </div>
-  ),
-}))
-
-vi.mock("../_components/comparison/TechnicalConfigurationCriterionPanel", () => ({
-  TechnicalConfigurationCriterionPanel: ({ open }: { open: boolean }) => (
-    <div data-testid="matrix-detail-state">{open ? "open" : "closed"}</div>
-  ),
-}))
-
 vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationWorkspace", () => ({
   TechnicalConfigurationEvaluationWorkspace: ({
     onDirtyChange,
@@ -106,6 +58,8 @@ vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationWorkspace", (
     onRevisionChange?: (revision: number) => void
   }) => (
     <div>
+      <span>Matrix toolbar</span>
+      <span>Matrix view</span>
       <span>Evaluation view</span>
       <button type="button" onClick={() => onDirtyChange?.(true)}>
         Mark evaluation dirty
@@ -145,56 +99,34 @@ function renderComparisonTab() {
   )
 }
 
-describe("P12A2 comparison evaluation mode", () => {
+describe("technical configuration unified comparison and evaluation workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it("guards dirty internal mode changes and discards only after confirmation", async () => {
+  it("renders matrix and evaluation content together without internal mode tabs", () => {
+    renderComparisonTab()
+
+    expect(screen.getByText("Matrix toolbar")).toBeInTheDocument()
+    expect(screen.getByText("Matrix view")).toBeInTheDocument()
+    expect(screen.getByText("Evaluation view")).toBeInTheDocument()
+    expect(screen.queryByRole("tab", { name: "Ma trận" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("tab", { name: "Đánh giá" })).not.toBeInTheDocument()
+  })
+
+  it("forwards dirty, save-pending and revision state from the unified workspace", async () => {
     const user = userEvent.setup()
     renderComparisonTab()
 
-    expect(screen.getByText("Matrix view")).toBeInTheDocument()
-    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
     await user.click(screen.getByRole("button", { name: "Mark evaluation dirty" }))
     await waitFor(() => expect(mocks.onDirtyChange).toHaveBeenLastCalledWith(true))
 
-    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
-    expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
-    await user.click(screen.getByRole("button", { name: "Hủy" }))
-    expect(screen.getByRole("tab", { name: "Đánh giá" })).toHaveAttribute("data-state", "active")
-
-    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
-    await user.click(screen.getByRole("button", { name: "Bỏ thay đổi" }))
-
-    expect(screen.getByRole("tab", { name: "Ma trận" })).toHaveAttribute("data-state", "active")
-    await waitFor(() => expect(mocks.onDirtyChange).toHaveBeenLastCalledWith(false))
-  })
-
-  it("hard-blocks mode changes during save and forwards workspace revision", async () => {
-    const user = userEvent.setup()
-    renderComparisonTab()
-
-    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
     await user.click(screen.getByRole("button", { name: "Bump evaluation revision" }))
     expect(mocks.onRevisionChange).toHaveBeenCalledWith(9)
 
     await user.click(screen.getByRole("button", { name: "Mark evaluation pending" }))
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Ma trận" })).toBeDisabled())
+    await waitFor(() => expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
     expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
-  })
-
-  it("does not reopen stale matrix detail after returning from evaluation mode", async () => {
-    const user = userEvent.setup()
-    renderComparisonTab()
-
-    await user.click(screen.getByRole("button", { name: "Mở chi tiết ma trận" }))
-    expect(screen.getByTestId("matrix-detail-state")).toHaveTextContent("open")
-
-    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
-    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
-
-    expect(screen.getByTestId("matrix-detail-state")).toHaveTextContent("closed")
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-matrix-presentation.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-matrix-presentation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../baseline-types"
+import { buildTechnicalConfigurationEvaluationMatrixPresentation } from "../_components/evaluation/technical-configuration-evaluation-matrix-presentation"
+
+const TIMESTAMP = "2026-08-04T00:00:00.000Z"
+
+function createAssessment(
+  criterionId: string,
+  technicalAxis: TechnicalConfigurationAssessmentWire["technical_axis"],
+  evidenceAxis: TechnicalConfigurationAssessmentWire["evidence_axis"]
+): TechnicalConfigurationAssessmentWire {
+  return {
+    id: `assessment-${criterionId}`,
+    comparison_set_id: "comparison-set-1",
+    baseline_version_id: "baseline-1",
+    criterion_id: criterionId,
+    technical_axis: technicalAxis,
+    evidence_axis: evidenceAxis,
+    notes: "",
+    revision: 1,
+    created_by: 1,
+    created_at: TIMESTAMP,
+    updated_by: 1,
+    updated_at: TIMESTAMP,
+  }
+}
+
+const groups: TechnicalConfigurationBaselineGroupWire[] = [
+  {
+    id: "group-1",
+    baseline_version_id: "baseline-1",
+    name: "Nhóm 1",
+    sort_order: 1,
+    created_at: TIMESTAMP,
+    created_by: 1,
+    updated_at: TIMESTAMP,
+    updated_by: 1,
+    criteria: [
+      {
+        id: "criterion-1",
+        baseline_version_id: "baseline-1",
+        group_id: "group-1",
+        criterion_code: "TC-01",
+        title: "Tiêu chí 1",
+        requirement_text: "Yêu cầu 1",
+        sort_order: 1,
+        source_criterion_id: null,
+        created_at: TIMESTAMP,
+        created_by: 1,
+        updated_at: TIMESTAMP,
+        updated_by: 1,
+      },
+      {
+        id: "criterion-2",
+        baseline_version_id: "baseline-1",
+        group_id: "group-1",
+        criterion_code: "TC-02",
+        title: "Tiêu chí 2",
+        requirement_text: "Yêu cầu 2",
+        sort_order: 2,
+        source_criterion_id: null,
+        created_at: TIMESTAMP,
+        created_by: 1,
+        updated_at: TIMESTAMP,
+        updated_by: 1,
+      },
+    ],
+  },
+]
+
+describe("buildTechnicalConfigurationEvaluationMatrixPresentation", () => {
+  it("builds progress and row statuses from the same assessment collection", () => {
+    const assessment = createAssessment("criterion-1", "meets", "complete")
+
+    const presentation = buildTechnicalConfigurationEvaluationMatrixPresentation({
+      groups,
+      assessmentsByCriterionId: { "criterion-1": assessment },
+      projection: [],
+      statusFilter: "all",
+    })
+
+    expect(presentation.progress).toMatchObject({
+      total: 2,
+      evaluated: 1,
+      statusCounts: {
+        meets: 1,
+        not_evaluated: 1,
+      },
+    })
+    expect(presentation.assessmentStatusByCriterionId.get("criterion-1")).toBe("meets")
+    expect(presentation.matchingEvaluationCriterionIds).toBeUndefined()
+  })
+
+  it("limits matrix actions to criteria returned by an active evaluation filter", () => {
+    const presentation = buildTechnicalConfigurationEvaluationMatrixPresentation({
+      groups,
+      assessmentsByCriterionId: {},
+      projection: [{ criterion: { id: "criterion-2" } }],
+      statusFilter: "not_evaluated",
+    })
+
+    expect(presentation.matchingEvaluationCriterionIds).toEqual(new Set(["criterion-2"]))
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.matrix-test-adapter.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.matrix-test-adapter.tsx
@@ -1,0 +1,81 @@
+import type { ComponentProps } from "react"
+
+import type { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+
+type MatrixProps = ComponentProps<typeof TechnicalConfigurationMatrix>
+
+export function TechnicalConfigurationEvaluationMatrixTestAdapter({
+  result,
+  activeEvaluationOptionId,
+  activeEvaluationCriterionId,
+  matchingEvaluationCriterionIds,
+  evaluationDisabled,
+  onOpenEvaluation,
+  onPageChange,
+}: MatrixProps) {
+  if (!result || !activeEvaluationOptionId || !onOpenEvaluation) return null
+
+  const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize))
+
+  return (
+    <div>
+      {result.data.criteria.map((row) => (
+        <button
+          key={row.criterion.id}
+          type="button"
+          data-testid="evaluation-criterion"
+          data-criterion-id={row.criterion.id}
+          data-filter-match={
+            matchingEvaluationCriterionIds?.has(row.criterion.id) ? "true" : "false"
+          }
+          aria-current={row.criterion.id === activeEvaluationCriterionId ? "true" : undefined}
+          disabled={evaluationDisabled}
+          onClick={(event) =>
+            onOpenEvaluation({
+              optionId: activeEvaluationOptionId,
+              criterionId: row.criterion.id,
+              detail: {
+                criterionCode: row.criterion.criterionCode,
+                criterionTitle: row.criterion.title,
+                optionLabel: result.data.options[0]?.displayLabel ?? null,
+                requirementText: row.requirementText,
+                responseText: null,
+                supplementaryInformation: null,
+                evidence: {
+                  documentCount: 0,
+                  citationCount: 0,
+                  hasEvidence: false,
+                },
+                evidenceTarget: {
+                  kind: "option",
+                  optionId: activeEvaluationOptionId,
+                  criterionId: row.criterion.id,
+                },
+              },
+              trigger: event.currentTarget,
+            })
+          }
+        >
+          {row.criterion.criterionCode}
+        </button>
+      ))}
+      <span>{`Trang ${result.page}/${totalPages}`}</span>
+      <button
+        type="button"
+        aria-label="Trang trước"
+        disabled={evaluationDisabled || result.page <= 1}
+        onClick={() => onPageChange(result.page - 1)}
+      >
+        Trang trước
+      </button>
+      <button
+        type="button"
+        aria-label="Trang tiếp theo"
+        disabled={evaluationDisabled || result.page >= totalPages}
+        onClick={() => onPageChange(result.page + 1)}
+      >
+        Trang tiếp theo
+      </button>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.matrix-test-adapter.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.matrix-test-adapter.tsx
@@ -34,24 +34,6 @@ export function TechnicalConfigurationEvaluationMatrixTestAdapter({
             onOpenEvaluation({
               optionId: activeEvaluationOptionId,
               criterionId: row.criterion.id,
-              detail: {
-                criterionCode: row.criterion.criterionCode,
-                criterionTitle: row.criterion.title,
-                optionLabel: result.data.options[0]?.displayLabel ?? null,
-                requirementText: row.requirementText,
-                responseText: null,
-                supplementaryInformation: null,
-                evidence: {
-                  documentCount: 0,
-                  citationCount: 0,
-                  hasEvidence: false,
-                },
-                evidenceTarget: {
-                  kind: "option",
-                  optionId: activeEvaluationOptionId,
-                  criterionId: row.criterion.id,
-                },
-              },
               trigger: event.currentTarget,
             })
           }

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -34,6 +34,9 @@ const mocks = vi.hoisted(() => ({
   comparisonSetQueryError: null as Error | null,
   discard: vi.fn(),
   loadEvaluationCriteria: vi.fn(),
+  matrixFocusedOptionId: null as string | null,
+  matrixSelectedOptionIds: ["option-1", "option-2"] as string[],
+  matrixVisibleOptionIds: ["option-1", "option-2"] as string[],
   refetchEvaluationCriteria: vi.fn(),
   refetchAssessment: vi.fn(),
   refetchComparisonSet: vi.fn(),
@@ -52,6 +55,13 @@ function createDeferred<T>() {
     reject = rejectPromise
   })
   return { promise, resolve, reject }
+}
+
+async function waitForEvaluationPanelToClose() {
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
 }
 
 vi.mock("../_hooks/useTechnicalConfigurationBaselineVersionSelection", () => ({
@@ -93,6 +103,80 @@ vi.mock("../_hooks/useTechnicalConfigurationOptionListQuery", () => ({
   }),
 }))
 
+vi.mock("../_hooks/useTechnicalConfigurationComparisonMatrix", () => ({
+  useTechnicalConfigurationComparisonMatrix: () => {
+    const [page, setPage] = React.useState(1)
+    const [visibleOptionIds, setVisibleOptionIds] = React.useState(
+      () => mocks.matrixVisibleOptionIds
+    )
+    const [focusedOptionId, setFocusedOptionId] = React.useState(() => mocks.matrixFocusedOptionId)
+    const options = [
+      createOption("option-1", "Nhà cung cấp A · Model A"),
+      createOption("option-2", "Nhà cung cấp B · Model B"),
+    ]
+    const versions = [
+      {
+        id: "baseline-1",
+        dossier_id: "dossier-1",
+        version_number: 2,
+        status: "locked",
+        revision: 4,
+        groups: createBaselineGroups(),
+      },
+    ]
+
+    return {
+      baselineVersionId: "baseline-1",
+      versions,
+      versionsQuery: {
+        isLoading: false,
+        isError: false,
+        isFetchingNextPage: false,
+        hasNextPage: false,
+      },
+      options,
+      optionsQuery: {
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      selectedOptionIds: mocks.matrixSelectedOptionIds,
+      selectedOptions: options.filter((option) =>
+        mocks.matrixSelectedOptionIds.includes(option.id)
+      ),
+      visibleOptionIds,
+      pinnedOptionIds: [],
+      focusedOptionId,
+      page,
+      isSelectionLimitReached: false,
+      comparison: {
+        comparisonQuery: {
+          data: createComparisonResult(page, "option-1"),
+          isLoading: false,
+          isError: false,
+          error: null,
+          refetch: vi.fn(),
+        },
+      },
+      selectBaselineVersion: vi.fn(),
+      loadMoreVersions: vi.fn(),
+      retryVersions: vi.fn(),
+      addOption: vi.fn(),
+      removeOption: vi.fn(),
+      setPage,
+      toggleOptionVisibility: (optionId: string) =>
+        setVisibleOptionIds((current) =>
+          current.includes(optionId)
+            ? current.filter((currentOptionId) => currentOptionId !== optionId)
+            : [...current, optionId]
+        ),
+      toggleOptionPin: vi.fn(),
+      focusOption: setFocusedOptionId,
+      exitFocusMode: () => setFocusedOptionId(null),
+    }
+  },
+}))
+
 vi.mock("../_hooks/useTechnicalConfigurationResultExport", () => ({
   useTechnicalConfigurationResultExport: () => ({
     status: "idle",
@@ -127,9 +211,21 @@ vi.mock("../_components/evaluation/TechnicalConfigurationOptionReferenceRanking"
   }) => <span data-testid="reference-ranking-scope">{`${dossierId}:${baselineVersionId}`}</span>,
 }))
 
-vi.mock("../comparison-matrix-constants", () => ({
-  TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE: 2,
-}))
+vi.mock("../comparison-matrix-constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../comparison-matrix-constants")>()
+  return {
+    ...actual,
+    TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE: 2,
+  }
+})
+
+vi.mock("../_components/comparison/TechnicalConfigurationMatrix", async () => {
+  const { TechnicalConfigurationEvaluationMatrixTestAdapter } =
+    await import("./technical-configuration-evaluation-workspace.matrix-test-adapter")
+  return {
+    TechnicalConfigurationMatrix: TechnicalConfigurationEvaluationMatrixTestAdapter,
+  }
+})
 
 vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
   useTechnicalConfigurationComparison: ({
@@ -308,6 +404,7 @@ afterAll(() => {
 describe("P12A2 technical configuration evaluation workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    document.body.style.pointerEvents = ""
     mocks.loadEvaluationCriteria.mockReset()
     const allCriteria = [
       { criterion_id: "criterion-1", canonical_index: 1, canonical_page: 1 },
@@ -336,6 +433,9 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     mocks.assessmentQueryError = null
     mocks.assessmentQueryLoading = false
     mocks.comparisonSetQueryError = null
+    mocks.matrixFocusedOptionId = null
+    mocks.matrixSelectedOptionIds = ["option-1", "option-2"]
+    mocks.matrixVisibleOptionIds = ["option-1", "option-2"]
     mocks.save.mockResolvedValue({})
   })
 
@@ -345,17 +445,23 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
 
     expect(screen.getByTestId("reference-ranking-scope")).toHaveTextContent("dossier-1:baseline-1")
-    expect(await screen.findByText("Đã đánh giá 2 / 3 tiêu chí")).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("evaluation-progress-kpi-grid")).getByText("2 / 3")
+    ).toBeInTheDocument()
     expect(screen.getByText("2 / 2")).toBeInTheDocument()
     expect(screen.getByText("0 / 1")).toBeInTheDocument()
 
     await user.click(screen.getByLabelText("Phương án đánh giá"))
     await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
 
-    expect(await screen.findByText("Đã đánh giá 1 / 3 tiêu chí")).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("evaluation-progress-kpi-grid")).getByText("1 / 3")
+    ).toBeInTheDocument()
     expect(screen.getByText("0 / 2")).toBeInTheDocument()
     expect(screen.getByText("1 / 1")).toBeInTheDocument()
-    expect(screen.queryByText("Đã đánh giá 2 / 3 tiêu chí")).not.toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("evaluation-progress-kpi-grid")).queryByText("2 / 3")
+    ).not.toBeInTheDocument()
   })
 
   it("exports the active option and current criterion page without changing navigator state", async () => {
@@ -396,7 +502,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
 
     expect(screen.getByText("Đang tải tiến độ đánh giá...")).toBeInTheDocument()
-    expect(screen.queryByText(/Đã đánh giá \d+ \/ 3 tiêu chí/)).not.toBeInTheDocument()
+    expect(screen.queryByTestId("evaluation-progress-kpi-grid")).not.toBeInTheDocument()
   })
 
   it.each([
@@ -416,7 +522,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
       expectedCriterionIds: [],
     },
   ])(
-    "renders only canonical IDs returned by the server-side $statusFilter filter",
+    "marks only canonical IDs returned by the server-side $statusFilter filter",
     async ({ label, statusFilter, expectedCriterionIds }) => {
       const user = userEvent.setup()
 
@@ -434,6 +540,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
       expect(
         screen
           .queryAllByTestId("evaluation-criterion")
+          .filter((criterion) => criterion.getAttribute("data-filter-match") === "true")
           .map((criterion) => criterion.getAttribute("data-criterion-id"))
       ).toEqual(expectedCriterionIds)
       if (expectedCriterionIds.length === 0) {
@@ -459,7 +566,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await user.click(screen.getByRole("button", { name: "Lưu", exact: true }))
 
     expect(
-      await screen.findByText("Tiêu chí đang mở không còn phù hợp với bộ lọc sau khi lưu.")
+      await screen.findByText("Tiêu chí đang mở không còn thuộc luồng đánh giá hiện tại.")
     ).toBeInTheDocument()
     expect(screen.getByRole("dialog")).toBeInTheDocument()
     expect(screen.getByText("Phản hồi TC-02")).toBeInTheDocument()
@@ -474,6 +581,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await user.click(getCriterion("criterion-3"))
     await user.type(screen.getByLabelText("Ghi chú"), "Giữ nguyên toàn bộ state")
     await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await waitForEvaluationPanelToClose()
 
     await user.click(screen.getByLabelText("Lọc trạng thái đánh giá"))
     await user.click(await screen.findByRole("option", { name: "Không đạt" }))
@@ -498,6 +606,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await openCurrentCriterion(user)
     await user.type(screen.getByLabelText("Ghi chú"), "Phải guard trước RPC")
     await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await waitForEvaluationPanelToClose()
     await user.click(screen.getByLabelText("Lọc trạng thái đánh giá"))
     await user.click(await screen.findByRole("option", { name: "Không đạt" }))
 
@@ -528,6 +637,87 @@ describe("P12A2 technical configuration evaluation workspace", () => {
 
     expect(screen.getByLabelText("Lọc trạng thái đánh giá")).toHaveTextContent("Không đạt")
     expect(getCriterion("criterion-1")).toHaveAttribute("aria-current", "true")
+  })
+
+  it("keeps the evaluator synchronized with the canonical matrix page before option changes", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    expect(getCriterion("criterion-1")).toHaveAttribute("aria-current", "true")
+    await user.click(screen.getByRole("button", { name: "Trang tiếp theo" }))
+    expect(await screen.findByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).toHaveAttribute("aria-current", "true")
+
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
+
+    expect(screen.getByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).toHaveAttribute("aria-current", "true")
+  })
+
+  it("keeps sparse filtered navigation anchored to the canonical matrix page", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await user.click(screen.getByLabelText("Lọc trạng thái đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Không đạt" }))
+    expect(getCriterion("criterion-2")).toHaveAttribute("aria-current", "true")
+
+    await user.click(screen.getByRole("button", { name: "Trang tiếp theo" }))
+    expect(await screen.findByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).not.toHaveAttribute("aria-current", "true")
+
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
+
+    expect(screen.getByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).not.toHaveAttribute("aria-current", "true")
+  })
+
+  it("keeps the focused supplier active after restoring all matrix columns", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await user.click(screen.getByRole("button", { name: "Tùy chỉnh cột so sánh" }))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Tập trung Nhà cung cấp B · Model B",
+      })
+    )
+    await waitFor(() =>
+      expect(screen.getByLabelText("Phương án đánh giá")).toHaveTextContent(
+        "Nhà cung cấp B · Model B"
+      )
+    )
+
+    await openCurrentCriterion(user)
+    await user.type(screen.getByLabelText("Ghi chú"), "Giữ bản nháp của B")
+    await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await waitForEvaluationPanelToClose()
+
+    await user.click(screen.getByRole("button", { name: "Thoát chế độ tập trung" }))
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Phương án đánh giá")).toHaveTextContent(
+      "Nhà cung cấp B · Model B"
+    )
+    await openCurrentCriterion(user)
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Giữ bản nháp của B")
+  })
+
+  it("offers evaluation only for supplier columns currently displayed in the matrix", async () => {
+    mocks.matrixVisibleOptionIds = ["option-1"]
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    expect(
+      screen.queryByRole("option", { name: "Nhà cung cấp B · Model B" })
+    ).not.toBeInTheDocument()
   })
 
   it("moves save-next through matching canonical results and shows no-more-match without wrapping", async () => {
@@ -561,7 +751,9 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await user.type(screen.getByLabelText("Ghi chú"), "Kết quả cuối")
     await user.click(screen.getByRole("button", { name: "Lưu & tiếp tục" }))
 
-    expect(await screen.findByText("Không còn tiêu chí phù hợp với bộ lọc.")).toBeInTheDocument()
+    expect(
+      await screen.findByText("Không còn tiêu chí phù hợp với luồng đánh giá.")
+    ).toBeInTheDocument()
     expect(screen.getByRole("dialog")).toBeInTheDocument()
     expect(screen.getByText("Phản hồi TC-03")).toBeInTheDocument()
   })
@@ -634,7 +826,9 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     expect(screen.getByLabelText("Lọc trạng thái đánh giá")).toHaveTextContent("Không đạt")
     expect(getCriterion("criterion-1")).toHaveAttribute("aria-current", "true")
     expect(screen.getByLabelText("Ghi chú")).toHaveValue("Giữ draft khi lỗi")
-    expect(screen.queryByText("Không còn tiêu chí phù hợp với bộ lọc.")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Không còn tiêu chí phù hợp với luồng đánh giá.")
+    ).not.toBeInTheDocument()
   })
 
   it("keeps Lưu on the criterion and advances Lưu & tiếp tục across page boundaries", async () => {
@@ -689,6 +883,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     expect(beforeUnloadEvent.defaultPrevented).toBe(true)
 
     await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await waitForEvaluationPanelToClose()
     await user.click(getCriterion("criterion-2"))
     expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
     await user.click(screen.getByRole("button", { name: "Hủy" }))
@@ -697,6 +892,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     expect(screen.getByLabelText("Ghi chú")).toHaveValue("Không được mất")
     expect(getCriterion("criterion-1")).toHaveAttribute("data-criterion-id", "criterion-1")
     await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await waitForEvaluationPanelToClose()
 
     await user.click(screen.getByLabelText("Phương án đánh giá"))
     await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
@@ -752,7 +948,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
 
     expect(await screen.findByText("Không thể tải dữ liệu đánh giá")).toBeInTheDocument()
     expect(screen.getByText("Chưa thể tính tiến độ đánh giá.")).toBeInTheDocument()
-    expect(screen.queryByText(/Đã đánh giá \d+ \/ 3 tiêu chí/)).not.toBeInTheDocument()
+    expect(screen.queryByTestId("evaluation-progress-kpi-grid")).not.toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: "Thử lại" }))
 
     expect(mocks.refetchAssessment).toHaveBeenCalledTimes(1)

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
@@ -1,19 +1,5 @@
-"use client"
-
-import * as React from "react"
-
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-
-import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
-import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
 import type { TechnicalConfigurationDossierWire } from "../../types"
 import { TechnicalConfigurationEvaluationWorkspace } from "../evaluation/TechnicalConfigurationEvaluationWorkspace"
-import {
-  TechnicalConfigurationCriterionPanel,
-  type TechnicalConfigurationCriterionDetail,
-} from "./TechnicalConfigurationCriterionPanel"
-import { TechnicalConfigurationMatrix } from "./TechnicalConfigurationMatrix"
-import { TechnicalConfigurationMatrixToolbar } from "./TechnicalConfigurationMatrixToolbar"
 
 type TechnicalConfigurationComparisonTabProps = {
   dossier: TechnicalConfigurationDossierWire
@@ -22,137 +8,19 @@ type TechnicalConfigurationComparisonTabProps = {
   onRevisionChange?: (revision: number) => void
 }
 
-type TechnicalConfigurationComparisonMode = "matrix" | "evaluation"
-
-/** Composes the P10B matrix and P12A2 evaluation as internal workspace modes. */
+/** Composes comparison and evaluation in one continuous workspace. */
 export function TechnicalConfigurationComparisonTab({
   dossier,
   onDirtyChange,
   onNavigationBlockedChange,
   onRevisionChange,
 }: Readonly<TechnicalConfigurationComparisonTabProps>) {
-  const matrix = useTechnicalConfigurationComparisonMatrix(dossier.id)
-  const [activeMode, setActiveMode] = React.useState<TechnicalConfigurationComparisonMode>("matrix")
-  const [isEvaluationDirty, setIsEvaluationDirty] = React.useState(false)
-  const [isEvaluationNavigationBlocked, setIsEvaluationNavigationBlocked] = React.useState(false)
-  const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
-  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
-  const { comparisonQuery } = matrix.comparison
-  const hasRequest = matrix.baselineVersionId !== null && matrix.selectedOptionIds.length > 0
-  const isDirty = activeMode === "evaluation" && isEvaluationDirty
-  const isNavigationBlocked = activeMode === "evaluation" && isEvaluationNavigationBlocked
-  const { requestNavigation, discardConfirmationDialog } =
-    useTechnicalConfigurationGuardedNavigation({
-      isDirty,
-      isBlocked: isNavigationBlocked,
-    })
-
-  const openDetail = React.useCallback((nextDetail: TechnicalConfigurationCriterionDetail) => {
-    detailReturnFocusRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null
-    setDetail(nextDetail)
-  }, [])
-
-  React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- WorkspaceShell owns top-level guards while this tab owns its internal mode.
-    onDirtyChange?.(isDirty)
-  }, [isDirty, onDirtyChange])
-  React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Evaluation save lifecycle must block mode, tab and dossier navigation.
-    onNavigationBlockedChange?.(isNavigationBlocked)
-  }, [isNavigationBlocked, onNavigationBlockedChange])
-  React.useEffect(
-    () => () => {
-      onDirtyChange?.(false)
-      onNavigationBlockedChange?.(false)
-    },
-    [onDirtyChange, onNavigationBlockedChange]
-  )
-
-  const handleModeChange = React.useCallback(
-    (nextMode: string) => {
-      if ((nextMode !== "matrix" && nextMode !== "evaluation") || nextMode === activeMode) {
-        return
-      }
-      requestNavigation(() => {
-        setActiveMode(nextMode)
-        if (activeMode === "matrix") setDetail(null)
-      })
-    },
-    [activeMode, requestNavigation]
-  )
-
   return (
-    <section className="min-w-0" aria-label="So sánh và đánh giá cấu hình kỹ thuật">
-      <Tabs value={activeMode} onValueChange={handleModeChange}>
-        <div className="flex justify-end border-b pb-3">
-          <TabsList
-            className="grid h-auto w-full max-w-56 grid-cols-2"
-            aria-label="Chế độ so sánh và đánh giá"
-          >
-            <TabsTrigger value="matrix" disabled={isNavigationBlocked}>
-              Ma trận
-            </TabsTrigger>
-            <TabsTrigger value="evaluation">Đánh giá</TabsTrigger>
-          </TabsList>
-        </div>
-
-        <TabsContent value="matrix" className="mt-4 space-y-4">
-          <TechnicalConfigurationMatrixToolbar
-            baselineVersionId={matrix.baselineVersionId}
-            versions={matrix.versions}
-            versionsQuery={matrix.versionsQuery}
-            options={matrix.options}
-            optionsQuery={matrix.optionsQuery}
-            selectedOptions={matrix.selectedOptions}
-            visibleOptionIds={matrix.visibleOptionIds}
-            pinnedOptionIds={matrix.pinnedOptionIds}
-            focusedOptionId={matrix.focusedOptionId}
-            isSelectionLimitReached={matrix.isSelectionLimitReached}
-            onSelectBaselineVersion={matrix.selectBaselineVersion}
-            onLoadMoreVersions={() => void matrix.loadMoreVersions()}
-            onRetryVersions={() => void matrix.retryVersions()}
-            onRetryOptions={() => void matrix.optionsQuery.refetch()}
-            onAddOption={matrix.addOption}
-            onRemoveOption={matrix.removeOption}
-            onToggleOptionVisibility={matrix.toggleOptionVisibility}
-            onToggleOptionPin={matrix.toggleOptionPin}
-            onFocusOption={matrix.focusOption}
-            onExitFocus={matrix.exitFocusMode}
-          />
-          <TechnicalConfigurationMatrix
-            hasRequest={hasRequest}
-            result={comparisonQuery.data}
-            visibleOptionIds={matrix.visibleOptionIds}
-            pinnedOptionIds={matrix.pinnedOptionIds}
-            focusedOptionId={matrix.focusedOptionId}
-            isLoading={comparisonQuery.isLoading}
-            isError={comparisonQuery.isError}
-            error={comparisonQuery.error}
-            onRetry={() => void comparisonQuery.refetch()}
-            onPageChange={matrix.setPage}
-            onOpenDetail={openDetail}
-          />
-          <TechnicalConfigurationCriterionPanel
-            detail={detail}
-            open={detail !== null}
-            returnFocusRef={detailReturnFocusRef}
-            onOpenChange={(open) => {
-              if (!open) setDetail(null)
-            }}
-          />
-        </TabsContent>
-
-        <TabsContent value="evaluation" className="mt-4">
-          <TechnicalConfigurationEvaluationWorkspace
-            dossier={dossier}
-            onDirtyChange={setIsEvaluationDirty}
-            onNavigationBlockedChange={setIsEvaluationNavigationBlocked}
-            onRevisionChange={onRevisionChange}
-          />
-        </TabsContent>
-      </Tabs>
-      {discardConfirmationDialog}
-    </section>
+    <TechnicalConfigurationEvaluationWorkspace
+      dossier={dossier}
+      onDirtyChange={onDirtyChange}
+      onNavigationBlockedChange={onNavigationBlockedChange}
+      onRevisionChange={onRevisionChange}
+    />
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -130,6 +130,7 @@ export function TechnicalConfigurationMatrix({
               type="button"
               variant="outline"
               size="sm"
+              disabled={evaluationDisabled}
               onClick={() => onPageChange(result.page - 1)}
             >
               <ChevronLeft aria-hidden="true" />

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -8,10 +8,14 @@ import {
 } from "@/app/(app)/technical-configurations/comparison-matrix-constants"
 import type { TechnicalConfigurationComparisonResult } from "@/app/(app)/technical-configurations/comparison-types"
 import { Button } from "@/components/ui/button"
+import type { TechnicalConfigurationDerivedStatus } from "@/lib/technical-configuration-evaluation"
 
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
 import { TechnicalConfigurationCriterionPagination } from "./TechnicalConfigurationCriterionPagination"
-import { TechnicalConfigurationMatrixRow } from "./TechnicalConfigurationMatrixRow"
+import {
+  TechnicalConfigurationMatrixRow,
+  type TechnicalConfigurationMatrixEvaluationTarget,
+} from "./TechnicalConfigurationMatrixRow"
 
 type TechnicalConfigurationMatrixProps = {
   hasRequest: boolean
@@ -25,6 +29,12 @@ type TechnicalConfigurationMatrixProps = {
   onRetry: () => void
   onPageChange: (page: number) => void
   onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+  activeEvaluationOptionId?: string | null
+  activeEvaluationCriterionId?: string | null
+  assessmentStatusByCriterionId?: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+  matchingEvaluationCriterionIds?: ReadonlySet<string>
+  evaluationDisabled?: boolean
+  onOpenEvaluation?: (target: TechnicalConfigurationMatrixEvaluationTarget) => void
 }
 
 type ComparisonCriterionRow = TechnicalConfigurationComparisonResult["data"]["criteria"][number]
@@ -75,6 +85,12 @@ export function TechnicalConfigurationMatrix({
   onRetry,
   onPageChange,
   onOpenDetail,
+  activeEvaluationOptionId = null,
+  activeEvaluationCriterionId = null,
+  assessmentStatusByCriterionId,
+  matchingEvaluationCriterionIds,
+  evaluationDisabled = false,
+  onOpenEvaluation,
 }: Readonly<TechnicalConfigurationMatrixProps>) {
   if (!hasRequest) {
     return (
@@ -215,6 +231,12 @@ export function TechnicalConfigurationMatrix({
                     new Map(row.optionValues.map((value) => [value.optionId, value]))
                   }
                   onOpenDetail={onOpenDetail}
+                  activeEvaluationOptionId={activeEvaluationOptionId}
+                  activeEvaluationCriterionId={activeEvaluationCriterionId}
+                  assessmentStatusByCriterionId={assessmentStatusByCriterionId}
+                  matchingEvaluationCriterionIds={matchingEvaluationCriterionIds}
+                  evaluationDisabled={evaluationDisabled}
+                  onOpenEvaluation={onOpenEvaluation}
                 />
               ))}
             </tbody>
@@ -227,6 +249,7 @@ export function TechnicalConfigurationMatrix({
         pageSize={result.pageSize}
         total={result.total}
         onPageChange={onPageChange}
+        disabled={evaluationDisabled}
       />
     </div>
   )

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -180,14 +180,15 @@ export function TechnicalConfigurationMatrixRow({
                   isFilterMatch && "bg-primary/10"
                 )}
               >
-                <button
-                  type="button"
-                  className="space-y-2 rounded-sm text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
-                  aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
-                  onClick={() => onOpenDetail(detail)}
-                >
-                  {cellContent}
-                </button>
+                <div className="relative space-y-2">
+                  <div className="space-y-2">{cellContent}</div>
+                  <button
+                    type="button"
+                    className="absolute inset-0 rounded-sm outline-none transition-colors hover:bg-muted/20 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
+                    onClick={() => onOpenDetail(detail)}
+                  />
+                </div>
                 <Button
                   type="button"
                   variant="outline"

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -1,3 +1,5 @@
+import { ClipboardCheck } from "lucide-react"
+
 import {
   COMPARISON_MATRIX_LAYOUT,
   getPinnedComparisonOptionLeft,
@@ -7,9 +9,23 @@ import type {
   TechnicalConfigurationComparisonOptionValue,
   TechnicalConfigurationComparisonResult,
 } from "@/app/(app)/technical-configurations/comparison-types"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+import { cn } from "@/lib/utils"
 
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
 import { createTechnicalConfigurationOptionCriterionDetail } from "./technical-configuration-criterion-detail"
+
+export type TechnicalConfigurationMatrixEvaluationTarget = {
+  optionId: string
+  criterionId: string
+  detail: TechnicalConfigurationCriterionDetail
+  trigger: HTMLElement
+}
 
 type TechnicalConfigurationMatrixRowProps = {
   row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
@@ -18,6 +34,12 @@ type TechnicalConfigurationMatrixRowProps = {
   pinnedOptionIds: readonly string[]
   valueByOptionId: ReadonlyMap<string, TechnicalConfigurationComparisonOptionValue>
   onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+  activeEvaluationOptionId?: string | null
+  activeEvaluationCriterionId?: string | null
+  assessmentStatusByCriterionId?: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+  matchingEvaluationCriterionIds?: ReadonlySet<string>
+  evaluationDisabled?: boolean
+  onOpenEvaluation?: (target: TechnicalConfigurationMatrixEvaluationTarget) => void
 }
 
 function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
@@ -33,6 +55,12 @@ export function TechnicalConfigurationMatrixRow({
   pinnedOptionIds,
   valueByOptionId,
   onOpenDetail,
+  activeEvaluationOptionId = null,
+  activeEvaluationCriterionId = null,
+  assessmentStatusByCriterionId,
+  matchingEvaluationCriterionIds,
+  evaluationDisabled = false,
+  onOpenEvaluation,
 }: Readonly<TechnicalConfigurationMatrixRowProps>) {
   const title = row.criterion.title ?? "Chưa có tiêu đề"
 
@@ -91,6 +119,48 @@ export function TechnicalConfigurationMatrixRow({
         })
         const pinnedIndex = pinnedOptionIds.indexOf(option.id)
         const isPinned = pinnedIndex >= 0
+        const isActiveEvaluationOption = option.id === activeEvaluationOptionId
+        const isActiveEvaluationTarget =
+          isActiveEvaluationOption && row.criterion.id === activeEvaluationCriterionId
+        const isFilterMatch =
+          isActiveEvaluationOption && Boolean(matchingEvaluationCriterionIds?.has(row.criterion.id))
+        const assessmentStatus =
+          assessmentStatusByCriterionId?.get(row.criterion.id) ?? "not_evaluated"
+        const cellContent = (
+          <>
+            {detail.responseText !== null ? (
+              <>
+                <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
+                  {detail.responseText}
+                </p>
+                {detail.supplementaryInformation ? (
+                  <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-muted-foreground">Chưa có phản hồi</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {formatEvidenceSummary(detail.evidence)}
+            </p>
+            {isActiveEvaluationOption ? (
+              <Badge
+                variant={
+                  assessmentStatus === "fails"
+                    ? "destructive"
+                    : assessmentStatus === "meets" || assessmentStatus === "exceeds"
+                      ? "secondary"
+                      : assessmentStatus === "not_evaluated"
+                        ? "muted"
+                        : "outline"
+                }
+                className="max-w-32 justify-center whitespace-normal text-center"
+              >
+                {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[assessmentStatus]}
+              </Badge>
+            ) : null}
+          </>
+        )
 
         return (
           <td
@@ -99,33 +169,57 @@ export function TechnicalConfigurationMatrixRow({
             data-criterion-id={row.criterion.id}
             data-option-id={option.id}
             data-pinned={isPinned ? "true" : "false"}
-            className={`${COMPARISON_MATRIX_LAYOUT.optionWidthClass} border-b border-r bg-background p-0 ${
-              isPinned ? "sticky z-20" : ""
-            }`}
+            data-evaluation-active={isActiveEvaluationTarget ? "true" : "false"}
+            data-evaluation-column={isActiveEvaluationOption ? "true" : "false"}
+            data-filter-match={isFilterMatch ? "true" : "false"}
+            className={cn(
+              COMPARISON_MATRIX_LAYOUT.optionWidthClass,
+              "border-b border-r bg-background p-0",
+              isPinned && "sticky z-20",
+              isActiveEvaluationOption && "bg-primary/5",
+              isActiveEvaluationTarget && "ring-2 ring-inset ring-primary"
+            )}
             style={isPinned ? { left: getPinnedComparisonOptionLeft(pinnedIndex) } : undefined}
           >
-            <button
-              type="button"
-              className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-              aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
-              onClick={() => onOpenDetail(detail)}
-            >
-              {detail.responseText !== null ? (
-                <>
-                  <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
-                    {detail.responseText}
-                  </p>
-                  {detail.supplementaryInformation ? (
-                    <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
-                  ) : null}
-                </>
-              ) : (
-                <p className="text-muted-foreground">Chưa có phản hồi</p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                {formatEvidenceSummary(detail.evidence)}
-              </p>
-            </button>
+            {onOpenEvaluation ? (
+              <div
+                className={cn(
+                  "flex h-full flex-col gap-2 px-3 py-3",
+                  isFilterMatch && "bg-primary/10"
+                )}
+              >
+                {cellContent}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  data-testid="matrix-evaluation-action"
+                  className="mt-auto w-full"
+                  aria-label={`Đánh giá ${row.criterion.criterionCode} · ${option.displayLabel}`}
+                  disabled={evaluationDisabled}
+                  onClick={(event) =>
+                    onOpenEvaluation({
+                      optionId: option.id,
+                      criterionId: row.criterion.id,
+                      detail,
+                      trigger: event.currentTarget,
+                    })
+                  }
+                >
+                  <ClipboardCheck aria-hidden="true" />
+                  Đánh giá
+                </Button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
+                onClick={() => onOpenDetail(detail)}
+              >
+                {cellContent}
+              </button>
+            )}
           </td>
         )
       })}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -19,11 +19,11 @@ import { cn } from "@/lib/utils"
 
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
 import { createTechnicalConfigurationOptionCriterionDetail } from "./technical-configuration-criterion-detail"
+import { TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS } from "../evaluation/technical-configuration-evaluation-status-badge"
 
 export type TechnicalConfigurationMatrixEvaluationTarget = {
   optionId: string
   criterionId: string
-  detail: TechnicalConfigurationCriterionDetail
   trigger: HTMLElement
 }
 
@@ -145,15 +145,7 @@ export function TechnicalConfigurationMatrixRow({
             </p>
             {isActiveEvaluationOption ? (
               <Badge
-                variant={
-                  assessmentStatus === "fails"
-                    ? "destructive"
-                    : assessmentStatus === "meets" || assessmentStatus === "exceeds"
-                      ? "secondary"
-                      : assessmentStatus === "not_evaluated"
-                        ? "muted"
-                        : "outline"
-                }
+                variant={TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS[assessmentStatus]}
                 className="max-w-32 justify-center whitespace-normal text-center"
               >
                 {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[assessmentStatus]}
@@ -188,7 +180,14 @@ export function TechnicalConfigurationMatrixRow({
                   isFilterMatch && "bg-primary/10"
                 )}
               >
-                {cellContent}
+                <button
+                  type="button"
+                  className="space-y-2 rounded-sm text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
+                  onClick={() => onOpenDetail(detail)}
+                >
+                  {cellContent}
+                </button>
                 <Button
                   type="button"
                   variant="outline"
@@ -201,7 +200,6 @@ export function TechnicalConfigurationMatrixRow({
                     onOpenEvaluation({
                       optionId: option.id,
                       criterionId: row.criterion.id,
-                      detail,
                       trigger: event.currentTarget,
                     })
                   }

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 
 import type { TechnicalConfigurationAssessmentWire } from "../../assessment-types"
 import type { TechnicalConfigurationEvaluationCriterionListItem } from "./technical-configuration-evaluation-navigation"
+import { TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS } from "./technical-configuration-evaluation-status-badge"
 
 type TechnicalConfigurationCriterionListProps = {
   criteria: readonly TechnicalConfigurationEvaluationCriterionListItem[]
@@ -68,13 +69,6 @@ function getCriterionStatus(
   )
 }
 
-function getStatusVariant(status: TechnicalConfigurationDerivedStatus) {
-  if (status === "fails") return "destructive" as const
-  if (status === "meets" || status === "exceeds") return "secondary" as const
-  if (status === "not_evaluated") return "muted" as const
-  return "outline" as const
-}
-
 /** Renders the canonical criterion sequence with one compact manual-status badge per row. */
 export function TechnicalConfigurationCriterionList({
   criteria,
@@ -125,7 +119,7 @@ export function TechnicalConfigurationCriterionList({
                     </span>
                   </span>
                   <Badge
-                    variant={getStatusVariant(status)}
+                    variant={TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS[status]}
                     className="max-w-32 justify-center whitespace-normal text-center"
                   >
                     {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[status]}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -62,15 +62,28 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
     baselineVersionId,
     pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
   })
+  const { comparisonQuery } = matrix.comparison
+  const matrixResult = comparisonQuery.data
+  const panelPage = navigator.currentCriterion?.canonicalPage ?? matrix.page
+  const canReuseMatrixResult =
+    panelPage === matrix.page &&
+    Boolean(
+      navigator.activeSelectedOptionId &&
+      matrixResult?.data.options.some((option) => option.id === navigator.activeSelectedOptionId)
+    )
   const panelComparison = useTechnicalConfigurationComparison({
     baselineVersionId,
-    optionIds: navigator.activeSelectedOptionId ? [navigator.activeSelectedOptionId] : [],
-    page: navigator.currentCriterion?.canonicalPage ?? matrix.page,
+    optionIds:
+      !canReuseMatrixResult && navigator.activeSelectedOptionId
+        ? [navigator.activeSelectedOptionId]
+        : [],
+    page: panelPage,
     pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
   })
   const panelResult = panelComparison.comparisonQuery.data
+  const criterionResult = canReuseMatrixResult ? matrixResult : panelResult
   const currentRow =
-    panelResult?.data.criteria.find((row) => row.criterion.id === navigator.criterionId) ?? null
+    criterionResult?.data.criteria.find((row) => row.criterion.id === navigator.criterionId) ?? null
   const evaluation = useTechnicalConfigurationEvaluationDraft({
     optionId: navigator.activeSelectedOptionId,
     baselineVersionId,
@@ -170,8 +183,6 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
   const draft = evaluation.draft
   const saveDisabled =
     Boolean(dossier.archived_at) || !evaluation.isReady || !isDirty || isNavigationBlocked
-  const { comparisonQuery } = matrix.comparison
-  const matrixResult = comparisonQuery.data
   const hasMatrixRequest = matrix.baselineVersionId !== null && matrix.selectedOptionIds.length > 0
 
   return (

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -288,7 +288,7 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
         actions={
           <TechnicalConfigurationEvaluationSaveActions
             disabled={saveDisabled}
-            saving={isNavigationBlocked}
+            saving={evaluation.isSaving}
             onSave={() => void handleSave()}
             onSaveAndContinue={() => void handleSaveAndContinue()}
           />

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -1,35 +1,33 @@
 "use client"
 
 import * as React from "react"
-import { Loader2, Save, StepForward } from "lucide-react"
-
-import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 
 import { useTechnicalConfigurationComparison } from "../../_hooks/useTechnicalConfigurationComparison"
+import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
 import { useTechnicalConfigurationEvaluationDraft } from "../../_hooks/useTechnicalConfigurationEvaluationDraft"
 import { useTechnicalConfigurationEvaluationNavigator } from "../../_hooks/useTechnicalConfigurationEvaluationNavigator"
+import { useTechnicalConfigurationEvaluationWorkspaceActions } from "../../_hooks/useTechnicalConfigurationEvaluationWorkspaceActions"
 import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
-import type { TechnicalConfigurationBaselineGroupWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
 import { TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE } from "../../comparison-matrix-constants"
 import type { TechnicalConfigurationComparisonOption } from "../../comparison-types"
 import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
 import { toTechnicalConfigurationComparisonOption } from "../../technical-configuration-comparison-mappers"
 import type { TechnicalConfigurationDossierWire } from "../../types"
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "../comparison/TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrix } from "../comparison/TechnicalConfigurationMatrix"
 import { createTechnicalConfigurationOptionCriterionDetail } from "../comparison/technical-configuration-criterion-detail"
-import { buildTechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
-import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
-import { TechnicalConfigurationEvaluationNavigatorPane } from "./TechnicalConfigurationEvaluationNavigatorPane"
+import { buildTechnicalConfigurationEvaluationMatrixPresentation } from "./technical-configuration-evaluation-matrix-presentation"
+import { TechnicalConfigurationEvaluationFeedback } from "./TechnicalConfigurationEvaluationFeedback"
+import { TechnicalConfigurationEvaluationMatrixControls } from "./TechnicalConfigurationEvaluationMatrixControls"
+import { TechnicalConfigurationEvaluationMatrixToolbar } from "./TechnicalConfigurationEvaluationMatrixToolbar"
 import { TechnicalConfigurationEvaluationPanel } from "./TechnicalConfigurationEvaluationPanel"
 import { TechnicalConfigurationProgressSummary } from "./TechnicalConfigurationProgressSummary"
 import { TechnicalConfigurationResultExportControl } from "./TechnicalConfigurationResultExportControl"
+import { TechnicalConfigurationEvaluationSaveActions } from "./TechnicalConfigurationEvaluationSaveActions"
 import { toTechnicalConfigurationSaveErrorMessage } from "./TechnicalConfigurationEvaluationWorkspaceUtils"
 
 type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
@@ -37,37 +35,42 @@ type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
   baselineVersionId: string
   baselineGroups: TechnicalConfigurationBaselineGroupWire[]
   options: TechnicalConfigurationOptionWire[]
+  matrix: ReturnType<typeof useTechnicalConfigurationComparisonMatrix>
   onDirtyChange: (dirty: boolean) => void
   onNavigationBlockedChange: (blocked: boolean) => void
   onRevisionChange?: (revision: number) => void
 }
 
-/** Owns the selected option, page, criterion and P12A1 draft for evaluation mode. */
+/** Owns matrix-based criterion selection and one supplier-local assessment draft. */
 export function TechnicalConfigurationEvaluationActiveWorkspace({
   dossier,
   baselineVersionId,
   baselineGroups,
   options,
+  matrix,
   onDirtyChange,
   onNavigationBlockedChange,
   onRevisionChange,
 }: Readonly<TechnicalConfigurationEvaluationActiveWorkspaceProps>) {
-  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const evaluationReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const readOnlyReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const [readOnlyDetail, setReadOnlyDetail] =
+    React.useState<TechnicalConfigurationCriterionDetail | null>(null)
   const navigator = useTechnicalConfigurationEvaluationNavigator({
     options,
     baselineGroups,
     baselineVersionId,
     pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
   })
-  const comparison = useTechnicalConfigurationComparison({
+  const panelComparison = useTechnicalConfigurationComparison({
     baselineVersionId,
     optionIds: navigator.activeSelectedOptionId ? [navigator.activeSelectedOptionId] : [],
-    page: navigator.currentCriterion?.canonicalPage ?? 1,
+    page: navigator.currentCriterion?.canonicalPage ?? matrix.page,
     pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
   })
-  const result = comparison.comparisonQuery.data
+  const panelResult = panelComparison.comparisonQuery.data
   const currentRow =
-    result?.data.criteria.find((row) => row.criterion.id === navigator.criterionId) ?? null
+    panelResult?.data.criteria.find((row) => row.criterion.id === navigator.criterionId) ?? null
   const evaluation = useTechnicalConfigurationEvaluationDraft({
     optionId: navigator.activeSelectedOptionId,
     baselineVersionId,
@@ -76,16 +79,6 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
     onDossierRevisionChange: onRevisionChange,
   })
   const { assessmentQuery, comparisonSetQuery } = evaluation
-  const {
-    error: assessmentQueryError,
-    isError: isAssessmentQueryError,
-    refetch: refetchAssessments,
-  } = assessmentQuery
-  const {
-    error: comparisonSetQueryError,
-    isError: isComparisonSetQueryError,
-    refetch: refetchComparisonSet,
-  } = comparisonSetQuery
   const isDirty = evaluation.draft?.isDirty ?? false
   const isNavigationBlocked = evaluation.isSaving || navigator.isTransitionPending
   const { requestNavigation, discardConfirmationDialog } =
@@ -94,25 +87,32 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
       isBlocked: evaluation.isSaving,
       onDiscard: evaluation.discard,
     })
-  const hasEvaluationReadError = isComparisonSetQueryError || isAssessmentQueryError
-  const evaluationReadError = isComparisonSetQueryError
-    ? comparisonSetQueryError
-    : assessmentQueryError
-  const progress = React.useMemo(
+  const hasEvaluationReadError = comparisonSetQuery.isError || assessmentQuery.isError
+  const evaluationReadError = comparisonSetQuery.isError
+    ? comparisonSetQuery.error
+    : assessmentQuery.error
+  const matrixPresentation = React.useMemo(
     () =>
-      buildTechnicalConfigurationEvaluationProgress({
+      buildTechnicalConfigurationEvaluationMatrixPresentation({
         groups: baselineGroups,
-        assessments: Object.values(evaluation.assessmentsByCriterionId),
+        assessmentsByCriterionId: evaluation.assessmentsByCriterionId,
+        projection: navigator.projection,
+        statusFilter: navigator.statusFilter,
       }),
-    [baselineGroups, evaluation.assessmentsByCriterionId]
+    [
+      baselineGroups,
+      evaluation.assessmentsByCriterionId,
+      navigator.projection,
+      navigator.statusFilter,
+    ]
   )
 
   React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- P12A2 exposes one criterion-local draft to every enclosing navigation boundary.
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- WorkspaceShell owns top-level navigation guards.
     onDirtyChange(isDirty)
   }, [isDirty, onDirtyChange])
   React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Pending assessment saves hard-block option, page, mode, tab and dossier navigation.
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Save and filtered transition state must block enclosing navigation.
     onNavigationBlockedChange(isNavigationBlocked)
   }, [isNavigationBlocked, onNavigationBlockedChange])
   React.useEffect(
@@ -123,70 +123,35 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
     [onDirtyChange, onNavigationBlockedChange]
   )
 
-  const handleOptionChange = React.useCallback(
-    (nextOptionId: string) => {
-      if (isNavigationBlocked) return
-      navigator.changeOption(nextOptionId, requestNavigation)
+  const handleOpenReadOnlyDetail = React.useCallback(
+    (detail: TechnicalConfigurationCriterionDetail) => {
+      readOnlyReturnFocusRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null
+      setReadOnlyDetail(detail)
     },
-    [isNavigationBlocked, navigator, requestNavigation]
+    []
   )
-  const handleFilterChange = React.useCallback(
-    (nextFilter: Parameters<typeof navigator.changeFilter>[0]) => {
-      if (isNavigationBlocked) return
-      navigator.changeFilter(nextFilter, requestNavigation)
-    },
-    [isNavigationBlocked, navigator, requestNavigation]
-  )
-  const handlePageChange = React.useCallback(
-    (nextPage: number) => {
-      navigator.changePage(nextPage, requestNavigation)
-    },
-    [navigator, requestNavigation]
-  )
-  const handleCriterionChange = React.useCallback(
-    (nextCriterionId: string) => {
-      navigator.changeCriterion(nextCriterionId, requestNavigation, () => {
-        detailReturnFocusRef.current =
-          document.activeElement instanceof HTMLElement ? document.activeElement : null
-      })
-    },
-    [navigator, requestNavigation]
-  )
-  const handleSave = React.useCallback(async () => {
-    try {
-      await evaluation.save()
-    } catch {
-      // The draft hook preserves input and exposes the actionable error.
-    }
-  }, [evaluation])
-  const handleSaveAndContinue = React.useCallback(async () => {
-    try {
-      await evaluation.save()
-      await navigator.advanceAfterSave()
-    } catch {
-      // Failed saves intentionally remain on the current criterion.
-    }
-  }, [evaluation, navigator])
-  const handleRetryEvaluationData = React.useCallback(() => {
-    if (isComparisonSetQueryError) {
-      void refetchComparisonSet()
-    }
-    if (isAssessmentQueryError) {
-      void refetchAssessments()
-    }
-    if (navigator.criteriaQuery.isError) {
-      void navigator.criteriaQuery.refetch()
-    }
-  }, [
-    isAssessmentQueryError,
-    isComparisonSetQueryError,
-    navigator.criteriaQuery,
-    refetchAssessments,
-    refetchComparisonSet,
-  ])
+  const {
+    handleOptionChange,
+    handleFilterChange,
+    handleOpenEvaluation,
+    handleMatrixPageChange,
+    handleSave,
+    handleSaveAndContinue,
+    handleRetryEvaluationData,
+    closeEvaluationPanel,
+    runMatrixContextChange,
+  } = useTechnicalConfigurationEvaluationWorkspaceActions({
+    evaluation,
+    navigator,
+    matrix,
+    requestNavigation,
+    isNavigationBlocked,
+    evaluationReturnFocusRef,
+  })
 
   const comparisonOption: TechnicalConfigurationComparisonOption | null = navigator.selectedOption
-    ? (result?.data.options.find((option) => option.id === navigator.activeSelectedOptionId) ??
+    ? (panelResult?.data.options.find((option) => option.id === navigator.activeSelectedOptionId) ??
       toTechnicalConfigurationComparisonOption(navigator.selectedOption))
     : null
   const currentOptionValue =
@@ -205,97 +170,99 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
   const draft = evaluation.draft
   const saveDisabled =
     Boolean(dossier.archived_at) || !evaluation.isReady || !isDirty || isNavigationBlocked
+  const { comparisonQuery } = matrix.comparison
+  const matrixResult = comparisonQuery.data
+  const hasMatrixRequest = matrix.baselineVersionId !== null && matrix.selectedOptionIds.length > 0
 
   return (
     <section className="min-w-0 space-y-4" aria-label="Không gian đánh giá cấu hình kỹ thuật">
-      <TechnicalConfigurationResultExportControl
-        key={`${dossier.id}:${baselineVersionId}`}
-        dossierId={dossier.id}
-        baselineVersionId={baselineVersionId}
-        options={options}
-        baselineGroups={baselineGroups}
+      <TechnicalConfigurationEvaluationMatrixToolbar
+        matrix={matrix}
         activeOptionId={navigator.activeSelectedOptionId}
-        currentCriteria={navigator.pageCriteria}
+        navigationBlocked={isNavigationBlocked}
+        runContextChange={runMatrixContextChange}
       />
 
-      <div className="flex flex-col gap-2 border-y py-3 sm:flex-row sm:items-center sm:justify-between">
-        <Label htmlFor="technical-configuration-evaluation-option">Phương án đánh giá</Label>
-        <Select
-          value={navigator.activeSelectedOptionId}
-          onValueChange={handleOptionChange}
-          disabled={isNavigationBlocked}
-        >
-          <SelectTrigger
-            id="technical-configuration-evaluation-option"
-            aria-label="Phương án đánh giá"
-            className="w-full sm:max-w-md"
-          >
-            <SelectValue placeholder="Chọn phương án" />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.display_label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex justify-end">
+        <TechnicalConfigurationResultExportControl
+          key={`${dossier.id}:${baselineVersionId}`}
+          dossierId={dossier.id}
+          baselineVersionId={baselineVersionId}
+          options={matrix.selectedOptions}
+          baselineGroups={baselineGroups}
+          activeOptionId={navigator.activeSelectedOptionId}
+          currentCriteria={matrixResult?.data.criteria ?? []}
+        />
       </div>
 
-      <TechnicalConfigurationProgressSummary
-        progress={progress}
-        isLoading={comparisonSetQuery.isLoading || assessmentQuery.isLoading}
-        isError={hasEvaluationReadError}
-      />
-
-      <TechnicalConfigurationEvaluationNavigatorPane
+      <TechnicalConfigurationEvaluationMatrixControls
+        options={options}
+        activeOptionId={navigator.activeSelectedOptionId}
+        onOptionChange={handleOptionChange}
         statusFilter={navigator.statusFilter}
         onStatusFilterChange={handleFilterChange}
-        criteria={navigator.pageCriteria}
-        assessmentsByCriterionId={evaluation.assessmentsByCriterionId}
-        currentCriterionId={navigator.criterionId}
-        onSelectCriterion={handleCriterionChange}
-        page={navigator.filteredPage}
-        pageSize={TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE}
-        total={navigator.projection.length}
-        onPageChange={handlePageChange}
         disabled={isNavigationBlocked}
         isLoading={navigator.criteriaQuery.isLoading || navigator.isTransitionPending}
         isError={navigator.criteriaQuery.isError}
         error={navigator.criteriaQuery.error}
         onRetry={() => void navigator.criteriaQuery.refetch()}
+        totalMatches={navigator.projection.length}
         isCurrentCriterionFilteredOut={navigator.isCurrentCriterionFilteredOut}
         hasNoMoreMatches={navigator.hasNoMoreMatches}
       />
 
-      {comparison.comparisonQuery.isLoading ? (
-        <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-          Đang tải tiêu chí...
-        </div>
-      ) : null}
-      {comparison.comparisonQuery.isError ? (
-        <TechnicalConfigurationEvaluationLoadError
-          title="Không thể tải tiêu chí đánh giá"
-          error={comparison.comparisonQuery.error}
-          fallback="Không thể tải dữ liệu so sánh."
-          onRetry={() => void comparison.comparisonQuery.refetch()}
-        />
-      ) : null}
-      {hasEvaluationReadError ? (
-        <TechnicalConfigurationEvaluationLoadError
-          title="Không thể tải dữ liệu đánh giá"
-          error={evaluationReadError}
-          fallback="Không thể tải comparison set hoặc đánh giá đã lưu."
-          onRetry={handleRetryEvaluationData}
-        />
-      ) : null}
+      <TechnicalConfigurationProgressSummary
+        progress={matrixPresentation.progress}
+        isLoading={comparisonSetQuery.isLoading || assessmentQuery.isLoading}
+        isError={hasEvaluationReadError}
+      />
 
+      <TechnicalConfigurationMatrix
+        hasRequest={hasMatrixRequest}
+        result={matrixResult}
+        visibleOptionIds={matrix.visibleOptionIds}
+        pinnedOptionIds={matrix.pinnedOptionIds}
+        focusedOptionId={matrix.focusedOptionId}
+        isLoading={comparisonQuery.isLoading}
+        isError={comparisonQuery.isError}
+        error={comparisonQuery.error}
+        onRetry={() => void comparisonQuery.refetch()}
+        onPageChange={handleMatrixPageChange}
+        onOpenDetail={handleOpenReadOnlyDetail}
+        activeEvaluationOptionId={navigator.activeSelectedOptionId}
+        activeEvaluationCriterionId={navigator.criterionId}
+        assessmentStatusByCriterionId={matrixPresentation.assessmentStatusByCriterionId}
+        matchingEvaluationCriterionIds={matrixPresentation.matchingEvaluationCriterionIds}
+        evaluationDisabled={isNavigationBlocked}
+        onOpenEvaluation={handleOpenEvaluation}
+      />
+
+      <TechnicalConfigurationEvaluationFeedback
+        isPanelOpen={navigator.isPanelOpen}
+        isPanelLoading={panelComparison.comparisonQuery.isLoading}
+        isPanelError={panelComparison.comparisonQuery.isError}
+        panelError={panelComparison.comparisonQuery.error}
+        onRetryPanel={() => void panelComparison.comparisonQuery.refetch()}
+        hasEvaluationReadError={hasEvaluationReadError}
+        evaluationReadError={evaluationReadError}
+        onRetryEvaluation={handleRetryEvaluationData}
+      />
+
+      <TechnicalConfigurationCriterionPanel
+        detail={readOnlyDetail}
+        open={readOnlyDetail !== null}
+        returnFocusRef={readOnlyReturnFocusRef}
+        onOpenChange={(open) => {
+          if (!open) setReadOnlyDetail(null)
+        }}
+      />
       <TechnicalConfigurationEvaluationPanel
         detail={detail}
         open={navigator.isPanelOpen && detail !== null}
-        onOpenChange={navigator.setIsPanelOpen}
-        returnFocusRef={detailReturnFocusRef}
+        onOpenChange={(open) => {
+          if (!open) closeEvaluationPanel()
+        }}
+        returnFocusRef={evaluationReturnFocusRef}
         technicalAxis={draft?.technicalAxis ?? null}
         evidenceAxis={draft?.evidenceAxis ?? null}
         notes={draft?.notes ?? ""}
@@ -308,29 +275,12 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
           evaluation.error ? toTechnicalConfigurationSaveErrorMessage(evaluation.error) : null
         }
         actions={
-          <>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={saveDisabled}
-              onClick={() => void handleSave()}
-            >
-              {isNavigationBlocked ? (
-                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-              ) : (
-                <Save className="size-4" aria-hidden="true" />
-              )}
-              Lưu
-            </Button>
-            <Button
-              type="button"
-              disabled={saveDisabled}
-              onClick={() => void handleSaveAndContinue()}
-            >
-              <StepForward className="size-4" aria-hidden="true" />
-              Lưu &amp; tiếp tục
-            </Button>
-          </>
+          <TechnicalConfigurationEvaluationSaveActions
+            disabled={saveDisabled}
+            saving={isNavigationBlocked}
+            onSave={() => void handleSave()}
+            onSaveAndContinue={() => void handleSaveAndContinue()}
+          />
         }
       />
       {discardConfirmationDialog}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationFeedback.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationFeedback.tsx
@@ -1,0 +1,53 @@
+import { Loader2 } from "lucide-react"
+
+import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
+
+type TechnicalConfigurationEvaluationFeedbackProps = {
+  isPanelOpen: boolean
+  isPanelLoading: boolean
+  isPanelError: boolean
+  panelError: unknown
+  onRetryPanel: () => void
+  hasEvaluationReadError: boolean
+  evaluationReadError: unknown
+  onRetryEvaluation: () => void
+}
+
+/** Renders asynchronous feedback for criterion details and saved assessments. */
+export function TechnicalConfigurationEvaluationFeedback({
+  isPanelOpen,
+  isPanelLoading,
+  isPanelError,
+  panelError,
+  onRetryPanel,
+  hasEvaluationReadError,
+  evaluationReadError,
+  onRetryEvaluation,
+}: Readonly<TechnicalConfigurationEvaluationFeedbackProps>) {
+  return (
+    <>
+      {isPanelLoading && isPanelOpen ? (
+        <div className="flex min-h-20 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Đang tải tiêu chí...
+        </div>
+      ) : null}
+      {isPanelError ? (
+        <TechnicalConfigurationEvaluationLoadError
+          title="Không thể tải tiêu chí đánh giá"
+          error={panelError}
+          fallback="Không thể tải dữ liệu so sánh."
+          onRetry={onRetryPanel}
+        />
+      ) : null}
+      {hasEvaluationReadError ? (
+        <TechnicalConfigurationEvaluationLoadError
+          title="Không thể tải dữ liệu đánh giá"
+          error={evaluationReadError}
+          fallback="Không thể tải comparison set hoặc đánh giá đã lưu."
+          onRetry={onRetryEvaluation}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationFeedback.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationFeedback.tsx
@@ -14,6 +14,7 @@ type TechnicalConfigurationEvaluationFeedbackProps = {
 }
 
 /** Renders asynchronous feedback for criterion details and saved assessments. */
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props -- Panel visibility and the two independent query states retain their source ownership.
 export function TechnicalConfigurationEvaluationFeedback({
   isPanelOpen,
   isPanelLoading,
@@ -27,12 +28,15 @@ export function TechnicalConfigurationEvaluationFeedback({
   return (
     <>
       {isPanelLoading && isPanelOpen ? (
-        <div className="flex min-h-20 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <div
+          className="flex min-h-20 items-center justify-center gap-2 text-sm text-muted-foreground"
+          role="status"
+        >
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
           Đang tải tiêu chí...
         </div>
       ) : null}
-      {isPanelError ? (
+      {isPanelOpen && isPanelError ? (
         <TechnicalConfigurationEvaluationLoadError
           title="Không thể tải tiêu chí đánh giá"
           error={panelError}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixControls.tsx
@@ -35,6 +35,7 @@ type TechnicalConfigurationEvaluationMatrixControlsProps = {
 }
 
 /** Keeps supplier targeting and save-next filtering visible above the unified matrix. */
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props -- Query, navigation, and projection flags are independent states owned by separate hooks.
 export function TechnicalConfigurationEvaluationMatrixControls({
   options,
   activeOptionId,
@@ -99,16 +100,23 @@ export function TechnicalConfigurationEvaluationMatrixControls({
       {!isLoading && !isError && totalMatches === 0 ? (
         <Alert>
           <AlertTitle>Không có tiêu chí phù hợp</AlertTitle>
-          <AlertDescription>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={disabled || statusFilter === "all"}
-              onClick={() => onStatusFilterChange("all")}
-            >
-              Xóa bộ lọc
-            </Button>
+          <AlertDescription className="space-y-3">
+            <p>
+              {statusFilter === "all"
+                ? "Phiên bản cấu hình này chưa có tiêu chí để đánh giá."
+                : "Không có tiêu chí nào khớp bộ lọc đang chọn."}
+            </p>
+            {statusFilter !== "all" ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                onClick={() => onStatusFilterChange("all")}
+              >
+                Xóa bộ lọc
+              </Button>
+            ) : null}
           </AlertDescription>
         </Alert>
       ) : null}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixControls.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import type { TechnicalConfigurationEvaluationStatusFilter } from "../../assessment-types"
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { TechnicalConfigurationEvaluationFilters } from "./TechnicalConfigurationEvaluationFilters"
+import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
+
+type TechnicalConfigurationEvaluationMatrixControlsProps = {
+  options: readonly TechnicalConfigurationOptionWire[]
+  activeOptionId: string
+  onOptionChange: (optionId: string) => void
+  statusFilter: TechnicalConfigurationEvaluationStatusFilter
+  onStatusFilterChange: (filter: TechnicalConfigurationEvaluationStatusFilter) => void
+  disabled: boolean
+  isLoading: boolean
+  isError: boolean
+  error: unknown
+  onRetry: () => void
+  totalMatches: number
+  isCurrentCriterionFilteredOut: boolean
+  hasNoMoreMatches: boolean
+}
+
+/** Keeps supplier targeting and save-next filtering visible above the unified matrix. */
+export function TechnicalConfigurationEvaluationMatrixControls({
+  options,
+  activeOptionId,
+  onOptionChange,
+  statusFilter,
+  onStatusFilterChange,
+  disabled,
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  totalMatches,
+  isCurrentCriterionFilteredOut,
+  hasNoMoreMatches,
+}: Readonly<TechnicalConfigurationEvaluationMatrixControlsProps>) {
+  return (
+    <section className="space-y-3" aria-label="Điều khiển luồng đánh giá">
+      <div className="grid gap-4 border-y py-3 lg:grid-cols-2 lg:items-end">
+        <div className="space-y-2">
+          <Label htmlFor="technical-configuration-evaluation-option">Phương án đánh giá</Label>
+          <Select value={activeOptionId} onValueChange={onOptionChange} disabled={disabled}>
+            <SelectTrigger
+              id="technical-configuration-evaluation-option"
+              aria-label="Phương án đánh giá"
+              className="w-full"
+            >
+              <SelectValue placeholder="Chọn phương án" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  {option.display_label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <TechnicalConfigurationEvaluationFilters
+          value={statusFilter}
+          onValueChange={onStatusFilterChange}
+          disabled={disabled}
+        />
+      </div>
+
+      {isLoading ? (
+        <div
+          className="flex min-h-12 items-center justify-center gap-2 text-sm text-muted-foreground"
+          role="status"
+        >
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Đang cập nhật luồng đánh giá...
+        </div>
+      ) : null}
+      {isError ? (
+        <TechnicalConfigurationEvaluationLoadError
+          title="Không thể tải luồng đánh giá"
+          error={error}
+          fallback="Không thể tải danh sách tiêu chí theo trạng thái."
+          onRetry={onRetry}
+        />
+      ) : null}
+      {!isLoading && !isError && totalMatches === 0 ? (
+        <Alert>
+          <AlertTitle>Không có tiêu chí phù hợp</AlertTitle>
+          <AlertDescription>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled || statusFilter === "all"}
+              onClick={() => onStatusFilterChange("all")}
+            >
+              Xóa bộ lọc
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {isCurrentCriterionFilteredOut ? (
+        <p className="text-sm text-muted-foreground" role="status">
+          Tiêu chí đang mở không còn thuộc luồng đánh giá hiện tại.
+        </p>
+      ) : null}
+      {hasNoMoreMatches ? (
+        <p className="text-sm text-muted-foreground" role="status">
+          Không còn tiêu chí phù hợp với luồng đánh giá.
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
+import { TechnicalConfigurationMatrixToolbar } from "../comparison/TechnicalConfigurationMatrixToolbar"
+
+type TechnicalConfigurationEvaluationMatrixToolbarProps = {
+  matrix: ReturnType<typeof useTechnicalConfigurationComparisonMatrix>
+  activeOptionId: string
+  navigationBlocked: boolean
+  runContextChange: (change: () => void) => void
+}
+
+/** Applies assessment navigation guards to matrix request and column controls. */
+export function TechnicalConfigurationEvaluationMatrixToolbar({
+  matrix,
+  activeOptionId,
+  navigationBlocked,
+  runContextChange,
+}: Readonly<TechnicalConfigurationEvaluationMatrixToolbarProps>) {
+  return (
+    <TechnicalConfigurationMatrixToolbar
+      baselineVersionId={matrix.baselineVersionId}
+      versions={matrix.versions}
+      versionsQuery={matrix.versionsQuery}
+      options={matrix.options}
+      optionsQuery={matrix.optionsQuery}
+      selectedOptions={matrix.selectedOptions}
+      visibleOptionIds={matrix.visibleOptionIds}
+      pinnedOptionIds={matrix.pinnedOptionIds}
+      focusedOptionId={matrix.focusedOptionId}
+      isSelectionLimitReached={matrix.isSelectionLimitReached}
+      onSelectBaselineVersion={(id) => runContextChange(() => matrix.selectBaselineVersion(id))}
+      onLoadMoreVersions={() => void matrix.loadMoreVersions()}
+      onRetryVersions={() => void matrix.retryVersions()}
+      onRetryOptions={() => void matrix.optionsQuery.refetch()}
+      onAddOption={(id) => {
+        if (!navigationBlocked) matrix.addOption(id)
+      }}
+      onRemoveOption={(id) => {
+        if (id === activeOptionId) {
+          runContextChange(() => matrix.removeOption(id))
+          return
+        }
+        if (!navigationBlocked) matrix.removeOption(id)
+      }}
+      onToggleOptionVisibility={(id) => {
+        if (id === activeOptionId && matrix.visibleOptionIds.includes(id)) {
+          runContextChange(() => matrix.toggleOptionVisibility(id))
+          return
+        }
+        if (!navigationBlocked) matrix.toggleOptionVisibility(id)
+      }}
+      onToggleOptionPin={(id) => {
+        if (!navigationBlocked) matrix.toggleOptionPin(id)
+      }}
+      onFocusOption={(id) => {
+        if (id === activeOptionId) {
+          if (!navigationBlocked) matrix.focusOption(id)
+          return
+        }
+        runContextChange(() => matrix.focusOption(id))
+      }}
+      onExitFocus={() => {
+        if (!navigationBlocked) matrix.exitFocusMode()
+      }}
+    />
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar.tsx
@@ -61,6 +61,10 @@ export function TechnicalConfigurationEvaluationMatrixToolbar({
         runContextChange(() => matrix.focusOption(id))
       }}
       onExitFocus={() => {
+        if (!matrix.visibleOptionIds.includes(activeOptionId)) {
+          runContextChange(() => matrix.exitFocusMode())
+          return
+        }
         if (!navigationBlocked) matrix.exitFocusMode()
       }}
     />

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationSaveActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationSaveActions.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Loader2, Save, StepForward } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationEvaluationSaveActionsProps = {
+  disabled: boolean
+  saving: boolean
+  onSave: () => void
+  onSaveAndContinue: () => void
+}
+
+/** Renders explicit assessment save commands for the criterion SideSheet. */
+export function TechnicalConfigurationEvaluationSaveActions({
+  disabled,
+  saving,
+  onSave,
+  onSaveAndContinue,
+}: Readonly<TechnicalConfigurationEvaluationSaveActionsProps>) {
+  return (
+    <>
+      <Button type="button" variant="outline" disabled={disabled} onClick={onSave}>
+        {saving ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <Save className="size-4" aria-hidden="true" />
+        )}
+        Lưu
+      </Button>
+      <Button type="button" disabled={disabled} onClick={onSaveAndContinue}>
+        <StepForward className="size-4" aria-hidden="true" />
+        Lưu &amp; tiếp tục
+      </Button>
+    </>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationSaveActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationSaveActions.tsx
@@ -20,6 +20,11 @@ export function TechnicalConfigurationEvaluationSaveActions({
 }: Readonly<TechnicalConfigurationEvaluationSaveActionsProps>) {
   return (
     <>
+      {saving ? (
+        <span className="sr-only" role="status">
+          Đang lưu đánh giá...
+        </span>
+      ) : null}
       <Button type="button" variant="outline" disabled={disabled} onClick={onSave}>
         {saving ? (
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
@@ -6,12 +6,11 @@ import { AlertCircle, Loader2, RefreshCw } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 
-import { useTechnicalConfigurationBaselineVersionSelection } from "../../_hooks/useTechnicalConfigurationBaselineVersionSelection"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "../../_hooks/useTechnicalConfigurationBeforeUnloadGuard"
-import { useTechnicalConfigurationOptionListQuery } from "../../_hooks/useTechnicalConfigurationOptionListQuery"
-import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
 import type { TechnicalConfigurationDossierWire } from "../../types"
 import { TechnicalConfigurationEvaluationActiveWorkspace } from "./TechnicalConfigurationEvaluationActiveWorkspace"
+import { TechnicalConfigurationEvaluationMatrixToolbar } from "./TechnicalConfigurationEvaluationMatrixToolbar"
 import { TechnicalConfigurationOptionReferenceRanking } from "./TechnicalConfigurationOptionReferenceRanking"
 
 type TechnicalConfigurationEvaluationWorkspaceProps = {
@@ -21,32 +20,32 @@ type TechnicalConfigurationEvaluationWorkspaceProps = {
   onRevisionChange?: (revision: number) => void
 }
 
-const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
-
-/** Activates one option-at-a-time manual assessment over canonical comparison pages. */
+/** Hosts the unified matrix while preserving assessment navigation and unload guards. */
 export function TechnicalConfigurationEvaluationWorkspace({
   dossier,
   onDirtyChange,
   onNavigationBlockedChange,
   onRevisionChange,
 }: Readonly<TechnicalConfigurationEvaluationWorkspaceProps>) {
+  const matrix = useTechnicalConfigurationComparisonMatrix(dossier.id)
   const [isDirty, setIsDirty] = React.useState(false)
   const [isNavigationBlocked, setIsNavigationBlocked] = React.useState(false)
-  const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
-  const { synchronizeVersion } = selection
-  const { optionsQuery } = useTechnicalConfigurationOptionListQuery(dossier.id)
-  const options = optionsQuery.data?.options ?? EMPTY_OPTIONS
+  const runImmediateContextChange = React.useCallback((change: () => void) => change(), [])
+  const selectedVersion =
+    matrix.versions.find((version) => version.id === matrix.baselineVersionId) ?? null
+  const displayedOptionIds = new Set(
+    matrix.focusedOptionId ? [matrix.focusedOptionId] : matrix.visibleOptionIds
+  )
+  const evaluationOptions = matrix.selectedOptions.filter((option) =>
+    displayedOptionIds.has(option.id)
+  )
 
-  React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Async baseline refresh must preserve the active assessment draft.
-    synchronizeVersion(isDirty || isNavigationBlocked)
-  }, [isDirty, isNavigationBlocked, synchronizeVersion])
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- WorkspaceShell owns top-level guards while this workspace owns assessment state.
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
   React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Pending saves block mode, tab and dossier navigation.
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Pending saves block tab and dossier navigation.
     onNavigationBlockedChange?.(isNavigationBlocked)
   }, [isNavigationBlocked, onNavigationBlockedChange])
   React.useEffect(
@@ -58,88 +57,102 @@ export function TechnicalConfigurationEvaluationWorkspace({
   )
   useTechnicalConfigurationBeforeUnloadGuard(isDirty || isNavigationBlocked)
 
-  if (selection.versionState.versionsQuery.isLoading || optionsQuery.isLoading) {
+  if (selectedVersion && evaluationOptions.length > 0) {
     return (
-      <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-        Đang tải không gian đánh giá...
+      <div className="min-w-0 space-y-6">
+        <TechnicalConfigurationEvaluationActiveWorkspace
+          dossier={dossier}
+          baselineVersionId={selectedVersion.id}
+          baselineGroups={selectedVersion.groups}
+          options={evaluationOptions}
+          matrix={matrix}
+          onDirtyChange={setIsDirty}
+          onNavigationBlockedChange={setIsNavigationBlocked}
+          onRevisionChange={onRevisionChange}
+        />
+        <TechnicalConfigurationOptionReferenceRanking
+          dossierId={dossier.id}
+          baselineVersionId={selectedVersion.id}
+        />
       </div>
     )
   }
 
-  if (selection.versionState.versionsQuery.isError && !selection.selectedVersion) {
-    return (
-      <Alert variant="destructive">
-        <AlertCircle className="size-4" aria-hidden="true" />
-        <AlertTitle>Không thể tải cấu hình cơ sở</AlertTitle>
-        <AlertDescription>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={selection.versionState.retryVersions}
-          >
-            <RefreshCw className="size-4" aria-hidden="true" />
-            Thử lại
-          </Button>
-        </AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (!selection.selectedVersion) {
-    return (
-      <Alert>
-        <AlertTitle>Chưa có cấu hình cơ sở</AlertTitle>
-        <AlertDescription>Khóa một phiên bản cấu hình trước khi đánh giá.</AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (optionsQuery.isError && options.length === 0) {
-    return (
-      <Alert variant="destructive">
-        <AlertCircle className="size-4" aria-hidden="true" />
-        <AlertTitle>Không thể tải phương án</AlertTitle>
-        <AlertDescription>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => void optionsQuery.refetch()}
-          >
-            <RefreshCw className="size-4" aria-hidden="true" />
-            Thử lại
-          </Button>
-        </AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (options.length === 0) {
-    return (
-      <Alert>
-        <AlertTitle>Chưa có phương án</AlertTitle>
-        <AlertDescription>Tạo phương án nhà cung cấp trước khi đánh giá.</AlertDescription>
-      </Alert>
-    )
-  }
-
   return (
-    <div className="min-w-0 space-y-6">
-      <TechnicalConfigurationEvaluationActiveWorkspace
-        dossier={dossier}
-        baselineVersionId={selection.selectedVersion.id}
-        baselineGroups={selection.selectedVersion.groups}
-        options={options}
-        onDirtyChange={setIsDirty}
-        onNavigationBlockedChange={setIsNavigationBlocked}
-        onRevisionChange={onRevisionChange}
+    <section className="min-w-0 space-y-4" aria-label="Không gian đánh giá cấu hình kỹ thuật">
+      <TechnicalConfigurationEvaluationMatrixToolbar
+        matrix={matrix}
+        activeOptionId=""
+        navigationBlocked={false}
+        runContextChange={runImmediateContextChange}
       />
-      <TechnicalConfigurationOptionReferenceRanking
-        dossierId={dossier.id}
-        baselineVersionId={selection.selectedVersion.id}
-      />
-    </div>
+
+      {matrix.versionsQuery.isLoading || matrix.optionsQuery.isLoading ? (
+        <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Đang tải không gian đánh giá...
+        </div>
+      ) : null}
+      {matrix.versionsQuery.isError && !selectedVersion ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>Không thể tải cấu hình cơ sở</AlertTitle>
+          <AlertDescription>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void matrix.retryVersions()}
+            >
+              <RefreshCw className="size-4" aria-hidden="true" />
+              Thử lại
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {!matrix.versionsQuery.isLoading && !matrix.versionsQuery.isError && !selectedVersion ? (
+        <Alert>
+          <AlertTitle>Chưa chọn cấu hình cơ sở</AlertTitle>
+          <AlertDescription>Chọn một phiên bản cấu hình để bắt đầu đánh giá.</AlertDescription>
+        </Alert>
+      ) : null}
+      {selectedVersion &&
+      matrix.options.length > 0 &&
+      evaluationOptions.length === 0 &&
+      !matrix.optionsQuery.isLoading &&
+      !matrix.optionsQuery.isError ? (
+        <Alert>
+          <AlertTitle>Chưa chọn phương án hiển thị</AlertTitle>
+          <AlertDescription>
+            Chọn và hiển thị ít nhất một phương án trong ma trận để bắt đầu đánh giá.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {matrix.optionsQuery.isError && matrix.options.length === 0 ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>Không thể tải phương án</AlertTitle>
+          <AlertDescription>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void matrix.optionsQuery.refetch()}
+            >
+              <RefreshCw className="size-4" aria-hidden="true" />
+              Thử lại
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {!matrix.optionsQuery.isLoading &&
+      !matrix.optionsQuery.isError &&
+      matrix.options.length === 0 ? (
+        <Alert>
+          <AlertTitle>Chưa có phương án</AlertTitle>
+          <AlertDescription>Tạo phương án nhà cung cấp trước khi đánh giá.</AlertDescription>
+        </Alert>
+      ) : null}
+    </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
@@ -1,0 +1,50 @@
+import {
+  deriveTechnicalConfigurationEvaluationStatus,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+
+import type {
+  TechnicalConfigurationAssessmentWire,
+  TechnicalConfigurationEvaluationStatusFilter,
+} from "../../assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+import { buildTechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
+
+type EvaluationProjectionItem = Readonly<{
+  criterion: Readonly<{ id: string }>
+}>
+
+type BuildTechnicalConfigurationEvaluationMatrixPresentationInput = Readonly<{
+  groups: readonly TechnicalConfigurationBaselineGroupWire[]
+  assessmentsByCriterionId: Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
+  projection: readonly EvaluationProjectionItem[]
+  statusFilter: TechnicalConfigurationEvaluationStatusFilter
+}>
+
+/** Derives all matrix-facing assessment presentation from one assessment snapshot. */
+export function buildTechnicalConfigurationEvaluationMatrixPresentation({
+  groups,
+  assessmentsByCriterionId,
+  projection,
+  statusFilter,
+}: BuildTechnicalConfigurationEvaluationMatrixPresentationInput) {
+  const assessments = Object.values(assessmentsByCriterionId)
+  const assessmentStatusByCriterionId = new Map<string, TechnicalConfigurationDerivedStatus>()
+
+  for (const assessment of assessments) {
+    assessmentStatusByCriterionId.set(
+      assessment.criterion_id,
+      deriveTechnicalConfigurationEvaluationStatus(
+        assessment.technical_axis,
+        assessment.evidence_axis
+      )
+    )
+  }
+
+  return {
+    progress: buildTechnicalConfigurationEvaluationProgress({ groups, assessments }),
+    assessmentStatusByCriterionId,
+    matchingEvaluationCriterionIds:
+      statusFilter === "all" ? undefined : new Set(projection.map((item) => item.criterion.id)),
+  }
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
@@ -21,13 +21,19 @@ type BuildTechnicalConfigurationEvaluationMatrixPresentationInput = Readonly<{
   statusFilter: TechnicalConfigurationEvaluationStatusFilter
 }>
 
+export type TechnicalConfigurationEvaluationMatrixPresentation = Readonly<{
+  progress: ReturnType<typeof buildTechnicalConfigurationEvaluationProgress>
+  assessmentStatusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+  matchingEvaluationCriterionIds: ReadonlySet<string> | undefined
+}>
+
 /** Derives all matrix-facing assessment presentation from one assessment snapshot. */
 export function buildTechnicalConfigurationEvaluationMatrixPresentation({
   groups,
   assessmentsByCriterionId,
   projection,
   statusFilter,
-}: BuildTechnicalConfigurationEvaluationMatrixPresentationInput) {
+}: BuildTechnicalConfigurationEvaluationMatrixPresentationInput): TechnicalConfigurationEvaluationMatrixPresentation {
   const assessments = Object.values(assessmentsByCriterionId)
   const assessmentStatusByCriterionId = new Map<string, TechnicalConfigurationDerivedStatus>()
 

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts
@@ -21,7 +21,7 @@ type BuildTechnicalConfigurationEvaluationMatrixPresentationInput = Readonly<{
   statusFilter: TechnicalConfigurationEvaluationStatusFilter
 }>
 
-export type TechnicalConfigurationEvaluationMatrixPresentation = Readonly<{
+type TechnicalConfigurationEvaluationMatrixPresentation = Readonly<{
   progress: ReturnType<typeof buildTechnicalConfigurationEvaluationProgress>
   assessmentStatusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
   matchingEvaluationCriterionIds: ReadonlySet<string> | undefined

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
@@ -104,6 +104,16 @@ export function getTechnicalConfigurationEvaluationPage({
   return projection.slice(start, start + pageSize)
 }
 
+/** Returns the filtered projection page containing a criterion. */
+export function getTechnicalConfigurationEvaluationProjectionPage(
+  projection: readonly TechnicalConfigurationEvaluationCriterionListItem[],
+  criterionId: string,
+  pageSize: number
+) {
+  const index = projection.findIndex((item) => item.criterion.id === criterionId)
+  return index >= 0 ? Math.floor(index / pageSize) + 1 : 1
+}
+
 /** Finds the first matching criterion after the saved canonical position without wrapping. */
 export function findNextTechnicalConfigurationEvaluationCriterion({
   projection,

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
@@ -104,16 +104,6 @@ export function getTechnicalConfigurationEvaluationPage({
   return projection.slice(start, start + pageSize)
 }
 
-/** Returns the filtered projection page containing a criterion. */
-export function getTechnicalConfigurationEvaluationProjectionPage(
-  projection: readonly TechnicalConfigurationEvaluationCriterionListItem[],
-  criterionId: string,
-  pageSize: number
-) {
-  const index = projection.findIndex((item) => item.criterion.id === criterionId)
-  return index >= 0 ? Math.floor(index / pageSize) + 1 : 1
-}
-
 /** Finds the first matching criterion after the saved canonical position without wrapping. */
 export function findNextTechnicalConfigurationEvaluationCriterion({
   projection,

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-status-badge.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-status-badge.ts
@@ -1,0 +1,15 @@
+import type { TechnicalConfigurationDerivedStatus } from "@/lib/technical-configuration-evaluation"
+
+/** Maps each derived evaluation status to its shared badge presentation. */
+export const TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS = {
+  not_evaluated: "muted",
+  not_applicable: "outline",
+  fails: "destructive",
+  unclear: "outline",
+  insufficient_evidence: "outline",
+  exceeds: "secondary",
+  meets: "secondary",
+} as const satisfies Record<
+  TechnicalConfigurationDerivedStatus,
+  "destructive" | "muted" | "outline" | "secondary"
+>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
@@ -12,11 +12,28 @@ import {
   buildTechnicalConfigurationEvaluationProjection,
   findNextTechnicalConfigurationEvaluationCriterion,
   findTechnicalConfigurationEvaluationCriterion,
-  getTechnicalConfigurationEvaluationPage,
 } from "../_components/evaluation/technical-configuration-evaluation-navigation"
 import { useTechnicalConfigurationEvaluationCriteria } from "./useTechnicalConfigurationEvaluationCriteria"
+import { useTechnicalConfigurationEvaluationTransition } from "./useTechnicalConfigurationEvaluationTransition"
 
 type RequestNavigation = (navigate: () => void) => void
+type EvaluationProjectionItem = ReturnType<
+  typeof buildTechnicalConfigurationEvaluationProjection
+>[number]
+type OnCriterionCommit = (criterion: EvaluationProjectionItem | null) => void
+
+function resolveContextCriterion(
+  projection: readonly EvaluationProjectionItem[],
+  criterionId: string | null,
+  canonicalPage: number
+) {
+  return (
+    (criterionId ? projection.find((item) => item.criterion.id === criterionId) : undefined) ??
+    projection.find((item) => item.canonicalPage === canonicalPage) ??
+    (criterionId ? projection[0] : undefined) ??
+    null
+  )
+}
 
 type UseTechnicalConfigurationEvaluationNavigatorInput = {
   options: readonly TechnicalConfigurationOptionWire[]
@@ -25,16 +42,7 @@ type UseTechnicalConfigurationEvaluationNavigatorInput = {
   pageSize: number
 }
 
-function getProjectionPage(
-  projection: ReturnType<typeof buildTechnicalConfigurationEvaluationProjection>,
-  criterionId: string,
-  pageSize: number
-) {
-  const index = projection.findIndex((item) => item.criterion.id === criterionId)
-  return index >= 0 ? Math.floor(index / pageSize) + 1 : 1
-}
-
-/** Owns P12B2 option, filter, filtered page, selection and no-more-match state. */
+/** Owns P12B2 option, filter, canonical page, selection and no-more-match state. */
 export function useTechnicalConfigurationEvaluationNavigator({
   options,
   baselineGroups,
@@ -44,14 +52,15 @@ export function useTechnicalConfigurationEvaluationNavigator({
   const [selectedOptionId, setSelectedOptionId] = React.useState(options[0]?.id ?? "")
   const [statusFilter, setStatusFilter] =
     React.useState<TechnicalConfigurationEvaluationStatusFilter>("all")
-  const [page, setPage] = React.useState(1)
+  const [canonicalPage, setCanonicalPage] = React.useState(1)
   const [requestedCriterionId, setRequestedCriterionId] = React.useState<string | null>(null)
   const [isPanelOpen, setIsPanelOpen] = React.useState(false)
   const [hasNoMoreMatches, setHasNoMoreMatches] = React.useState(false)
-  const [isTransitionPending, setIsTransitionPending] = React.useState(false)
-  const transitionPendingRef = React.useRef(false)
+  const { isTransitionPending, transitionPendingRef, startTransition } =
+    useTechnicalConfigurationEvaluationTransition()
   const selectedOption = options.find((option) => option.id === selectedOptionId) ?? options[0]
   const activeSelectedOptionId = selectedOption?.id ?? ""
+  if (selectedOptionId !== activeSelectedOptionId) setSelectedOptionId(activeSelectedOptionId)
   const { criteriaQuery, loadCriteria } = useTechnicalConfigurationEvaluationCriteria({
     optionId: activeSelectedOptionId,
     baselineVersionId,
@@ -65,14 +74,10 @@ export function useTechnicalConfigurationEvaluationNavigator({
       }),
     [baselineGroups, criteriaQuery.data]
   )
-  const totalPages = Math.max(1, Math.ceil(projection.length / pageSize))
-  const filteredPage = Math.min(page, totalPages)
-  const pageCriteria = getTechnicalConfigurationEvaluationPage({
-    projection,
-    page: filteredPage,
-    pageSize,
-  })
-  const criterionId = requestedCriterionId ?? pageCriteria[0]?.criterion.id ?? null
+  const criterionId =
+    requestedCriterionId ??
+    projection.find((item) => item.canonicalPage === canonicalPage)?.criterion.id ??
+    null
   const currentCriterion =
     projection.find((item) => item.criterion.id === criterionId) ??
     findTechnicalConfigurationEvaluationCriterion({
@@ -86,25 +91,11 @@ export function useTechnicalConfigurationEvaluationNavigator({
     !criteriaQuery.isError &&
     !projection.some((item) => item.criterion.id === criterionId)
 
-  const startTransition = React.useCallback((transition: () => Promise<void>) => {
-    if (transitionPendingRef.current) return Promise.resolve()
-
-    transitionPendingRef.current = true
-    setIsTransitionPending(true)
-    return transition()
-      .catch(() => {
-        // Candidate load failures preserve the current navigation state.
-      })
-      .finally(() => {
-        transitionPendingRef.current = false
-        setIsTransitionPending(false)
-      })
-  }, [])
-
   const changeFilter = React.useCallback(
     (
       nextFilter: TechnicalConfigurationEvaluationStatusFilter,
-      requestNavigation: RequestNavigation
+      requestNavigation: RequestNavigation,
+      onCriterionCommit?: OnCriterionCommit
     ) => {
       if (nextFilter === statusFilter || !activeSelectedOptionId || transitionPendingRef.current) {
         return
@@ -122,17 +113,15 @@ export function useTechnicalConfigurationEvaluationNavigator({
         })
         const currentRemainsVisible =
           criterionId !== null && nextProjection.some((item) => item.criterion.id === criterionId)
-        const nextCriterionId = currentRemainsVisible
-          ? criterionId
-          : (nextProjection[0]?.criterion.id ?? null)
+        const nextCriterion = resolveContextCriterion(nextProjection, criterionId, canonicalPage)
+        const nextCriterionId = nextCriterion?.criterion.id ?? null
         const commit = () => {
           setStatusFilter(nextFilter)
-          setPage(
-            nextCriterionId ? getProjectionPage(nextProjection, nextCriterionId, pageSize) : 1
-          )
+          if (nextCriterion) setCanonicalPage(nextCriterion.canonicalPage)
           setRequestedCriterionId(nextCriterionId)
           setHasNoMoreMatches(false)
           if (!nextCriterionId) setIsPanelOpen(false)
+          onCriterionCommit?.(nextCriterion)
         }
 
         if (criterionId === null || currentRemainsVisible) {
@@ -146,16 +135,21 @@ export function useTechnicalConfigurationEvaluationNavigator({
       activeSelectedOptionId,
       baselineGroups,
       baselineVersionId,
+      canonicalPage,
       criterionId,
       loadCriteria,
-      pageSize,
       startTransition,
       statusFilter,
+      transitionPendingRef,
     ]
   )
 
   const changeOption = React.useCallback(
-    (nextOptionId: string, requestNavigation: RequestNavigation) => {
+    (
+      nextOptionId: string,
+      requestNavigation: RequestNavigation,
+      onCriterionCommit?: OnCriterionCommit
+    ) => {
       if (nextOptionId === activeSelectedOptionId || transitionPendingRef.current) return
 
       requestNavigation(() => {
@@ -169,19 +163,15 @@ export function useTechnicalConfigurationEvaluationNavigator({
             groups: baselineGroups,
             entries,
           })
-          const nextCriterionId =
-            (criterionId &&
-              nextProjection.find((item) => item.criterion.id === criterionId)?.criterion.id) ||
-            nextProjection[0]?.criterion.id ||
-            null
+          const nextCriterion = resolveContextCriterion(nextProjection, criterionId, canonicalPage)
+          const nextCriterionId = nextCriterion?.criterion.id ?? null
 
           setSelectedOptionId(nextOptionId)
-          setPage(
-            nextCriterionId ? getProjectionPage(nextProjection, nextCriterionId, pageSize) : 1
-          )
+          if (nextCriterion) setCanonicalPage(nextCriterion.canonicalPage)
           setRequestedCriterionId(nextCriterionId)
           setIsPanelOpen(false)
           setHasNoMoreMatches(false)
+          onCriterionCommit?.(nextCriterion)
         })
       })
     },
@@ -189,24 +179,26 @@ export function useTechnicalConfigurationEvaluationNavigator({
       activeSelectedOptionId,
       baselineGroups,
       baselineVersionId,
+      canonicalPage,
       criterionId,
       loadCriteria,
-      pageSize,
       startTransition,
       statusFilter,
+      transitionPendingRef,
     ]
   )
 
   const changePage = React.useCallback(
-    (nextPage: number, requestNavigation: RequestNavigation) => {
-      if (nextPage === filteredPage) return
+    (nextPage: number, requestNavigation: RequestNavigation, onCommit?: () => void) => {
       requestNavigation(() => {
-        setPage(nextPage)
+        setCanonicalPage(nextPage)
         setRequestedCriterionId(null)
+        setIsPanelOpen(false)
         setHasNoMoreMatches(false)
+        onCommit?.()
       })
     },
-    [filteredPage]
+    []
   )
 
   const changeCriterion = React.useCallback(
@@ -226,8 +218,56 @@ export function useTechnicalConfigurationEvaluationNavigator({
     [criterionId]
   )
 
+  const changeTarget = React.useCallback(
+    (
+      nextOptionId: string,
+      nextCriterionId: string,
+      requestNavigation: RequestNavigation,
+      beforeOpen?: () => void
+    ) => {
+      if (transitionPendingRef.current) return
+      if (nextOptionId === activeSelectedOptionId) {
+        changeCriterion(nextCriterionId, requestNavigation, beforeOpen)
+        return
+      }
+
+      requestNavigation(() => {
+        void startTransition(async () => {
+          const entries = await loadCriteria({
+            optionId: nextOptionId,
+            baselineVersionId,
+            statusFilter,
+          })
+          const nextProjection = buildTechnicalConfigurationEvaluationProjection({
+            groups: baselineGroups,
+            entries,
+          })
+
+          beforeOpen?.()
+          setSelectedOptionId(nextOptionId)
+          setRequestedCriterionId(nextCriterionId)
+          setIsPanelOpen(true)
+          setHasNoMoreMatches(false)
+        })
+      })
+    },
+    [
+      activeSelectedOptionId,
+      baselineGroups,
+      baselineVersionId,
+      changeCriterion,
+      loadCriteria,
+      startTransition,
+      statusFilter,
+      transitionPendingRef,
+    ]
+  )
+
   const advanceAfterSave = React.useCallback(async () => {
-    if (!currentCriterion || !activeSelectedOptionId) return
+    if (!currentCriterion || !activeSelectedOptionId) return null
+    const transitionResult: {
+      nextCriterion: (typeof projection)[number] | null
+    } = { nextCriterion: null }
     await startTransition(async () => {
       const entries = await loadCriteria({
         optionId: activeSelectedOptionId,
@@ -238,28 +278,28 @@ export function useTechnicalConfigurationEvaluationNavigator({
         groups: baselineGroups,
         entries,
       })
-      const nextCriterion = findNextTechnicalConfigurationEvaluationCriterion({
+      transitionResult.nextCriterion = findNextTechnicalConfigurationEvaluationCriterion({
         projection: nextProjection,
         currentCanonicalIndex: currentCriterion.canonicalIndex,
       })
 
-      if (!nextCriterion) {
+      if (!transitionResult.nextCriterion) {
         setHasNoMoreMatches(true)
         return
       }
 
-      setPage(getProjectionPage(nextProjection, nextCriterion.criterion.id, pageSize))
-      setRequestedCriterionId(nextCriterion.criterion.id)
+      setCanonicalPage(transitionResult.nextCriterion.canonicalPage)
+      setRequestedCriterionId(transitionResult.nextCriterion.criterion.id)
       setIsPanelOpen(true)
       setHasNoMoreMatches(false)
     })
+    return transitionResult.nextCriterion
   }, [
     activeSelectedOptionId,
     baselineGroups,
     baselineVersionId,
     currentCriterion,
     loadCriteria,
-    pageSize,
     startTransition,
     statusFilter,
   ])
@@ -268,8 +308,6 @@ export function useTechnicalConfigurationEvaluationNavigator({
     selectedOption,
     activeSelectedOptionId,
     statusFilter,
-    filteredPage,
-    pageCriteria,
     projection,
     criterionId,
     currentCriterion,
@@ -283,6 +321,7 @@ export function useTechnicalConfigurationEvaluationNavigator({
     changeOption,
     changePage,
     changeCriterion,
+    changeTarget,
     advanceAfterSave,
   }
 }

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
@@ -233,14 +233,10 @@ export function useTechnicalConfigurationEvaluationNavigator({
 
       requestNavigation(() => {
         void startTransition(async () => {
-          const entries = await loadCriteria({
+          await loadCriteria({
             optionId: nextOptionId,
             baselineVersionId,
             statusFilter,
-          })
-          const nextProjection = buildTechnicalConfigurationEvaluationProjection({
-            groups: baselineGroups,
-            entries,
           })
 
           beforeOpen?.()
@@ -253,7 +249,6 @@ export function useTechnicalConfigurationEvaluationNavigator({
     },
     [
       activeSelectedOptionId,
-      baselineGroups,
       baselineVersionId,
       changeCriterion,
       loadCriteria,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationTransition.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationTransition.ts
@@ -12,8 +12,8 @@ export function useTechnicalConfigurationEvaluationTransition() {
     transitionPendingRef.current = true
     setIsTransitionPending(true)
     return transition()
-      .catch(() => {
-        // Candidate load failures preserve the current navigation state.
+      .catch((error: unknown) => {
+        console.error("Technical configuration evaluation transition failed.", error)
       })
       .finally(() => {
         transitionPendingRef.current = false

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationTransition.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationTransition.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import * as React from "react"
+
+/** Serializes async evaluator navigation and exposes one blocking state. */
+export function useTechnicalConfigurationEvaluationTransition() {
+  const [isTransitionPending, setIsTransitionPending] = React.useState(false)
+  const transitionPendingRef = React.useRef(false)
+  const startTransition = React.useCallback((transition: () => Promise<void>) => {
+    if (transitionPendingRef.current) return Promise.resolve()
+
+    transitionPendingRef.current = true
+    setIsTransitionPending(true)
+    return transition()
+      .catch(() => {
+        // Candidate load failures preserve the current navigation state.
+      })
+      .finally(() => {
+        transitionPendingRef.current = false
+        setIsTransitionPending(false)
+      })
+  }, [])
+
+  return { isTransitionPending, transitionPendingRef, startTransition }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts
@@ -28,27 +28,29 @@ export function useTechnicalConfigurationEvaluationWorkspaceActions({
   isNavigationBlocked,
   evaluationReturnFocusRef,
 }: UseTechnicalConfigurationEvaluationWorkspaceActionsInput) {
+  const syncMatrixPage = React.useCallback(
+    (
+      criterion: ReturnType<typeof useTechnicalConfigurationEvaluationNavigator>["currentCriterion"]
+    ) => {
+      if (criterion && criterion.canonicalPage !== matrix.page) {
+        matrix.setPage(criterion.canonicalPage)
+      }
+    },
+    [matrix]
+  )
   const handleOptionChange = React.useCallback(
     (nextOptionId: string) => {
       if (isNavigationBlocked) return
-      navigator.changeOption(nextOptionId, requestNavigation, (nextCriterion) => {
-        if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
-          matrix.setPage(nextCriterion.canonicalPage)
-        }
-      })
+      navigator.changeOption(nextOptionId, requestNavigation, syncMatrixPage)
     },
-    [isNavigationBlocked, matrix, navigator, requestNavigation]
+    [isNavigationBlocked, navigator, requestNavigation, syncMatrixPage]
   )
   const handleFilterChange = React.useCallback(
     (nextFilter: TechnicalConfigurationEvaluationStatusFilter) => {
       if (isNavigationBlocked) return
-      navigator.changeFilter(nextFilter, requestNavigation, (nextCriterion) => {
-        if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
-          matrix.setPage(nextCriterion.canonicalPage)
-        }
-      })
+      navigator.changeFilter(nextFilter, requestNavigation, syncMatrixPage)
     },
-    [isNavigationBlocked, matrix, navigator, requestNavigation]
+    [isNavigationBlocked, navigator, requestNavigation, syncMatrixPage]
   )
   const handleOpenEvaluation = React.useCallback(
     (target: TechnicalConfigurationMatrixEvaluationTarget) => {
@@ -77,13 +79,11 @@ export function useTechnicalConfigurationEvaluationWorkspaceActions({
     try {
       await evaluation.save()
       const nextCriterion = await navigator.advanceAfterSave()
-      if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
-        matrix.setPage(nextCriterion.canonicalPage)
-      }
+      syncMatrixPage(nextCriterion)
     } catch {
       // Failed saves intentionally remain on the current criterion.
     }
-  }, [evaluation, matrix, navigator])
+  }, [evaluation, navigator, syncMatrixPage])
   const handleRetryEvaluationData = React.useCallback(() => {
     if (evaluation.comparisonSetQuery.isError) void evaluation.comparisonSetQuery.refetch()
     if (evaluation.assessmentQuery.isError) void evaluation.assessmentQuery.refetch()

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts
@@ -1,0 +1,118 @@
+"use client"
+
+import * as React from "react"
+
+import type { TechnicalConfigurationEvaluationStatusFilter } from "../assessment-types"
+import type { TechnicalConfigurationMatrixEvaluationTarget } from "../_components/comparison/TechnicalConfigurationMatrixRow"
+import { useTechnicalConfigurationComparisonMatrix } from "./useTechnicalConfigurationComparisonMatrix"
+import { useTechnicalConfigurationEvaluationDraft } from "./useTechnicalConfigurationEvaluationDraft"
+import { useTechnicalConfigurationEvaluationNavigator } from "./useTechnicalConfigurationEvaluationNavigator"
+
+type RequestNavigation = (navigate: () => void) => void
+
+type UseTechnicalConfigurationEvaluationWorkspaceActionsInput = {
+  evaluation: ReturnType<typeof useTechnicalConfigurationEvaluationDraft>
+  navigator: ReturnType<typeof useTechnicalConfigurationEvaluationNavigator>
+  matrix: ReturnType<typeof useTechnicalConfigurationComparisonMatrix>
+  requestNavigation: RequestNavigation
+  isNavigationBlocked: boolean
+  evaluationReturnFocusRef: React.RefObject<HTMLElement | null>
+}
+
+/** Owns guarded matrix, panel and save transitions for the unified evaluator. */
+export function useTechnicalConfigurationEvaluationWorkspaceActions({
+  evaluation,
+  navigator,
+  matrix,
+  requestNavigation,
+  isNavigationBlocked,
+  evaluationReturnFocusRef,
+}: UseTechnicalConfigurationEvaluationWorkspaceActionsInput) {
+  const handleOptionChange = React.useCallback(
+    (nextOptionId: string) => {
+      if (isNavigationBlocked) return
+      navigator.changeOption(nextOptionId, requestNavigation, (nextCriterion) => {
+        if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
+          matrix.setPage(nextCriterion.canonicalPage)
+        }
+      })
+    },
+    [isNavigationBlocked, matrix, navigator, requestNavigation]
+  )
+  const handleFilterChange = React.useCallback(
+    (nextFilter: TechnicalConfigurationEvaluationStatusFilter) => {
+      if (isNavigationBlocked) return
+      navigator.changeFilter(nextFilter, requestNavigation, (nextCriterion) => {
+        if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
+          matrix.setPage(nextCriterion.canonicalPage)
+        }
+      })
+    },
+    [isNavigationBlocked, matrix, navigator, requestNavigation]
+  )
+  const handleOpenEvaluation = React.useCallback(
+    (target: TechnicalConfigurationMatrixEvaluationTarget) => {
+      if (isNavigationBlocked) return
+      navigator.changeTarget(target.optionId, target.criterionId, requestNavigation, () => {
+        evaluationReturnFocusRef.current = target.trigger
+      })
+    },
+    [evaluationReturnFocusRef, isNavigationBlocked, navigator, requestNavigation]
+  )
+  const handleMatrixPageChange = React.useCallback(
+    (nextPage: number) => {
+      if (nextPage === matrix.page || isNavigationBlocked) return
+      navigator.changePage(nextPage, requestNavigation, () => matrix.setPage(nextPage))
+    },
+    [isNavigationBlocked, matrix, navigator, requestNavigation]
+  )
+  const handleSave = React.useCallback(async () => {
+    try {
+      await evaluation.save()
+    } catch {
+      // The draft hook preserves input and exposes the actionable error.
+    }
+  }, [evaluation])
+  const handleSaveAndContinue = React.useCallback(async () => {
+    try {
+      await evaluation.save()
+      const nextCriterion = await navigator.advanceAfterSave()
+      if (nextCriterion && nextCriterion.canonicalPage !== matrix.page) {
+        matrix.setPage(nextCriterion.canonicalPage)
+      }
+    } catch {
+      // Failed saves intentionally remain on the current criterion.
+    }
+  }, [evaluation, matrix, navigator])
+  const handleRetryEvaluationData = React.useCallback(() => {
+    if (evaluation.comparisonSetQuery.isError) void evaluation.comparisonSetQuery.refetch()
+    if (evaluation.assessmentQuery.isError) void evaluation.assessmentQuery.refetch()
+    if (navigator.criteriaQuery.isError) void navigator.criteriaQuery.refetch()
+  }, [evaluation.assessmentQuery, evaluation.comparisonSetQuery, navigator.criteriaQuery])
+  const closeEvaluationPanel = React.useCallback(() => {
+    if (isNavigationBlocked) return
+    navigator.setIsPanelOpen(false)
+  }, [isNavigationBlocked, navigator])
+  const runMatrixContextChange = React.useCallback(
+    (change: () => void) => {
+      if (isNavigationBlocked) return
+      requestNavigation(() => {
+        navigator.setIsPanelOpen(false)
+        change()
+      })
+    },
+    [isNavigationBlocked, navigator, requestNavigation]
+  )
+
+  return {
+    handleOptionChange,
+    handleFilterChange,
+    handleOpenEvaluation,
+    handleMatrixPageChange,
+    handleSave,
+    handleSaveAndContinue,
+    handleRetryEvaluationData,
+    closeEvaluationPanel,
+    runMatrixContextChange,
+  }
+}


### PR DESCRIPTION
## Summary
- consolidate supplier comparison and evaluation into one matrix workspace while keeping evaluation editing in the existing side sheet
- align matrix actions, filters, KPI progress, evaluation feedback, and save workflows in the unified layout
- preserve the active supplier across focus/visibility changes and keep sparse filtered navigation anchored to the canonical matrix page
- add focused regression coverage for matrix presentation, navigation, supplier visibility, dirty drafts, and save transitions

## Test Plan
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- 10 focused Vitest files: 73/73 tests passed
- `node scripts/npm-run.js run react-doctor` (100/100)
- `git diff --check main`

Browser tests were intentionally not run per request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies supplier comparison and evaluation into one matrix workspace with guarded toolbar/controls and serialized navigation. Keeps side‑sheet editing, shows derived status badges and KPI progress, and improves loading/error feedback.

- **New Features**
  - Open evaluation from matrix cells; highlights the active filtered criterion and shows status badges.
  - Dedicated evaluation toolbar and controls with guards; disables pagination and request/column changes while transitions run.
  - Clear feedback: panel loading announcements, scoped panel/read errors, and retry for matrix/panel queries.
  - Save and save‑and‑continue actions with loading states and screen‑reader cues.
  - Navigation stays on the canonical matrix page and preserves the active supplier.

- **Refactors**
  - Comparison tab now mounts the evaluation workspace; matrix hook/pagination reused and toolbar logic unified.
  - Matrix row emits evaluation targets; extracted focused components for toolbar, controls, feedback, and save actions.
  - Centralized status badge variants and matrix presentation builder; removed ad‑hoc status mapping.
  - Added hooks for workspace actions and serialized transitions; navigator resolves canonical context and blocks conflicting moves.
  - Expanded tests for matrix presentation, navigation blocking, feedback scoping, and active workspace regressions.

<sup>Written for commit 052431fac4a12f054c805d42473c551ed6ea6a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified technical configuration evaluation workspace combining the comparison matrix and evaluation panel.
  * Added assessment status badges, active-cell highlighting, evaluation actions, and status-based filtering.
  * Added evaluation option controls, pagination, focus and visibility handling, export, retry, and save/save-and-continue actions.
  * Added contextual loading, empty-state, error, and pending-save feedback.
* **Bug Fixes**
  * Improved evaluation navigation, preserving selections and progress while changing filters, options, or pages.
  * Prevented invalid transitions and retained drafts after failed saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->