### PR TITLE
fix(technical-config): restore non-baseline tab scrolling

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-focus-mode.test.tsx
@@ -172,4 +172,23 @@ describe("technical configuration workspace focus mode", () => {
     expect(await screen.findByText("Bố cục mặc định")).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "Cấu hình máy thở" })).toBeInTheDocument()
   })
+
+  it("keeps every non-baseline workspace vertically scrollable", async () => {
+    const user = userEvent.setup()
+    render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
+
+    const tabs = [
+      { name: "Tài liệu & trích dẫn", content: "Tài liệu kiểm thử" },
+      { name: "Sản phẩm tham chiếu", content: "Sản phẩm tham chiếu kiểm thử" },
+      { name: "Phương án", content: "Phương án kiểm thử" },
+      { name: "So sánh & đánh giá", content: "So sánh kiểm thử" },
+    ]
+
+    for (const tab of tabs) {
+      await user.click(screen.getByRole("tab", { name: tab.name }))
+
+      const panel = screen.getByText(tab.content).closest('[role="tabpanel"]')
+      expect(panel).toHaveClass("min-h-0", "flex-1", "overflow-y-auto")
+    }
+  })
 })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -245,21 +245,21 @@ export function TechnicalConfigurationWorkspaceShell({
             onToggleFocusMode={handleToggleBaselineFocusMode}
           />
         </TabsContent>
-        <TabsContent value="evidence" className="mt-3">
+        <TabsContent value="evidence" className="mt-3 min-h-0 flex-1 overflow-y-auto">
           <TechnicalConfigurationBaselineEvidence
             dossier={workspaceDossier}
             onDirtyChange={setIsEvidenceDirty}
             onNavigationBlockedChange={setIsEvidenceNavigationBlocked}
           />
         </TabsContent>
-        <TabsContent value="references" className="mt-3">
+        <TabsContent value="references" className="mt-3 min-h-0 flex-1 overflow-y-auto">
           <TechnicalConfigurationReferenceProducts
             dossier={workspaceDossier}
             onDirtyChange={setIsReferenceDirty}
             onNavigationBlockedChange={setIsReferenceNavigationBlocked}
           />
         </TabsContent>
-        <TabsContent value="options" className="mt-3">
+        <TabsContent value="options" className="mt-3 min-h-0 flex-1 overflow-y-auto">
           <TechnicalConfigurationSuppliers
             dossier={workspaceDossier}
             onDirtyChange={setIsOptionDirty}
@@ -267,7 +267,7 @@ export function TechnicalConfigurationWorkspaceShell({
             onRevisionChange={handleRevisionChange}
           />
         </TabsContent>
-        <TabsContent value="comparison" className="mt-3">
+        <TabsContent value="comparison" className="mt-3 min-h-0 flex-1 overflow-y-auto">
           <TechnicalConfigurationComparisonTab
             dossier={workspaceDossier}
             onDirtyChange={setIsComparisonDirty}


### PR DESCRIPTION
## Summary
- restore dedicated vertical scrolling for evidence, reference products, options, and comparison tabs
- keep the workspace-level overflow lock so the footer and document scroll behavior from #861 remain unchanged
- add a user-event regression test that visits all four tabs and verifies scroll ownership

## Root cause
PR #861 added `overflow-hidden` to the workspace, but only the baseline tab had an internal scroll region. The other tab panels still had only spacing classes, so long content was clipped.

## Test plan
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 2 files, 12 tests
- `node scripts/npm-run.js run react-doctor` (100/100)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores vertical scrolling for the Evidence, Reference Products, Options, and Comparison tabs in Technical Configuration by adding internal scroll regions. Keeps the workspace overflow behavior from #861 unchanged and adds a regression test to verify scroll on these tabs.

<sup>Written for commit 659b2c9cf79575d480cf28d24257455fde7709c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical scrolling in the Evidence, References, Options, and Comparison tabs.
  * Tab content now uses the available workspace height and remains accessible without causing layout overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->