### PR TITLE
feat(technical-config): expand baseline editing workspace

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchical-editor.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchical-editor.test.tsx
@@ -78,6 +78,7 @@ function EditorHarness({
   initialDraft?: TechnicalConfigurationBaselineEditorDraft
 }) {
   const [draft, setDraft] = useState(initialDraft)
+  const [isFocusMode, setIsFocusMode] = useState(false)
   const bulkSessions = useTechnicalConfigurationBulkEntrySessions()
   const inlineEditor = useTechnicalConfigurationInlineEditor({
     draft,
@@ -107,6 +108,7 @@ function EditorHarness({
           saveStatus: "idle",
           hasPendingBulkInput: bulkSessions.hasPendingInput,
         }}
+        isFocusMode={isFocusMode}
         activeValue={inlineEditor.activeValue}
         entryMode={inlineEditor.entryMode}
         getBulkSession={bulkSessions.getSession}
@@ -126,6 +128,7 @@ function EditorHarness({
         onBulkCancel={inlineEditor.cancelBulk}
         onBulkAccept={inlineEditor.acceptBulk}
         onSave={vi.fn()}
+        onToggleFocusMode={() => setIsFocusMode((current) => !current)}
       />
     </>
   )
@@ -169,6 +172,22 @@ describe("TechnicalConfigurationBaselineEditor hierarchy", () => {
     expect(scrollRegion).toHaveAttribute("tabindex", "0")
     expect(scrollRegion).not.toContainElement(saveButton)
     expect(workspace).toContainElement(saveButton)
+  })
+
+  it("toggles focus mode without replacing the editor or its draft", async () => {
+    const user = userEvent.setup()
+    render(<EditorHarness />)
+
+    const workspace = screen.getByTestId("baseline-editor-workspace")
+    const requirement = screen.getByLabelText("Nội dung yêu cầu 1.1")
+
+    await user.type(requirement, " đã sửa")
+    await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
+
+    expect(screen.getByTestId("baseline-editor-workspace")).toBe(workspace)
+    expect(screen.getByLabelText("Nội dung yêu cầu 1.1")).toBe(requirement)
+    expect(requirement).toHaveValue("Nguồn điện ổn định đã sửa")
+    expect(screen.getByRole("button", { name: "Thu nhỏ vùng chỉnh sửa" })).toBeInTheDocument()
   })
 
   it("collapses one group independently and restores its row content", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchical-editor.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchical-editor.test.tsx
@@ -180,14 +180,19 @@ describe("TechnicalConfigurationBaselineEditor hierarchy", () => {
 
     const workspace = screen.getByTestId("baseline-editor-workspace")
     const requirement = screen.getByLabelText("Nội dung yêu cầu 1.1")
+    const focusButton = screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" })
 
     await user.type(requirement, " đã sửa")
-    await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
+    expect(focusButton).toHaveAttribute("aria-pressed", "false")
+    await user.click(focusButton)
 
     expect(screen.getByTestId("baseline-editor-workspace")).toBe(workspace)
     expect(screen.getByLabelText("Nội dung yêu cầu 1.1")).toBe(requirement)
     expect(requirement).toHaveValue("Nguồn điện ổn định đã sửa")
-    expect(screen.getByRole("button", { name: "Thu nhỏ vùng chỉnh sửa" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Thu nhỏ vùng chỉnh sửa" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
   })
 
   it("collapses one group independently and restores its row content", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
@@ -134,6 +134,33 @@ describe("technical configuration inline workflow", () => {
     expect(editor).toHaveClass("min-h-0", "flex-1")
   })
 
+  it("replaces the version toolbar with compact dossier context in focus mode", async () => {
+    const user = userEvent.setup()
+    const onToggleFocusMode = vi.fn()
+
+    render(
+      <TechnicalConfigurationBaselineTab
+        dossier={dossier}
+        isFocusMode
+        onDirtyChange={vi.fn()}
+        onToggleFocusMode={onToggleFocusMode}
+      />
+    )
+
+    expect(
+      await screen.findByRole("region", { name: "Ngữ cảnh cấu hình đang chỉnh sửa" })
+    ).toHaveTextContent("Cấu hình máy lọc thận")
+    expect(
+      screen.getByRole("region", { name: "Ngữ cảnh cấu hình đang chỉnh sửa" })
+    ).toHaveTextContent("Phiên bản 1 · Bản nháp")
+    expect(
+      screen.queryByRole("region", { name: "Lịch sử phiên bản cấu hình cơ sở" })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Thu nhỏ vùng chỉnh sửa" }))
+    expect(onToggleFocusMode).toHaveBeenCalledOnce()
+  })
+
   it("uses current-draft validation for summaries without exposing field errors before save", async () => {
     const originalDraft = baseline.editorDraft
     baseline.editorDraft = {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
@@ -1,0 +1,162 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationWorkspaceShell } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab",
+  () => ({
+    TechnicalConfigurationBaselineTab: ({
+      isFocusMode,
+      onDirtyChange,
+      onNavigationBlockedChange,
+      onToggleFocusMode,
+    }: {
+      isFocusMode: boolean
+      onDirtyChange: (dirty: boolean) => void
+      onNavigationBlockedChange?: (blocked: boolean) => void
+      onToggleFocusMode: () => void
+    }) => {
+      const [isDialogOpen, setIsDialogOpen] = React.useState(false)
+
+      React.useEffect(() => {
+        onDirtyChange(false)
+        onNavigationBlockedChange?.(false)
+      }, [onDirtyChange, onNavigationBlockedChange])
+
+      return (
+        <div>
+          <label>
+            Nội dung bản nháp
+            <input defaultValue="Nguồn điện ổn định" />
+          </label>
+          <div role="region" aria-label="Các nhóm cấu hình cơ sở" tabIndex={0}>
+            Danh sách tiêu chí
+          </div>
+          <span>{isFocusMode ? "Đang tập trung chỉnh sửa" : "Bố cục mặc định"}</span>
+          <button type="button" onClick={onToggleFocusMode}>
+            {isFocusMode ? "Thu nhỏ vùng chỉnh sửa" : "Mở rộng vùng chỉnh sửa"}
+          </button>
+          <button type="button" onClick={() => setIsDialogOpen(true)}>
+            Mở hộp thoại
+          </button>
+          {isDialogOpen ? (
+            <div role="dialog" aria-label="Hộp thoại kiểm thử">
+              <button type="button">Thao tác hộp thoại</button>
+              <button type="button" onClick={() => setIsDialogOpen(false)}>
+                Đóng hộp thoại
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )
+    },
+  })
+)
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence",
+  () => ({
+    TechnicalConfigurationBaselineEvidence: () => <div>Tài liệu kiểm thử</div>,
+  })
+)
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts",
+  () => ({
+    TechnicalConfigurationReferenceProducts: () => <div>Sản phẩm tham chiếu kiểm thử</div>,
+  })
+)
+
+vi.mock("@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers", () => ({
+  TechnicalConfigurationSuppliers: () => <div>Phương án kiểm thử</div>,
+}))
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab",
+  () => ({
+    TechnicalConfigurationComparisonTab: () => <div>So sánh kiểm thử</div>,
+  })
+)
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy lọc thận",
+  name: "Cấu hình máy lọc thận",
+  description: "Hồ sơ kiểm thử",
+  revision: 3,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-13T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-13T00:00:00.000Z",
+  updated_by: 1,
+}
+
+describe("technical configuration workspace focus mode", () => {
+  it("expands the editor without remounting its draft or scroll region", async () => {
+    const user = userEvent.setup()
+    render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
+
+    const workspace = screen.getByTestId("technical-configuration-workspace")
+    const draftInput = screen.getByLabelText("Nội dung bản nháp")
+    const scrollRegion = screen.getByRole("region", { name: "Các nhóm cấu hình cơ sở" })
+    scrollRegion.scrollTop = 137
+
+    await user.type(draftInput, " đã sửa")
+    await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
+
+    expect(workspace).toHaveClass("overflow-hidden")
+    expect(screen.queryByRole("heading", { name: dossier.name })).not.toBeInTheDocument()
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument()
+    expect(screen.getByText("Đang tập trung chỉnh sửa")).toBeInTheDocument()
+    expect(screen.getByLabelText("Nội dung bản nháp")).toBe(draftInput)
+    expect(draftInput).toHaveValue("Nguồn điện ổn định đã sửa")
+    expect(screen.getByRole("region", { name: "Các nhóm cấu hình cơ sở" })).toBe(scrollRegion)
+    expect(scrollRegion.scrollTop).toBe(137)
+
+    await user.click(screen.getByRole("button", { name: "Thu nhỏ vùng chỉnh sửa" }))
+
+    expect(screen.getByRole("heading", { name: dossier.name })).toBeInTheDocument()
+    expect(screen.getAllByRole("tab")).toHaveLength(5)
+    expect(screen.getByLabelText("Nội dung bản nháp")).toBe(draftInput)
+  })
+
+  it("uses guarded Escape behavior and resets focus mode for another dossier", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
+    const draftInput = screen.getByLabelText("Nội dung bản nháp")
+    await user.click(draftInput)
+    await user.keyboard("{Escape}")
+    expect(screen.getByText("Đang tập trung chỉnh sửa")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Mở hộp thoại" }))
+    await user.click(screen.getByRole("button", { name: "Thao tác hộp thoại" }))
+    await user.keyboard("{Escape}")
+    expect(screen.getByText("Đang tập trung chỉnh sửa")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Đóng hộp thoại" }))
+    await user.click(screen.getByText("Đang tập trung chỉnh sửa"))
+    await user.keyboard("{Escape}")
+    expect(screen.getByText("Bố cục mặc định")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
+    rerender(
+      <TechnicalConfigurationWorkspaceShell
+        dossier={{ ...dossier, id: "dossier-2", name: "Cấu hình máy thở" }}
+        onBack={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText("Bố cục mặc định")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Cấu hình máy thở" })).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
@@ -37,6 +37,15 @@ vi.mock(
           <div role="region" aria-label="Các nhóm cấu hình cơ sở" tabIndex={0}>
             Danh sách tiêu chí
           </div>
+          <div
+            contentEditable="plaintext-only"
+            suppressContentEditableWarning
+            role="textbox"
+            aria-label="Ghi chú định dạng"
+            tabIndex={0}
+          >
+            Ghi chú
+          </div>
           <span>{isFocusMode ? "Đang tập trung chỉnh sửa" : "Bố cục mặc định"}</span>
           <button type="button" onClick={onToggleFocusMode}>
             {isFocusMode ? "Thu nhỏ vùng chỉnh sửa" : "Mở rộng vùng chỉnh sửa"}
@@ -135,6 +144,10 @@ describe("technical configuration workspace focus mode", () => {
     await user.click(screen.getByRole("button", { name: "Mở rộng vùng chỉnh sửa" }))
     const draftInput = screen.getByLabelText("Nội dung bản nháp")
     await user.click(draftInput)
+    await user.keyboard("{Escape}")
+    expect(screen.getByText("Đang tập trung chỉnh sửa")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("textbox", { name: "Ghi chú định dạng" }))
     await user.keyboard("{Escape}")
     expect(screen.getByText("Đang tập trung chỉnh sửa")).toBeInTheDocument()
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
@@ -191,6 +191,7 @@ export function TechnicalConfigurationBaselineEditor({
                     size="icon"
                     className="size-9"
                     aria-label={isFocusMode ? "Thu nhỏ vùng chỉnh sửa" : "Mở rộng vùng chỉnh sửa"}
+                    aria-pressed={isFocusMode}
                     onClick={onToggleFocusMode}
                   >
                     {isFocusMode ? (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { LoaderCircle, Plus, Save } from "lucide-react"
+import { LoaderCircle, Maximize2, Minimize2, Plus, Save } from "lucide-react"
 
 import { TechnicalConfigurationBaselineGroupSection } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection"
 import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
@@ -13,6 +13,7 @@ import type {
 } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 export type TechnicalConfigurationEntryMode = "row" | "bulk"
 export type TechnicalConfigurationFocusTarget =
@@ -41,6 +42,7 @@ type TechnicalConfigurationBaselineEditorProps = Readonly<{
   validation: TechnicalConfigurationBaselineEditorValidation
   summaryValidation: TechnicalConfigurationBaselineEditorValidation
   status: TechnicalConfigurationBaselineEditorStatus
+  isFocusMode: boolean
   activeValue: string
   entryMode: TechnicalConfigurationEntryMode
   getBulkSession: (groupKey: string) => TechnicalConfigurationBulkEntrySession
@@ -65,6 +67,7 @@ type TechnicalConfigurationBaselineEditorProps = Readonly<{
   onBulkCancel: () => void
   onBulkAccept: () => void
   onSave: () => void
+  onToggleFocusMode?: () => void
 }>
 
 const PENDING_BULK_STATUS_ID = "technical-configuration-pending-bulk-status"
@@ -92,6 +95,7 @@ export function TechnicalConfigurationBaselineEditor({
   validation,
   summaryValidation,
   status,
+  isFocusMode,
   activeValue,
   entryMode,
   getBulkSession,
@@ -111,6 +115,7 @@ export function TechnicalConfigurationBaselineEditor({
   onBulkCancel,
   onBulkAccept,
   onSave,
+  onToggleFocusMode,
 }: TechnicalConfigurationBaselineEditorProps): React.JSX.Element {
   const {
     dirty: isDirty,
@@ -157,11 +162,11 @@ export function TechnicalConfigurationBaselineEditor({
     >
       <div
         data-testid="baseline-editor-toolbar"
-        className="flex shrink-0 flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between"
+        className="flex shrink-0 flex-col gap-2 border-b pb-3 sm:flex-row sm:items-center sm:justify-between"
       >
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-lg font-semibold">Bản nháp cấu hình cơ sở</h2>
+            <h2 className="text-base font-semibold">Bản nháp cấu hình cơ sở</h2>
             <Badge variant="secondary">Bản nháp</Badge>
           </div>
           {hasPendingBulkInput ? (
@@ -175,19 +180,50 @@ export function TechnicalConfigurationBaselineEditor({
           ) : null}
         </div>
 
-        <Button
-          type="button"
-          disabled={isEditingDisabled || !isDirty || isSaving || isConflict || hasPendingBulkInput}
-          aria-describedby={hasPendingBulkInput ? PENDING_BULK_STATUS_ID : undefined}
-          onClick={onSave}
-        >
-          {isSaving ? (
-            <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
-          ) : (
-            <Save className="size-4" aria-hidden="true" />
-          )}
-          {isSaving ? "Đang lưu..." : "Lưu"}
-        </Button>
+        <div className="flex shrink-0 items-center gap-2 self-start sm:self-auto">
+          {onToggleFocusMode ? (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-9"
+                    aria-label={isFocusMode ? "Thu nhỏ vùng chỉnh sửa" : "Mở rộng vùng chỉnh sửa"}
+                    onClick={onToggleFocusMode}
+                  >
+                    {isFocusMode ? (
+                      <Minimize2 className="size-4" aria-hidden="true" />
+                    ) : (
+                      <Maximize2 className="size-4" aria-hidden="true" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {isFocusMode ? "Thu nhỏ vùng chỉnh sửa" : "Mở rộng vùng chỉnh sửa"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+
+          <Button
+            type="button"
+            className="h-9"
+            disabled={
+              isEditingDisabled || !isDirty || isSaving || isConflict || hasPendingBulkInput
+            }
+            aria-describedby={hasPendingBulkInput ? PENDING_BULK_STATUS_ID : undefined}
+            onClick={onSave}
+          >
+            {isSaving ? (
+              <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Save className="size-4" aria-hidden="true" />
+            )}
+            {isSaving ? "Đang lưu..." : "Lưu"}
+          </Button>
+        </div>
       </div>
 
       <div

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -23,15 +23,19 @@ import { TechnicalConfigurationVersionBar } from "./TechnicalConfigurationVersio
 
 type TechnicalConfigurationBaselineTabProps = {
   dossier: TechnicalConfigurationDossierWire
+  isFocusMode?: boolean
   onDirtyChange: (dirty: boolean) => void
   onNavigationBlockedChange?: (blocked: boolean) => void
+  onToggleFocusMode?: () => void
 }
 
 /** Composes baseline data state with transient spreadsheet interaction state. */
 export function TechnicalConfigurationBaselineTab({
   dossier,
+  isFocusMode = false,
   onDirtyChange,
   onNavigationBlockedChange,
+  onToggleFocusMode,
 }: Readonly<TechnicalConfigurationBaselineTabProps>) {
   const [isLockDialogOpen, setIsLockDialogOpen] = React.useState(false)
   const [hasUnresolvedImportState, setHasUnresolvedImportState] = React.useState(false)
@@ -201,33 +205,49 @@ export function TechnicalConfigurationBaselineTab({
   return (
     <div
       data-testid="technical-configuration-baseline-tab"
-      className="flex min-h-0 flex-1 flex-col gap-4"
+      className="flex min-h-0 flex-1 flex-col gap-3"
     >
-      <TechnicalConfigurationVersionBar
-        versions={baseline.versions}
-        selectedVersion={selectedVersion}
-        lockBlockedReason={lockBlockedReason}
-        status={{
-          hasDraft: baseline.hasDraft,
-          isCreating: baseline.isCreating,
-          isLocking: baseline.isLocking,
-          isCopying: baseline.isCopying,
-          isLoadingMoreVersions: baseline.isLoadingMoreVersions,
-          hasLoadMoreError: baseline.hasLoadMoreError,
-          isNavigationDisabled: baseline.isLifecycleBusy,
-          hasMoreVersions: baseline.hasMoreVersions,
-          isDownloadingTemplate: baselineImport.isDownloading,
-          isImportBusy: baselineImport.isPreviewing || baselineImport.isApplying,
-          isImportBlocked,
-        }}
-        onSelectVersion={handleSelectVersion}
-        onLoadMoreVersions={() => void baseline.onLoadMoreVersions()}
-        onRequestLock={() => setIsLockDialogOpen(true)}
-        onCreateBlank={baseline.onCreate}
-        onCopy={() => void handleCopy()}
-        onDownloadTemplate={() => void baselineImport.downloadTemplate()}
-        onRequestImport={baselineImport.openDialog}
-      />
+      <div className="shrink-0">
+        {isFocusMode ? (
+          <div
+            role="region"
+            aria-label="Ngữ cảnh cấu hình đang chỉnh sửa"
+            className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-b pb-2 text-sm"
+          >
+            <strong className="truncate font-semibold">{dossier.name}</strong>
+            <span className="text-muted-foreground">
+              Phiên bản {selectedVersion.version_number} ·{" "}
+              {selectedVersion.status === "locked" ? "Đã khóa" : "Bản nháp"}
+            </span>
+          </div>
+        ) : (
+          <TechnicalConfigurationVersionBar
+            versions={baseline.versions}
+            selectedVersion={selectedVersion}
+            lockBlockedReason={lockBlockedReason}
+            status={{
+              hasDraft: baseline.hasDraft,
+              isCreating: baseline.isCreating,
+              isLocking: baseline.isLocking,
+              isCopying: baseline.isCopying,
+              isLoadingMoreVersions: baseline.isLoadingMoreVersions,
+              hasLoadMoreError: baseline.hasLoadMoreError,
+              isNavigationDisabled: baseline.isLifecycleBusy,
+              hasMoreVersions: baseline.hasMoreVersions,
+              isDownloadingTemplate: baselineImport.isDownloading,
+              isImportBusy: baselineImport.isPreviewing || baselineImport.isApplying,
+              isImportBlocked,
+            }}
+            onSelectVersion={handleSelectVersion}
+            onLoadMoreVersions={() => void baseline.onLoadMoreVersions()}
+            onRequestLock={() => setIsLockDialogOpen(true)}
+            onCreateBlank={baseline.onCreate}
+            onCopy={() => void handleCopy()}
+            onDownloadTemplate={() => void baselineImport.downloadTemplate()}
+            onRequestImport={baselineImport.openDialog}
+          />
+        )}
+      </div>
 
       <TechnicalConfigurationBaselineAlerts
         isConflict={baseline.isConflict}
@@ -262,6 +282,7 @@ export function TechnicalConfigurationBaselineTab({
             saveStatus: baseline.saveStatus,
             hasPendingBulkInput: bulkSessions.hasPendingInput,
           }}
+          isFocusMode={isFocusMode}
           activeValue={inlineEditor.activeValue}
           entryMode={inlineEditor.entryMode}
           getBulkSession={bulkSessions.getSession}
@@ -281,6 +302,7 @@ export function TechnicalConfigurationBaselineTab({
           onBulkCancel={inlineEditor.cancelBulk}
           onBulkAccept={inlineEditor.acceptBulk}
           onSave={baseline.onSave}
+          onToggleFocusMode={onToggleFocusMode}
         />
       ) : null}
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
@@ -76,9 +76,9 @@ export function TechnicalConfigurationVersionBar({
   }))
 
   return (
-    <section className="border-y py-4" aria-label="Lịch sử phiên bản cấu hình cơ sở">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0 space-y-3">
+    <section className="border-y py-2" aria-label="Lịch sử phiên bản cấu hình cơ sở">
+      <div className="flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex min-w-0 flex-1 flex-col gap-2 md:flex-row md:items-center">
           <div className="flex flex-wrap items-center gap-2">
             <History className="size-4 text-muted-foreground" aria-hidden="true" />
             <strong className="text-sm font-semibold">
@@ -92,7 +92,7 @@ export function TechnicalConfigurationVersionBar({
           <SingleSelect
             value={selectedVersion.id}
             ariaLabel="Lịch sử phiên bản"
-            className="w-full sm:w-[280px]"
+            className="w-full shrink-0 sm:w-[280px]"
             disabled={isNavigationDisabled}
             onValueChange={onSelectVersion}
             options={versionOptions}
@@ -115,7 +115,7 @@ export function TechnicalConfigurationVersionBar({
           ) : null}
 
           {hasLockMetadata || hasLineage ? (
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            <div className="flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-sm text-muted-foreground">
               {selectedVersion.status === "locked" && selectedVersion.locked_at ? (
                 <span>Khóa lúc {formatVietnamDateTime(selectedVersion.locked_at)}</span>
               ) : null}
@@ -129,7 +129,7 @@ export function TechnicalConfigurationVersionBar({
           ) : null}
         </div>
 
-        <div className="flex flex-col items-start gap-2 lg:items-end">
+        <div className="flex shrink-0 flex-col items-start gap-1 xl:items-end">
           {selectedVersion.status === "draft" ? (
             <>
               <div className="flex flex-wrap gap-2 lg:justify-end">

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -33,10 +33,11 @@ type WorkspaceRevisionOverride = {
 
 function shouldIgnoreFocusModeEscape(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false
+  if (target.closest('input, textarea, select, [role="dialog"], [role="alertdialog"]')) return true
+
+  const editableHost = target.closest<HTMLElement>("[contenteditable]")
   return Boolean(
-    target.closest(
-      'input, textarea, select, [contenteditable="true"], [role="dialog"], [role="alertdialog"]'
-    )
+    editableHost && (editableHost.isContentEditable || editableHost.contentEditable !== "false")
   )
 }
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -12,6 +12,7 @@ import {
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
 
 import { useTechnicalConfigurationGuardedNavigation } from "../_hooks/useTechnicalConfigurationGuardedNavigation"
 import { TechnicalConfigurationBaselineTab } from "./TechnicalConfigurationBaselineTab"
@@ -28,6 +29,15 @@ type TechnicalConfigurationWorkspaceShellProps = {
 type WorkspaceRevisionOverride = {
   dossierId: string
   revision: number
+}
+
+function shouldIgnoreFocusModeEscape(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false
+  return Boolean(
+    target.closest(
+      'input, textarea, select, [contenteditable="true"], [role="dialog"], [role="alertdialog"]'
+    )
+  )
 }
 
 /** Renders the dossier workspace tabs available in the current delivery phase. */
@@ -49,6 +59,10 @@ export function TechnicalConfigurationWorkspaceShell({
   const [isOptionNavigationBlocked, setIsOptionNavigationBlocked] = React.useState(false)
   const [isComparisonDirty, setIsComparisonDirty] = React.useState(false)
   const [isComparisonNavigationBlocked, setIsComparisonNavigationBlocked] = React.useState(false)
+  const [focusedBaselineDossierId, setFocusedBaselineDossierId] = React.useState<string | null>(
+    null
+  )
+  const isBaselineFocusMode = activeTab === "baseline" && focusedBaselineDossierId === dossier.id
   const isDirty =
     isBaselineDirty || isEvidenceDirty || isReferenceDirty || isOptionDirty || isComparisonDirty
   const isNavigationBlocked =
@@ -97,21 +111,51 @@ export function TechnicalConfigurationWorkspaceShell({
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
       if (nextTab === activeTab) return
-      requestNavigation(() => setActiveTab(nextTab))
+      requestNavigation(() => {
+        setFocusedBaselineDossierId(null)
+        setActiveTab(nextTab)
+      })
     },
     [activeTab, requestNavigation]
   )
 
+  const handleToggleBaselineFocusMode = React.useCallback(() => {
+    setFocusedBaselineDossierId((current) => (current === dossier.id ? null : dossier.id))
+  }, [dossier.id])
+
+  React.useEffect(() => {
+    if (!isBaselineFocusMode) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== "Escape" ||
+        event.defaultPrevented ||
+        shouldIgnoreFocusModeEscape(event.target)
+      ) {
+        return
+      }
+      setFocusedBaselineDossierId(null)
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [isBaselineFocusMode])
+
   return (
     <div
       data-testid="technical-configuration-workspace"
-      className="flex min-h-0 w-full flex-1 flex-col"
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
     >
-      <header className="shrink-0 border-b pb-5">
+      <header
+        hidden={isBaselineFocusMode}
+        aria-hidden={isBaselineFocusMode || undefined}
+        className="shrink-0 border-b pb-3"
+      >
         <Button
           type="button"
           variant="ghost"
-          className="-ml-3"
+          size="sm"
+          className="-ml-2"
           disabled={isNavigationBlocked}
           onClick={handleBack}
         >
@@ -119,13 +163,13 @@ export function TechnicalConfigurationWorkspaceShell({
           Danh sách hồ sơ
         </Button>
 
-        <div className="mt-4 flex min-w-0 items-start gap-3">
-          <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-muted">
-            <ClipboardList className="size-5" aria-hidden="true" />
+        <div className="mt-2 flex min-w-0 items-center gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted">
+            <ClipboardList className="size-4" aria-hidden="true" />
           </span>
           <div className="min-w-0">
-            <h1 className="break-words text-2xl font-semibold">{dossier.name}</h1>
-            <p className="mt-1 break-words text-sm text-muted-foreground">
+            <h1 className="break-words text-xl font-semibold">{dossier.name}</h1>
+            <p className="break-words text-sm text-muted-foreground">
               {dossier.device_type_name}
               {dossier.description ? ` · ${dossier.description}` : ""}
             </p>
@@ -136,12 +180,16 @@ export function TechnicalConfigurationWorkspaceShell({
       <Tabs
         value={activeTab}
         onValueChange={handleTabChange}
-        className="mt-6 flex min-h-0 flex-1 flex-col"
+        className={cn("flex min-h-0 flex-1 flex-col", isBaselineFocusMode ? "mt-0" : "mt-3")}
       >
-        <TabsList className="grid h-auto w-full shrink-0 grid-cols-1 gap-1 sm:grid-cols-5">
+        <TabsList
+          hidden={isBaselineFocusMode}
+          aria-hidden={isBaselineFocusMode || undefined}
+          className="grid h-auto w-full shrink-0 grid-cols-1 gap-1 sm:grid-cols-5"
+        >
           <TabsTrigger
             value="baseline"
-            className="min-h-10 gap-2"
+            className="min-h-9 gap-2"
             disabled={isNavigationBlocked && activeTab !== "baseline"}
           >
             <ListChecks className="size-4" aria-hidden="true" />
@@ -149,7 +197,7 @@ export function TechnicalConfigurationWorkspaceShell({
           </TabsTrigger>
           <TabsTrigger
             value="evidence"
-            className="min-h-10 gap-2"
+            className="min-h-9 gap-2"
             disabled={isNavigationBlocked && activeTab !== "evidence"}
           >
             <FileText className="size-4" aria-hidden="true" />
@@ -157,7 +205,7 @@ export function TechnicalConfigurationWorkspaceShell({
           </TabsTrigger>
           <TabsTrigger
             value="references"
-            className="min-h-10 gap-2"
+            className="min-h-9 gap-2"
             disabled={isNavigationBlocked && activeTab !== "references"}
           >
             <LibraryBig className="size-4" aria-hidden="true" />
@@ -165,7 +213,7 @@ export function TechnicalConfigurationWorkspaceShell({
           </TabsTrigger>
           <TabsTrigger
             value="options"
-            className="min-h-10 gap-2"
+            className="min-h-9 gap-2"
             disabled={isNavigationBlocked && activeTab !== "options"}
           >
             <PackageSearch className="size-4" aria-hidden="true" />
@@ -173,7 +221,7 @@ export function TechnicalConfigurationWorkspaceShell({
           </TabsTrigger>
           <TabsTrigger
             value="comparison"
-            className="min-h-10 gap-2"
+            className="min-h-9 gap-2"
             disabled={isNavigationBlocked && activeTab !== "comparison"}
           >
             <GitCompareArrows className="size-4" aria-hidden="true" />
@@ -181,28 +229,36 @@ export function TechnicalConfigurationWorkspaceShell({
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="baseline" className="mt-6 flex min-h-0 flex-1 overflow-hidden">
+        <TabsContent
+          value="baseline"
+          className={cn(
+            "flex min-h-0 flex-1 overflow-hidden",
+            isBaselineFocusMode ? "mt-0" : "mt-3"
+          )}
+        >
           <TechnicalConfigurationBaselineTab
             dossier={workspaceDossier}
+            isFocusMode={isBaselineFocusMode}
             onDirtyChange={setIsBaselineDirty}
             onNavigationBlockedChange={setIsBaselineNavigationBlocked}
+            onToggleFocusMode={handleToggleBaselineFocusMode}
           />
         </TabsContent>
-        <TabsContent value="evidence" className="mt-6">
+        <TabsContent value="evidence" className="mt-3">
           <TechnicalConfigurationBaselineEvidence
             dossier={workspaceDossier}
             onDirtyChange={setIsEvidenceDirty}
             onNavigationBlockedChange={setIsEvidenceNavigationBlocked}
           />
         </TabsContent>
-        <TabsContent value="references" className="mt-6">
+        <TabsContent value="references" className="mt-3">
           <TechnicalConfigurationReferenceProducts
             dossier={workspaceDossier}
             onDirtyChange={setIsReferenceDirty}
             onNavigationBlockedChange={setIsReferenceNavigationBlocked}
           />
         </TabsContent>
-        <TabsContent value="options" className="mt-6">
+        <TabsContent value="options" className="mt-3">
           <TechnicalConfigurationSuppliers
             dossier={workspaceDossier}
             onDirtyChange={setIsOptionDirty}
@@ -210,7 +266,7 @@ export function TechnicalConfigurationWorkspaceShell({
             onRevisionChange={handleRevisionChange}
           />
         </TabsContent>
-        <TabsContent value="comparison" className="mt-6">
+        <TabsContent value="comparison" className="mt-3">
           <TechnicalConfigurationComparisonTab
             dossier={workspaceDossier}
             onDirtyChange={setIsComparisonDirty}


### PR DESCRIPTION
## Summary
- compact the dossier, tab, and version controls to give the baseline editor more vertical space
- add an optional focus mode that preserves the mounted editor, draft state, disclosure state, focus, and scroll position
- keep document scrolling locked to the app layout and guard Escape while editing or using dialogs

## Test plan
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 5 files, 31 tests
- `node scripts/npm-run.js run react-doctor` (100/100)

## Notes
- UI-only; no API, RPC, database, or migration changes
- no local dev server was started

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the baseline editor workspace with a new Focus Mode that removes chrome, preserves the live editor, and improves readability. Also tightened headers and toolbars to give the editor more vertical space.

- **New Features**
  - Added Focus Mode toggle in the baseline editor. Hides the page header and tabs, replaces the version bar with a compact dossier context, and locks scrolling to the workspace.
  - Preserves the mounted editor and its state across toggles (draft values, disclosure, focus, and scroll).
  - Hardened Escape behavior: ignored while typing, in dialogs, or inside contenteditable; exits Focus Mode only when pressed outside inputs. Focus Mode resets when switching tabs or dossiers.
  - Compacted toolbar, version bar, and workspace header (smaller headings, tighter spacing). Added an icon toggle with tooltip and `aria-pressed`. UI-only; no API/DB changes.

<sup>Written for commit 7902ddfa225c305448740a4d95687be025a1239a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added focus mode for technical configuration editing.
  * Expand the baseline editor into a distraction-free view with compact dossier and version context.
  * Hide workspace navigation and version history while focus mode is active.
  * Exit focus mode using the collapse control or Escape key.
  * Preserve draft values, editor state, and scroll position when toggling focus mode.
* **Style**
  * Improved responsive spacing and layout for configuration headers, tabs, and version controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->