### PR TITLE
docs: split P15 dossier lifecycle rollout

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -12,13 +12,15 @@
 1. A dossier is the aggregate root and the single configuration lineage for one device type. There is no separate lineage table.
 2. A dossier has zero or more locked baseline versions and at most one editable draft.
 3. Archived dossiers are hidden from default lists, remain readable and reject every descendant mutation. MVP has no restore operation.
-4. Locked baseline-owned data is immutable for every role, including `global` and raw `admin`.
-5. Direct Data API access to module tables is denied. Reads and writes use guarded `SECURITY DEFINER` RPCs.
-6. Every editable aggregate has `revision BIGINT NOT NULL`. Every mutation requires `p_expected_revision`.
-7. Criterion codes are system-generated, unique per baseline version and stable across reorder/copy.
-8. Suppliers belong to one dossier and are shared only by options in that dossier.
-9. A dossier may contain unlimited options. One matrix request selects at most 8 options and reads at most 100 criteria.
-10. MVP adds no AI runtime table, column, RPC, job, cache, quota, API call or UI affordance.
+4. Active dossier metadata remains editable after a baseline is locked because dossier metadata is outside the immutable baseline aggregate.
+5. Hard-delete is allowed only for an active dossier that has never had a locked baseline. After the first lock, deletion is permanently denied; archive remains a separate one-way lifecycle.
+6. Locked baseline-owned data is immutable for every role, including `global` and raw `admin`.
+7. Direct Data API access to module tables is denied. Reads and writes use guarded `SECURITY DEFINER` RPCs.
+8. Every editable aggregate has `revision BIGINT NOT NULL`. Every mutation requires `p_expected_revision`.
+9. Criterion codes are system-generated, unique per baseline version and stable across reorder/copy.
+10. Suppliers belong to one dossier and are shared only by options in that dossier.
+11. A dossier may contain unlimited options. One matrix request selects at most 8 options and reads at most 100 criteria.
+12. MVP adds no AI runtime table, column, RPC, job, cache, quota, API call or UI affordance.
 
 ## Frontend Surface Ownership
 
@@ -134,6 +136,12 @@
   matrix, including the complete TC-18 ranking flow. P12A2/P12B1/P12B2 retain
   focused React/source regressions required by their own dependency and exit
   gates.
+- P15B owns the dossier metadata edit adapter, generalized create/edit form,
+  row-action surface and mutation-state hook. It does not consume
+  `can_delete` or expose the dormant P15A delete RPC.
+- P15C extends the P15B row-action owner with list eligibility, the guarded
+  delete adapter and one destructive confirmation dialog. It does not create a
+  second row-action/mutation owner or treat `can_delete` as authorization.
 - No P10B leaf renders response editors, copy controls, dirty drafts, save
   commands, assessment persistence, ranking or derived compliance.
 - P8B3 adds no RPC name, request/response shape, query key, migration, table,
@@ -143,28 +151,29 @@
 
 Each entity or schema alteration has one primary leaf owner. A later leaf may extend an existing copy/guard function only when its own entities require that extension.
 
-| Leaf  | Entity or alteration                          | Key ownership and cascade contract                                                                                            |
-| ----- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| P1    | `technical_configuration_dossiers`            | UUID root; device type/name/description; archive and audit metadata; `revision`; no hard-delete RPC                           |
-| P2    | `technical_configuration_baseline_versions`   | FK `dossier_id`; partial unique draft per dossier; sequential version number; `next_criterion_number`; audit/revision         |
-| P2    | `technical_configuration_baseline_groups`     | FK baseline version; ordered editable seed records; delete cascades only inside an editable version transaction               |
-| P2    | `technical_configuration_baseline_criteria`   | FK group/version; system code unique per version; optional title; multiline text; order; `source_criterion_id` initially null |
-| P4    | baseline lifecycle alterations                | Adds lock metadata, `source_baseline_version_id`, copy/lock functions and locked mutation guard                               |
-| P7A1  | `technical_configuration_reference_products`  | FK exact baseline version; zero-to-many; excluded from supplier/ranking domains                                               |
-| P7A1  | `technical_configuration_reference_responses` | Unique reference product + criterion; cascade with reference product/version                                                  |
-| P7B1  | `technical_configuration_baseline_documents`  | FK exact baseline version; URL metadata only                                                                                  |
-| P7B1  | `technical_configuration_baseline_citations`  | FK baseline document + criterion in the same version                                                                          |
-| P7B1  | `technical_configuration_reference_documents` | FK reference product; URL metadata only                                                                                       |
-| P7B1  | `technical_configuration_reference_citations` | FK reference document + criterion in the reference product's version                                                          |
-| P8A1  | `technical_configuration_suppliers`           | FK dossier; normalized name unique per dossier; delete cascades options and their descendants                                 |
-| P8A2  | `technical_configuration_options`             | FK supplier and dossier-consistent ownership; directly editable; delete cascades response datasets                            |
-| P8A3  | `technical_configuration_comparison_sets`     | FK option + exact baseline version; one active response dataset per pair                                                      |
-| P8A3  | `technical_configuration_option_responses`    | Unique comparison set + criterion; response and supplementary text remain separate                                            |
-| P8A4  | nullable comparison-set read contract         | Exact option + baseline lookup returns an existing snapshot or `data: null` without mutation, revision or audit side effects  |
-| P9B1  | `technical_configuration_option_documents`    | FK option; URL metadata shared by every baseline comparison for that option                                                   |
-| P9B1  | `technical_configuration_option_citations`    | FK option document + criterion through the matching option/baseline comparison set                                            |
-| P11B  | `technical_configuration_manual_assessments`  | Unique comparison set + criterion; canonical two axes, notes, audit metadata and row-level revision                           |
-| P12C1 | complete option ranking read contract         | Read-only set-based RPC over dossier options, exact baseline criteria and persisted manual assessments; no new table          |
+| Leaf  | Entity or alteration                           | Key ownership and cascade contract                                                                                                   |
+| ----- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| P1    | `technical_configuration_dossiers`             | UUID root; device type/name/description; archive and audit metadata; `revision`; no hard-delete RPC                                  |
+| P2    | `technical_configuration_baseline_versions`    | FK `dossier_id`; partial unique draft per dossier; sequential version number; `next_criterion_number`; audit/revision                |
+| P2    | `technical_configuration_baseline_groups`      | FK baseline version; ordered editable seed records; delete cascades only inside an editable version transaction                      |
+| P2    | `technical_configuration_baseline_criteria`    | FK group/version; system code unique per version; optional title; multiline text; order; `source_criterion_id` initially null        |
+| P4    | baseline lifecycle alterations                 | Adds lock metadata, `source_baseline_version_id`, copy/lock functions and locked mutation guard                                      |
+| P7A1  | `technical_configuration_reference_products`   | FK exact baseline version; zero-to-many; excluded from supplier/ranking domains                                                      |
+| P7A1  | `technical_configuration_reference_responses`  | Unique reference product + criterion; cascade with reference product/version                                                         |
+| P7B1  | `technical_configuration_baseline_documents`   | FK exact baseline version; URL metadata only                                                                                         |
+| P7B1  | `technical_configuration_baseline_citations`   | FK baseline document + criterion in the same version                                                                                 |
+| P7B1  | `technical_configuration_reference_documents`  | FK reference product; URL metadata only                                                                                              |
+| P7B1  | `technical_configuration_reference_citations`  | FK reference document + criterion in the reference product's version                                                                 |
+| P8A1  | `technical_configuration_suppliers`            | FK dossier; normalized name unique per dossier; delete cascades options and their descendants                                        |
+| P8A2  | `technical_configuration_options`              | FK supplier and dossier-consistent ownership; directly editable; delete cascades response datasets                                   |
+| P8A3  | `technical_configuration_comparison_sets`      | FK option + exact baseline version; one active response dataset per pair                                                             |
+| P8A3  | `technical_configuration_option_responses`     | Unique comparison set + criterion; response and supplementary text remain separate                                                   |
+| P8A4  | nullable comparison-set read contract          | Exact option + baseline lookup returns an existing snapshot or `data: null` without mutation, revision or audit side effects         |
+| P9B1  | `technical_configuration_option_documents`     | FK option; URL metadata shared by every baseline comparison for that option                                                          |
+| P9B1  | `technical_configuration_option_citations`     | FK option document + criterion through the matching option/baseline comparison set                                                   |
+| P11B  | `technical_configuration_manual_assessments`   | Unique comparison set + criterion; canonical two axes, notes, audit metadata and row-level revision                                  |
+| P12C1 | complete option ranking read contract          | Read-only set-based RPC over dossier options, exact baseline criteria and persisted manual assessments; no new table                 |
+| P15A  | dossier hard-delete and eligibility alteration | Adds guarded aggregate-root delete plus set-based `can_delete` to the dossier list; adds no table and relies on verified FK cascades |
 
 All tables include UUID primary keys and the audit columns required by `design.md`. Foreign keys must prevent cross-dossier and cross-version relationships even when a caller bypasses the UI.
 
@@ -183,6 +192,13 @@ and `updated_at` identify the latest evaluator without duplicate
 - Archived: readable, excluded from default list and immutable.
 - Archive is one-way in MVP; no restore RPC exists.
 - `technical_configuration_dossiers_archive` increments dossier revision atomically.
+- Active metadata (`device_type_name`, `name`, `description`) remains editable
+  after baseline lock through the existing revision-guarded update RPC.
+- `can_delete=true` means the active dossier has no historical baseline with
+  `status='locked'`. It is a list affordance only; the delete RPC rechecks the
+  same condition under row lock.
+- A never-locked active dossier may be hard-deleted. An archived dossier or a
+  dossier that has ever had a locked baseline may not be hard-deleted.
 
 P1 creates `technical_configuration_dossiers` with:
 
@@ -223,6 +239,19 @@ technical_configuration_dossiers_archive(
 ```
 
 Create requires `p_expected_revision=0` and returns revision `1`. Update and archive require the current dossier revision and increment it atomically. P1 adds no hard-delete or restore RPC.
+
+P15A adds:
+
+```text
+technical_configuration_dossiers_delete(
+  p_id UUID,
+  p_expected_revision BIGINT
+)
+```
+
+The delete RPC removes the dossier aggregate root and relies only on the
+verified `ON DELETE CASCADE` foreign keys for descendants. It does not archive,
+restore or manually delete child tables.
 
 ### Baseline Version
 
@@ -283,8 +312,17 @@ Outside the RPC proxy, raw `admin` handling uses `isGlobalRole()`. SQL tests may
 - `_technical_configuration_require_global_user()` validates role and non-empty user ID claims, normalizes `admin` to global semantics and returns the actor ID.
 - `_technical_configuration_require_editable_dossier(p_dossier_id uuid, p_expected_revision bigint)` calls the role guard, locks the dossier, verifies existence, archive state and revision, then returns the actor ID.
 - P4 owns `_technical_configuration_require_editable_baseline_version(p_baseline_version_id uuid)`, which calls the dossier guard and raises `locked_version` when needed.
+- P15A delete calls `_technical_configuration_require_editable_dossier()` first,
+  then checks locked-baseline existence while retaining the dossier row lock.
+  It raises `locked_dossier` before deleting when any historical baseline is
+  locked.
 
 Every descendant mutation leaf must call the most specific applicable guard. A leaf may not duplicate or weaken these checks.
+
+Baseline lock and dossier delete both acquire the dossier row lock before their
+baseline-specific work. Concurrent operations therefore serialize: a completed
+delete makes the lock path return `not_found`, while a completed lock makes the
+delete path return `locked_dossier`.
 
 ### Table Exposure
 
@@ -295,6 +333,8 @@ REVOKE ALL ON TABLE public.<table_name> FROM anon, authenticated, public;
 ```
 
 Sequences receive no direct Data API grants. RPC execution is granted only as required, and every `SECURITY DEFINER` function sets `search_path = public, pg_temp`.
+P15A follows the existing dossier RPC boundary: revoke delete execution from
+`PUBLIC`, `anon` and `service_role`, then grant only to `authenticated`.
 
 ## RPC Contract
 
@@ -331,6 +371,7 @@ SQL parameters use `p_`-prefixed `snake_case`. Wire result fields use database `
 | P14A1 | `technical_configuration_result_export_manifest_get`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | P14A2 | `technical_configuration_result_export_ranking_list`, `technical_configuration_result_export_matrix_list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | P14A4 | `technical_configuration_result_export_option_axis_list`, `technical_configuration_result_export_criterion_axis_list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| P15A  | `technical_configuration_dossiers_delete`; additive `can_delete` response field on `technical_configuration_dossiers_list`                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 Except for the explicitly dormant P10A1/P10A2 and P11B/P11C splits, each leaf
 that introduces an RPC also owns allowlisting only the names introduced by that
@@ -347,6 +388,11 @@ manifest and proxy allowlist entry. P14A2 owns only the two bounded data RPCs
 that consume the P14A1 snapshot helper, plus their allowlist entries. P14A4 owns
 only the two bounded ordered-axis RPCs and their allowlist entries. P14A3 and all
 P14B/P14C leaves add no RPC or migration.
+P15A creates the delete RPC and list eligibility field but deliberately leaves
+the new RPC absent from every proxy allowlist/manifest. P15B reuses the existing
+P1 update RPC and adds no RPC name. P15C owns the delete RPC manifest, proxy
+allowlist entry, typed adapter and user-visible activation after P15A is applied
+and gated.
 P3A owns the module-local typed client used by all module RPCs. Shared
 `callRpc()` remains unchanged because its current consumers depend on the
 existing plain-`Error` behavior.
@@ -355,6 +401,8 @@ existing plain-`Error` behavior.
 
 - List request: `p_page >= 1`, `1 <= p_page_size <= 100`, optional leaf-specific filters.
 - Dossier list defaults `p_include_archived=false`.
+- Each dossier list item includes `can_delete BOOLEAN NOT NULL`, computed from
+  active state and historical locked-baseline existence.
 - List response wire shape: `{ data, total, page, page_size }`.
 - Get/create/update/archive/copy/upsert response: `{ data }`.
 - Nullable comparison-set read request:
@@ -379,6 +427,9 @@ existing plain-`Error` behavior.
   claims or disallowed roles; `PT422/validation_error` for invalid arguments;
   `PT404/not_found` for missing, foreign or mixed-dossier identifiers.
 - Delete response: `{ data: { id, revision } }`.
+- Dossier hard-delete is the explicit exception:
+  `technical_configuration_dossiers_delete` returns `{ data: { id } }` because
+  the deleted aggregate has no persisted next revision.
 - Preview response: `{ data, errors }`; preview does not persist.
 - Baseline import preview/apply request: `p_baseline_version_id`, `p_template_metadata JSONB`, `p_rows JSONB`, `p_expected_revision`.
 - Baseline import apply response: `{ data }`, where `data` is the complete updated baseline snapshot and owning revision.
@@ -566,7 +617,8 @@ criterion_title, requirement_text, criterion_order }`. Both surfaces page the
   then reads manifest again. It publishes no partial dataset and rejects the
   whole export if the final manifest differs from the first. Independent axes
   preserve valid `0 x 0`, `1 x 0`, `0 x 1` and normal `N x M` dimensions.
-- A successful mutation returns the new revision in `data`.
+- A successful mutation returns the new revision in `data`, except dossier
+  hard-delete, which returns only the deleted `id`.
 
 ### Error Taxonomy
 
@@ -579,6 +631,7 @@ RPCs raise the SQLSTATE and machine message below. The proxy's `{ error: payload
 | `PT409`  | `stale_revision`       | P1           | `p_expected_revision` does not match current revision               |
 | `PT409`  | `archived_dossier`     | P1           | Mutation targets an archived dossier or descendant                  |
 | `PT409`  | `locked_version`       | P4           | Mutation targets locked baseline-owned data                         |
+| `PT409`  | `locked_dossier`       | P15A         | Hard-delete targets a dossier that has ever had a locked baseline   |
 | `PT409`  | `draft_already_exists` | P2           | Dossier already has an editable draft                               |
 | `PT422`  | `validation_error`     | P1           | Field, relationship, order, code or request-bound validation failed |
 | `PT422`  | `template_mismatch`    | P5C          | Workbook kind/version/metadata/shape does not match the contract    |
@@ -838,6 +891,9 @@ not lift or duplicate navigator ownership.
 ## Query And Performance Budgets
 
 - Dossier and entity lists use bounded pagination with a maximum page size of 100.
+- Dossier-list `can_delete` is computed in the list query with set-based
+  locked-baseline existence logic. It must not call the baseline-version list
+  or issue one baseline query per dossier row.
 - `technical_configuration_comparison_get` accepts 1-8 option IDs from one dossier and one baseline version.
 - It returns at most 100 ordered criteria per request and supports criterion pagination.
 - A ninth option remains available for another request; total dossier option count is unlimited.
@@ -868,8 +924,8 @@ not lift or duplicate navigator ownership.
   phase-gates only the evidenced query/index remediation under the required
   approvals, then P13A-P1 reruns green before P13A-V performs final
   authorization, security and performance acceptance. P13A-V satisfies only
-  the database dependency; P13C starts only after P13A-V, P13B, P7A2, P9A3 and
-  P14C2 are all complete.
+  the database dependency; P13C starts only after P13A-V, P13B, P7A2, P9A3,
+  P14C2 and P15C are all complete.
 
 ## Migration Order
 
@@ -892,11 +948,16 @@ not lift or duplicate navigator ownership.
 13. P12C1 adds the guarded, read-only reference-ranking RPC after P12B2. Apply
     requires explicit approval, then its rollback-only live phase gate requires
     a second explicit approval before P13A-P1 or P12C2 may depend on it.
+14. P15A adds the guarded dossier hard-delete RPC and replaces the dossier-list
+    definition with the additive set-based `can_delete` field. Its migration
+    timestamp must sort after every existing local migration that redefines the
+    dossier list, editable-dossier guard, baseline-lock function or the
+    dossier-row-first lock order used by baseline lock.
 
 The numbered sequence above describes persistence-object and migration-definition order only; it does not override leaf delivery dependencies. P7B1 is still delivered after P7A2.
 
 P5A, P5B, P5D, P9A1, P9A3, P9B2, P10A2, P11A, P11C, P11D, P12A1, P12A2,
-P12B1 and P12B2 create no technical-configuration persistence. P6A and P6B also create no
+P12B1, P12B2, P15B and P15C create no technical-configuration persistence. P6A and P6B also create no
 technical-configuration persistence; P6A lands after P5D, P6B follows it, and
 both land before the first document UI in P7B2. Migration timestamps are
 selected at leaf execution time after checking all local migrations touching

--- a/openspec/changes/add-technical-configuration-comparison/design.md
+++ b/openspec/changes/add-technical-configuration-comparison/design.md
@@ -50,6 +50,12 @@ Không thêm foreign key tới `thiet_bi`. Việc độc lập giúp cấu hình
 
 Archive là thao tác một chiều trong MVP. Hồ sơ active được phép chuyển sang archived qua contract `technical_configuration_dossiers_archive`. Sau khi hồ sơ đã archive, mọi mutation nhắm tới chính hồ sơ đó hoặc bất kỳ entity nào trong toàn bộ aggregate con phải gọi cùng archive guard và bị từ chối. Hồ sơ đã archive bị ẩn khỏi list mặc định nhưng vẫn đọc được qua get hoặc list có cờ gồm dữ liệu archive; không có RPC hoặc UI restore.
 
+P15 bổ sung hard-delete như một lifecycle khác, không thay thế archive. Hard-delete chỉ áp dụng cho hồ sơ active chưa từng có baseline version `locked`. Sau lần khóa đầu tiên, lịch sử hồ sơ được coi là có giá trị cần bảo toàn và `technical_configuration_dossiers_delete` luôn trả conflict `locked_dossier`, kể cả khi hồ sơ hiện có một draft mới.
+
+Delete RPC trước tiên dùng dossier revision guard hiện có để khóa aggregate root, sau đó kiểm tra sự tồn tại của baseline `locked` trong cùng transaction rồi mới xóa root. Baseline lock cũng khóa dossier row trước baseline row, nên hai thao tác được serialize: delete thắng thì baseline lock nhận `not_found`; baseline lock thắng thì delete nhận `locked_dossier`. Mọi foreign key con phải tiếp tục dùng cascade đã được kiểm chứng; P15 không thêm chuỗi delete thủ công hoặc xóa từng bảng từ client.
+
+Danh sách hồ sơ trả thêm `can_delete` bằng một biểu thức set-based dựa trên sự tồn tại của baseline `locked`; không gọi version-list theo từng row. Đây chỉ là affordance sớm cho UI. Delete RPC vẫn là authority cuối cùng để chống stale UI, direct-call bypass và race condition. Hồ sơ active vẫn được sửa `device_type_name`, `name` và `description` sau khi có baseline khóa vì metadata dossier nằm ngoài immutable baseline aggregate; update không được sửa nội dung hoặc trạng thái baseline.
+
 ### 2. Cấu hình cơ sở text-first với hai cấp
 
 Mỗi phiên bản cơ sở gồm các nhóm có thứ tự. Mỗi nhóm gồm các tiêu chí có:
@@ -702,7 +708,9 @@ Các quyết định trên là compatibility notes, không phải acceptance cri
 ### Danh sách hồ sơ
 
 - Bảng danh sách gọn, ưu tiên tên thiết bị, phiên bản cơ sở hiện hành, số nhà cung cấp/phương án, tiến độ đánh giá và thời điểm cập nhật.
-- Hành động chính: tạo hồ sơ, mở hồ sơ.
+- Hành động chính: tạo hồ sơ, mở hồ sơ và row-action menu cho sửa metadata/xóa.
+- Sửa metadata dùng lại side sheet explicit-save với dữ liệu hiện tại và dossier revision.
+- Xóa mở destructive confirmation nêu rõ tên hồ sơ và toàn bộ dữ liệu nháp/dữ liệu làm việc phụ thuộc sẽ bị xóa vĩnh viễn. Action bị vô hiệu hóa với lý do rõ ràng khi `can_delete=false`.
 - Không dùng landing page hoặc dashboard marketing.
 
 ### Chi tiết hồ sơ
@@ -747,6 +755,8 @@ khai phải áp dụng scope MVP, thuật ngữ và semantics của OpenSpec/P14
 - Xóa tài liệu đang được liên kết trong dữ liệu còn chỉnh sửa: yêu cầu xác nhận và nêu số liên kết bị ảnh hưởng.
 - Xóa hoặc sửa document metadata/URL thuộc phiên bản cơ sở đã khóa: từ chối trước khi áp dụng flow xác nhận xóa.
 - Hồ sơ đã archive: list mặc định không trả hồ sơ, get vẫn đọc được và mọi mutation con trả conflict `archived_dossier`.
+- Hard-delete hồ sơ đã có baseline khóa: từ chối `locked_dossier` trước `DELETE`; giữ nguyên root và toàn bộ descendants.
+- Hard-delete dùng revision cũ: từ chối `stale_revision`; UI giữ dialog/trạng thái hiện tại để người dùng tải lại.
 - Export snapshot thay đổi trong lúc thu page/chunk: hủy toàn bộ thao tác, không tải partial file và yêu cầu người dùng thử lại.
 - Export scope không còn hợp lệ do option/criterion bị xóa hoặc đổi hồ sơ/phiên bản: từ chối file thay vì âm thầm thu hẹp phạm vi.
 - Trình duyệt không thể tạo Blob hoặc download bị chặn: giữ dialog, hiển thị lỗi retry được và luôn giải phóng object URL đã tạo.
@@ -769,6 +779,10 @@ khai phải áp dụng scope MVP, thuật ngữ và semantics của OpenSpec/P14
 - **Client export có thể ghép dữ liệu từ nhiều thời điểm:** P14 dùng canonical
   snapshot token trên manifest/ranking/matrix, thu tuần tự và revalidate manifest
   trước khi render.
+- **Hard-delete làm mất toàn bộ dữ liệu chưa khóa:** đây là chủ đích cho hồ sơ
+  nháp/dữ liệu làm việc chưa tạo lịch sử khóa. Giảm rủi ro bằng backend guard
+  vĩnh viễn sau lần khóa đầu tiên, optimistic revision, destructive confirmation
+  và transaction/cascade verification; không cung cấp bulk delete.
 
 ## Migration Plan
 
@@ -780,7 +794,10 @@ khai phải áp dụng scope MVP, thuật ngữ và semantics của OpenSpec/P14
 6. P14A1/P14A2 thêm read-only result-export RPCs trước; P14A3/P14B/P14C có thể
    deploy dần nhưng nút export chỉ được mount ở P14C2 sau khi collector,
    workbook renderer và dialog đều gated.
-7. Chỉ apply migration lên live Supabase sau khi người dùng cấp quyền rõ ràng cho thao tác live DB cụ thể.
+7. P15A thêm additive hard-delete/list-eligibility contract nhưng chưa kích
+   hoạt UI/proxy; P15B thêm metadata edit độc lập; P15C chỉ mount delete action
+   sau khi P15A đã apply/gated và P15B đã landed.
+8. Chỉ apply migration lên live Supabase sau khi người dùng cấp quyền rõ ràng cho thao tác live DB cụ thể.
 
 Rollback có thể gỡ route/navigation và migration mới mà không tác động dữ liệu Equipment. Việc xóa dữ liệu đã tạo trong module phải là quyết định migration riêng, không thực hiện tự động khi rollback UI.
 

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -29,9 +29,9 @@ Each leaf phase SHALL use:
 4. One main implementation session. Follow-up review fixes may continue in the same branch.
 5. One durable handoff note containing commit/PR/issue IDs, schema decisions and remaining risks.
 
-Parent labels such as `P3`, `P7`, `P8`, `P9`, `P10`, `P12`, `P13` and
-`P14` group related work only. Their leaf phases (`P3A`, `P3B`...) are the
-actual delivery units.
+Parent labels such as `P3`, `P7`, `P8`, `P9`, `P10`, `P12`, `P13`, `P14`
+and `P15` group related work only. Their leaf phases (`P3A`, `P3B`...) are
+the actual delivery units.
 
 Do not combine adjacent leaf phases merely because the implementation appears small. A leaf phase may be split further when discovery shows:
 
@@ -131,7 +131,10 @@ P13A-P1         -> P13A-V
 P13A-P1 fail    -> P13A-P2 -> approved apply/gate -> rerun P13A-P1 green -> P13A-V
 P12C2           -> P13B
 P12C1           -> P14A1 -> P14A2 -> P14A3 -> P14A4 -> P14B1 -> P14B1F -> P14B2 -> P14C1 -> P14C2
-P13A-V + P13B + P7A2 + P9A3 + P14C2 -> P13C
+P3A + P4        -> P15A
+P3A             -> P15B
+P15A + P15B     -> P15C
+P13A-V + P13B + P7A2 + P9A3 + P14C2 + P15C -> P13C
 ```
 
 `P5A` is technically independent after `P0`, but the default delivery order places it after `P4` so the completed baseline lifecycle remains the starting point for the P5A-P5D rollout. `P6A` is also technically independent after `P0`, but the default delivery order places it after `P5D`; `P6B` follows `P6A` and must land before the first document UI in `P7B2`. Neither P6 leaf blocks reference-product or supplier work that has no document UI.
@@ -183,33 +186,41 @@ uses in-memory fixtures larger than 100 options x 102 criteria. P13C waits for
 P14C2 because final release evidence must include the approved result-export
 workflow, but P14 does not wait for P13A-P1, P13A-V or P13B.
 
+P15 is a lifecycle follow-up with two independently deployable prerequisites.
+P15A adds only the dormant database hard-delete contract and additive
+`can_delete` list field after P3A/P4. P15B independently activates metadata
+editing through the existing P1 update RPC after P3A. P15C starts only after
+both leaves are merged and P15A is applied/gated; it then allowlists and mounts
+hard-delete through the row-action surface introduced by P15B. P13C waits for
+P15C so final acceptance includes the complete dossier lifecycle.
+
 ## Requirement Traceability
 
 Requirement IDs are roadmap aliases. The authoritative requirement names and scenarios remain in the OpenSpec delta.
 
-| ID    | Requirement                                     | Primary phases                                                                                                                                                                                         |
-| ----- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| TC-01 | Independent technical configuration dossier     | P0, P1                                                                                                                                                                                                 |
-| TC-02 | Global administrator access boundary            | Every DB phase, P3A, P13A-V                                                                                                                                                                            |
-| TC-03 | Flexible two-level baseline authoring           | P0, P2, P3B, P3C                                                                                                                                                                                       |
-| TC-04 | Explicit save for editable workflows            | P3A, P3B, P3C, P7A2, P7B2, P8A4, P8B1, P8B2, P8B3, P9A3, P9B2, P12A1, P12A2, P12B1, P12B2                                                                                                              |
-| TC-05 | Standard baseline Excel template                | P0, P5A, P5B, P5C, P5D                                                                                                                                                                                 |
-| TC-06 | Immutable locked baseline versions              | P4, P7A1, P7A2, P7B1, P7B2                                                                                                                                                                             |
-| TC-07 | Historical baseline linkage                     | P4, P8A3, P8A4                                                                                                                                                                                         |
-| TC-08 | Optional reference products                     | P0, P7A1, P7A2                                                                                                                                                                                         |
-| TC-09 | Multiple supplier configuration options         | P8A1, P8A2, P8A3, P8A4, P8B1, P8B2, P8B3                                                                                                                                                               |
-| TC-10 | Standard supplier option Excel template         | P9A1, P9A2, P9A3                                                                                                                                                                                       |
-| TC-11 | URL-only document profiles                      | P6A, P6B, P7B1, P7B2, P9B1, P9B2                                                                                                                                                                       |
-| TC-12 | Criterion-level document citations              | P7B1, P7B2, P9B1, P9B2                                                                                                                                                                                 |
-| TC-13 | Scan-friendly comparison matrix                 | P10A1, P10A2, P10B1, P10B2, P10B3, P12A1, P12A2                                                                                                                                                        |
-| TC-14 | Per-option manual evaluation workflow           | P11D, P12A1, P12A2, P12B1, P12B2                                                                                                                                                                       |
-| TC-15 | Separate manual evaluation axes                 | P11A, P11B, P11C, P11D, P12A1, P12A2                                                                                                                                                                   |
-| TC-16 | Transparent derived overall status              | P11A, P12A1, P12A2, P12B1, P12B2                                                                                                                                                                       |
-| TC-17 | Non-scoring supplementary information           | P8A3, P8A4, P8B2, P8B3, P10A1, P10A2, P10B1, P12A1, P12A2, P13B                                                                                                                                        |
-| TC-18 | Optional transparent reference ranking          | P12C1, P12C2                                                                                                                                                                                           |
-| TC-19 | AI-ready data boundaries without MVP AI runtime | P0, P1, P11A, P11B, P11C, P13C                                                                                                                                                                         |
-| TC-20 | Optimistic conflict protection                  | P0, P1, P2, P3B, P4, P5C, P5D, P7A1, P7A2, P7B1, P7B2, P8A1, P8A2, P8A3, P8A4, P8B1, P8B2, P8B3, P9A2, P9A3, P9B1, P9B2, P11B, P11C, P12A1, P12A2, P12B2, P13A-P1, P13A-P2 (conditional), P13A-V, P13B |
-| TC-21 | Final comparison result Excel export            | P14A1, P14A2, P14A3, P14A4, P14B1, P14B1F, P14B2, P14C1, P14C2                                                                                                                                         |
+| ID    | Requirement                                     | Primary phases                                                                                                                                                                                                           |
+| ----- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TC-01 | Independent technical configuration dossier     | P0, P1, P15A, P15B, P15C                                                                                                                                                                                                 |
+| TC-02 | Global administrator access boundary            | Every DB phase, P3A, P15C, P13A-V                                                                                                                                                                                        |
+| TC-03 | Flexible two-level baseline authoring           | P0, P2, P3B, P3C                                                                                                                                                                                                         |
+| TC-04 | Explicit save for editable workflows            | P3A, P3B, P3C, P7A2, P7B2, P8A4, P8B1, P8B2, P8B3, P9A3, P9B2, P12A1, P12A2, P12B1, P12B2, P15B, P15C                                                                                                                    |
+| TC-05 | Standard baseline Excel template                | P0, P5A, P5B, P5C, P5D                                                                                                                                                                                                   |
+| TC-06 | Immutable locked baseline versions              | P4, P7A1, P7A2, P7B1, P7B2, P15A, P15C                                                                                                                                                                                   |
+| TC-07 | Historical baseline linkage                     | P4, P8A3, P8A4                                                                                                                                                                                                           |
+| TC-08 | Optional reference products                     | P0, P7A1, P7A2                                                                                                                                                                                                           |
+| TC-09 | Multiple supplier configuration options         | P8A1, P8A2, P8A3, P8A4, P8B1, P8B2, P8B3                                                                                                                                                                                 |
+| TC-10 | Standard supplier option Excel template         | P9A1, P9A2, P9A3                                                                                                                                                                                                         |
+| TC-11 | URL-only document profiles                      | P6A, P6B, P7B1, P7B2, P9B1, P9B2                                                                                                                                                                                         |
+| TC-12 | Criterion-level document citations              | P7B1, P7B2, P9B1, P9B2                                                                                                                                                                                                   |
+| TC-13 | Scan-friendly comparison matrix                 | P10A1, P10A2, P10B1, P10B2, P10B3, P12A1, P12A2                                                                                                                                                                          |
+| TC-14 | Per-option manual evaluation workflow           | P11D, P12A1, P12A2, P12B1, P12B2                                                                                                                                                                                         |
+| TC-15 | Separate manual evaluation axes                 | P11A, P11B, P11C, P11D, P12A1, P12A2                                                                                                                                                                                     |
+| TC-16 | Transparent derived overall status              | P11A, P12A1, P12A2, P12B1, P12B2                                                                                                                                                                                         |
+| TC-17 | Non-scoring supplementary information           | P8A3, P8A4, P8B2, P8B3, P10A1, P10A2, P10B1, P12A1, P12A2, P13B                                                                                                                                                          |
+| TC-18 | Optional transparent reference ranking          | P12C1, P12C2                                                                                                                                                                                                             |
+| TC-19 | AI-ready data boundaries without MVP AI runtime | P0, P1, P11A, P11B, P11C, P13C                                                                                                                                                                                           |
+| TC-20 | Optimistic conflict protection                  | P0, P1, P2, P3B, P4, P5C, P5D, P7A1, P7A2, P7B1, P7B2, P8A1, P8A2, P8A3, P8A4, P8B1, P8B2, P8B3, P9A2, P9A3, P9B1, P9B2, P11B, P11C, P12A1, P12A2, P12B2, P15A, P15B, P15C, P13A-P1, P13A-P2 (conditional), P13A-V, P13B |
+| TC-21 | Final comparison result Excel export            | P14A1, P14A2, P14A3, P14A4, P14B1, P14B1F, P14B2, P14C1, P14C2                                                                                                                                                           |
 
 ## Shared Technical Constraints
 
@@ -3369,9 +3380,181 @@ The approved export action produces the requested complete workbook from one
 stable read-only snapshot, preserves all existing Excel and evaluation
 workflows and is independently deployable before deferred P13 hardening.
 
+## Phase P15A - Dormant Dossier Hard-Delete Contract
+
+**Detailed TDD plan:** [P15A - Dormant Dossier Hard-Delete Contract](./p15a-tdd-plan.md)
+**Tracking issue:** [#864](https://github.com/thienchi2109/qltbyt-nam-phong/issues/864)
+
+**Depends on:** P3A, P4  
+**Requirements:** TC-01, TC-02, TC-06, TC-20  
+**Deploy boundary:** additive database-only delete and eligibility contract; no
+proxy allowlist, client adapter or user-visible action
+
+### Planned files
+
+- Create at execution time after migration-order inspection:
+  `supabase/migrations/<timestamp>_technical_configuration_dossier_delete.sql`
+- Create:
+  `src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts`
+- Regression-only; do not modify unless execution-time source inspection shows
+  its P1 marker isolation changed:
+  `src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts`
+- Create:
+  `supabase/tests/technical_configuration_dossier_delete_phase_gate.sql`
+- Create:
+  `supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql`
+
+### Tasks
+
+- [ ] Inspect current local migration order and live dossier functions, grants,
+      FK cascades and baseline indexes read-only.
+- [ ] Write RED source tests for the exact delete signature, additive
+      `can_delete`, guard/row-lock ordering, locked-history rejection, grants
+      and deliberate absence from proxy allowlists.
+- [ ] Add one ordered migration that replaces the dossier-list response
+      additively and creates
+      `technical_configuration_dossiers_delete(UUID, BIGINT)`.
+- [ ] Call `_technical_configuration_require_editable_dossier()` first, check
+      historical `status='locked'` existence under the retained dossier row
+      lock, raise `PT409/locked_dossier`, then delete only the aggregate root.
+- [ ] Add a rollback-only SQL phase gate for global/raw-admin success,
+      unauthorized, stale, archived, never-locked cascade, permanently locked
+      rejection and list/get disappearance.
+- [ ] Add a two-session Supabase MCP concurrency gate proving delete-first
+      yields `not_found` to baseline lock, lock-first yields `locked_dossier` to
+      delete, exactly one operation commits and disposable fixtures are cleaned.
+- [ ] Keep the delete RPC dormant. Do not add it to
+      `allowed-functions.ts`, any RPC-name manifest or frontend code.
+- [ ] Apply and run live gates only after explicit user authorization, then run
+      security/performance advisors and preserve the evidence.
+
+### Exit gate
+
+The database can safely delete only a never-locked active dossier and reports
+set-based eligibility, while the deployed application has no route through
+which a browser can invoke the new mutation.
+
+## Phase P15B - Active Dossier Metadata Editing
+
+**Detailed TDD plan:** [P15B - Active Dossier Metadata Editing](./p15b-tdd-plan.md)
+**Tracking issue:** [#863](https://github.com/thienchi2109/qltbyt-nam-phong/issues/863)
+
+**Depends on:** P3A  
+**Requirements:** TC-01, TC-04, TC-20  
+**Deploy boundary:** metadata-edit workflow through the existing update RPC;
+no delete proxy exposure or delete action
+
+### Planned files
+
+- Create:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx`
+- Create:
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-rpc.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx`
+
+### Tasks
+
+- [ ] Write RED adapter and React tests for opening edit from one row,
+      prefilled metadata, explicit save, cancel/no mutation, validation,
+      loading/error/retry and stale-revision handling.
+- [ ] Add the typed update adapter over the existing
+      `technical_configuration_dossiers_update` RPC.
+- [ ] Generalize the dossier form for create/edit mode without duplicating
+      schema, fields or submit behavior.
+- [ ] Add a reusable row-action surface and extracted action-state hook so
+      `TechnicalConfigurationsClient.tsx` remains orchestration-only and below
+      the 350-line extraction threshold.
+- [ ] On success, adopt the returned dossier revision in list/detail cache and
+      preserve the currently open workspace when the edited dossier is active.
+- [ ] Keep metadata editable after baseline lock and leave archive, baseline
+      content and every delete contract unchanged.
+
+### Exit gate
+
+Admin/global users can explicitly edit active dossier metadata with optimistic
+revision protection. No P15 delete RPC is allowlisted or visible.
+
+## Phase P15C - Guarded Dossier Delete Activation
+
+**Detailed TDD plan:** [P15C - Guarded Dossier Delete Activation](./p15c-tdd-plan.md)
+**Tracking issue:** [#865](https://github.com/thienchi2109/qltbyt-nam-phong/issues/865)
+
+**Depends on:** P15A applied/gated, P15B  
+**Requirements:** TC-01, TC-02, TC-04, TC-06, TC-20  
+**Deploy boundary:** activates hard-delete in proxy/client/list UI only after
+the dormant database contract and metadata row-action surface are available
+
+### Planned files
+
+- Create:
+  `src/lib/technical-configuration-dossier-rpcs.ts`
+- Create:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierDeleteDialog.tsx`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-delete-dialog.test.tsx`
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Modify:
+  `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+- Modify: `src/app/(app)/technical-configurations/types.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-rpc.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx`
+
+### Tasks
+
+- [ ] Verify P15A is applied and its rollback-only phase gate is green before
+      adding the delete name to the proxy boundary.
+- [ ] Write RED allowlist, adapter and React tests for `can_delete`, a visible
+      disabled locked-row delete action with accessible explanation, explicit
+      destructive confirmation,
+      loading/error/retry, stale/locked conflicts and no pre-confirm mutation.
+- [ ] Add the dedicated dossier RPC-name manifest, allowlist only the P15A
+      delete function and map its `{ data: { id } }` response.
+- [ ] Extend the P15B row-action hook/component with delete eligibility and one
+      destructive confirmation dialog; keep archive as a separate lifecycle.
+- [ ] After success, remove the deleted dossier from cache, invalidate the list
+      root, clear an open matching workspace and move to the previous page when
+      deletion empties a non-first page.
+- [ ] Treat `can_delete` as an affordance only. Surface authoritative
+      `locked_dossier`, `stale_revision`, `archived_dossier` and `not_found`
+      responses without optimistic hard deletion.
+- [ ] Run standard TypeScript/React gates, focused RPC/form/shell regressions,
+      React Doctor, browser verification at desktop/narrow widths and strict
+      OpenSpec validation.
+
+### Exit gate
+
+Admin/global users can permanently delete only an active dossier that has never
+had a locked baseline. Metadata editing remains independent, archive semantics
+remain unchanged and every server-side rejection leaves the UI/cache intact.
+
 ## Phase P13C - Release, OpenSpec And AI-Boundary Audit
 
-**Depends on:** P13A-V, P13B, P7A2, P9A3, P14C2
+**Depends on:** P13A-V, P13B, P7A2, P9A3, P14C2, P15C
 **Requirements:** TC-19  
 **Deploy boundary:** release documentation and final acceptance only
 
@@ -3389,6 +3572,9 @@ workflows and is independently deployable before deferred P13 hardening.
 - [ ] Confirm optional productivity leaves P7A1, P7A2 and P9A1-P9A3 are complete even though they are not on the manual-comparison critical path.
 - [ ] Confirm P14A1-P14C2 landed and the final result workbook contract remains
       read-only, snapshot-stable and free of scoring/award semantics.
+- [ ] Confirm P15A and P15B are merged independently, P15A is applied/gated,
+      P15C activates deletion only afterward and locked-history dossiers remain
+      permanently retained.
 - [ ] Aggregate preserved per-leaf `verify:no-explicit-any`, `verify:dedupe`, focused test and review evidence.
 - [ ] Run fresh full `typecheck` and all focused feature Vitest suites; do not claim a fresh P13 branch diff covers earlier merged leaf diffs.
 - [ ] Run `openspec validate add-technical-configuration-comparison --strict`.

--- a/openspec/changes/add-technical-configuration-comparison/p15a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p15a-tdd-plan.md
@@ -1,0 +1,171 @@
+# P15A TDD Plan - Dormant Dossier Hard-Delete Contract
+
+> **For agentic workers:** Execute test-first with
+> `superpowers:test-driven-development`, `karpathy-coding-heuristics` and
+> `supabase-postgres-best-practices`. Use Supabase MCP for every live DB read or
+> write. Do not apply the migration or run the rollback-only live phase gate
+> without explicit permission for each live write operation.
+
+## Goal
+
+Add the authoritative database contract for permanently deleting an active
+technical-configuration dossier that has never had a locked baseline. Extend
+the dossier list with set-based `can_delete`, but keep the delete RPC dormant:
+no proxy allowlist, TypeScript adapter or UI belongs to this leaf.
+
+**Tracking issue:** [#864](https://github.com/thienchi2109/qltbyt-nam-phong/issues/864)
+
+## Preconditions
+
+- P3A and P4 are merged and verified on `main`.
+- The execution branch starts from clean, synchronized `main`.
+- AgentMemory, Code Review Graph and GitNexus are refreshed for the dossier
+  list, editable-dossier guard and baseline-lock functions.
+- Live DB inspection remains read-only until the user explicitly authorizes an
+  apply or rollback-only phase gate.
+
+## Frozen Contract
+
+- RPC:
+  `technical_configuration_dossiers_delete(p_id UUID, p_expected_revision BIGINT)`.
+- Success response: `{ data: { id: <uuid> } }`.
+- The RPC calls `_technical_configuration_require_editable_dossier()` first.
+- While retaining the dossier row lock, it rejects any dossier with historical
+  `technical_configuration_baseline_versions.status='locked'` using
+  `PT409/locked_dossier`.
+- A later draft never restores delete eligibility after the first lock.
+- On success, delete only `technical_configuration_dossiers`; verified
+  `ON DELETE CASCADE` constraints remove descendants in the same transaction.
+- The dossier list adds non-null boolean `can_delete`, computed set-based from
+  active state plus locked-baseline existence.
+- `can_delete` is an affordance, not authorization.
+- Archive remains one-way and distinct from hard-delete.
+- Baseline lock and delete both lock the dossier row first.
+- No new table or speculative index is planned.
+
+## Planned Files
+
+- Create after checking all local migrations touching the dossier list, dossier
+  guard or baseline lock:
+  `supabase/migrations/<timestamp>_technical_configuration_dossier_delete.sql`
+- Create:
+  `src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts`
+- Regression-only; keep unchanged unless its source marker changes:
+  `src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts`
+- Create:
+  `supabase/tests/technical_configuration_dossier_delete_phase_gate.sql`
+- Create:
+  `supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql`
+- Do not modify:
+  `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Do not create or modify frontend RPC manifests, adapters, types or components.
+
+## Chunk 1: RED - Freeze Source And Dormancy Contracts
+
+- [ ] Inspect current local migration timestamps and identify the latest file
+      redefining the dossier list, editable-dossier guard or baseline lock.
+- [ ] Inspect live function definitions, grants, baseline indexes and all
+      dossier-descendant foreign keys through read-only Supabase MCP.
+- [ ] Write a focused migration-source test for the exact delete signature,
+      `{ data: { id } }`, `SECURITY DEFINER` and
+      `SET search_path = public, pg_temp`.
+- [ ] Require `REVOKE` from `PUBLIC`, `anon` and `service_role`, with
+      `GRANT EXECUTE` only to `authenticated`, matching the existing dossier RPC
+      boundary.
+- [ ] Require editable-dossier guard invocation before locked-baseline
+      inspection, dossier-row-first serialization, `PT409/locked_dossier` and
+      one root `DELETE` with no manual child-table delete chain.
+- [ ] Require additive non-null `can_delete` and set-based locked existence with
+      no per-row function/list call.
+- [ ] Add a negative assertion that the delete function is absent from
+      `allowed-functions.ts` and every technical-configuration RPC manifest.
+- [ ] Keep the existing foundation migration test scoped to the historical P1
+      file through its `technical_configuration_dossier_foundation` marker. It
+      must continue to prove the original five P1 RPCs without claiming that
+      later P15A migrations cannot add a delete RPC.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`.
+- [ ] Confirm RED only because the P15A migration and phase-gate artifacts do
+      not yet exist.
+
+## Chunk 2: GREEN - Add The Minimal Ordered Migration
+
+- [ ] Create one transaction-scoped migration whose timestamp sorts after every
+      local migration identified in Chunk 1.
+- [ ] Replace `technical_configuration_dossiers_list` additively so each row
+      includes `can_delete` without changing existing pagination/filter totals.
+- [ ] Compute eligibility in the list statement with `EXISTS`/`NOT EXISTS` or
+      an equivalent set-based join; do not invoke a version-list RPC.
+- [ ] Create the delete RPC with the exact signature and common guard.
+- [ ] Check locked history under the retained dossier row lock and fail before
+      deletion with `locked_dossier`.
+- [ ] Delete the aggregate root once and return only the deleted ID.
+- [ ] Preserve deny-by-default table access, explicit function grants and fixed
+      search paths.
+- [ ] Run the focused source/whitelist tests and confirm only SQL runtime cases
+      remain RED.
+
+## Chunk 3: GREEN - Add The Rollback-Only SQL Phase Gate
+
+- [ ] Build transaction-scoped fixtures with unique suffixes for: - active dossier with no baseline - active dossier with draft-only descendants - active dossier with historical locked baseline and a later draft - archived dossier
+- [ ] Prove global and raw-admin semantics.
+- [ ] Prove denied role, missing claim, stale revision, archived dossier,
+      missing dossier and locked dossier failures with exact SQLSTATE/message.
+- [ ] Prove draft-only aggregate deletion cascades through every current
+      descendant table and leaves list/get absent.
+- [ ] Prove locked-history rejection leaves root and all descendants unchanged.
+- [ ] Prove `can_delete=true` only for active never-locked dossiers and remains
+      false after a later draft is created.
+- [ ] Add a reproducible two-session concurrency protocol whose labeled SQL
+      blocks are executed through two concurrent Supabase MCP sessions.
+- [ ] Prove delete-first: delete commits, baseline lock returns
+      `PT404/not_found`, exactly one operation succeeds and no descendant row
+      survives.
+- [ ] Prove lock-first: baseline lock commits, delete returns
+      `PT409/locked_dossier`, exactly one operation succeeds and the complete
+      locked aggregate remains.
+- [ ] Use unique disposable fixtures and include explicit post-assert cleanup.
+      Do not replace this gate with static source inspection.
+- [ ] End the phase gate with `ROLLBACK`.
+- [ ] Run the focused migration-source test and confirm GREEN.
+
+## Chunk 4: Refactor And Static Gate
+
+- [ ] Recheck all cascade constraints against current local and live schema.
+- [ ] Use semantic deduplication before adding any SQL helper; prefer the
+      existing editable-dossier guard and baseline-lock pattern.
+- [ ] Review the list query plan statically and through a rollback-only
+      representative fixture. Add an index only if measured evidence proves the
+      existing dossier/status indexes are insufficient.
+- [ ] Confirm the diff contains no allowlist, adapter, type, React or UI change.
+- [ ] Run in repository order through one context-mode batch.
+
+  ```bash
+  rtk node scripts/npm-run.js run format:check
+  rtk node scripts/npm-run.js run verify:no-explicit-any
+  rtk node scripts/npm-run.js run verify:dedupe
+  rtk node scripts/npm-run.js run typecheck
+  # Run the focused Vitest command from Chunk 1.
+  rtk openspec validate add-technical-configuration-comparison --strict
+  ```
+
+## Live DB Gate
+
+- [ ] Ask for explicit permission before applying the P15A migration.
+- [ ] Apply through Supabase MCP only.
+- [ ] Verify function definitions, grants and list response read-only.
+- [ ] Ask for separate explicit permission before executing the rollback-only
+      phase gate against live DB.
+- [ ] Ask for separate explicit permission before executing the two-session
+      concurrency gate. Run its labeled blocks through two concurrent Supabase
+      MCP sessions, verify both winner orderings and confirm cleanup leaves no
+      disposable fixture rows.
+- [ ] Run security and performance advisors after the approved gate.
+- [ ] Preserve migration version, gate output and advisor findings in the leaf
+      handoff.
+
+## Exit Gate
+
+P15A stops after a tested, applied and gated dormant database contract. The
+browser cannot invoke hard-delete, metadata editing is unchanged and P15C may
+not start until the live P15A evidence is available.

--- a/openspec/changes/add-technical-configuration-comparison/p15b-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p15b-tdd-plan.md
@@ -1,0 +1,136 @@
+# P15B TDD Plan - Active Dossier Metadata Editing
+
+> **For agentic workers:** Execute test-first with
+> `superpowers:test-driven-development`, `karpathy-coding-heuristics`,
+> `next-best-practices`, `vercel-react-best-practices` and
+> `code-deduplication`. This leaf is independent of P15A and must not import,
+> expose or conditionally depend on the dormant delete contract.
+
+## Goal
+
+Allow `admin/global` users to edit the device type, dossier name and description
+of an active dossier through the existing
+`technical_configuration_dossiers_update` RPC. Reuse one form contract for
+create/edit and introduce a row-action ownership seam that P15C can extend
+without growing `TechnicalConfigurationsClient.tsx` into a state-heavy module.
+
+**Tracking issue:** [#863](https://github.com/thienchi2109/qltbyt-nam-phong/issues/863)
+
+## Preconditions
+
+- P3A is merged and verified on `main`.
+- The execution branch starts from clean, synchronized `main`.
+- Current file sizes and row/table ownership are rechecked before editing.
+- Code Review Graph and GitNexus confirm the callers of
+  `TechnicalConfigurationDossierForm`,
+  `TechnicalConfigurationDossierTable` and the dossier query root.
+
+## Frozen Product Contract
+
+- Editable fields: `device_type_name`, `name`, `description`.
+- The edit form is prefilled from the selected active dossier.
+- Opening, typing and cancelling do not call the backend.
+- Explicit save sends the current dossier revision exactly once.
+- Success adopts the returned dossier and new revision in list/detail state.
+- `stale_revision`, validation and network errors keep the form open and show a
+  retryable error without discarding user input.
+- Metadata remains editable after a baseline is locked because it is outside the
+  immutable baseline aggregate.
+- Archived dossier rejection remains authoritative at the existing RPC guard.
+- No archive UI, delete affordance, delete type, delete adapter or P15A
+  `can_delete` dependency belongs to this leaf.
+
+## Planned Files
+
+- Create:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx`
+- Create:
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-rpc.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx`
+
+## Chunk 1: RED - Typed Update Adapter
+
+- [ ] Add adapter tests for
+      `updateTechnicalConfigurationDossier(args, signal?)`.
+- [ ] Require the exact RPC name and body fields:
+      `p_id`, `p_device_type_name`, `p_name`, `p_description`,
+      `p_expected_revision`.
+- [ ] Reuse the existing typed error path and prove
+      status/code/message/details/hint preservation for `stale_revision`.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- 'src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts'`.
+- [ ] Confirm RED because the update adapter is missing.
+- [ ] Add the minimal adapter without changing shared `callRpc()`.
+- [ ] Rerun and confirm GREEN.
+
+## Chunk 2: RED/GREEN - Generalize The Dossier Form
+
+- [ ] Add form tests for create defaults and edit prefill.
+- [ ] Prove opening/editing/cancelling causes no mutation.
+- [ ] Prove edit submit maps all three fields plus ID/current revision.
+- [ ] Prove validation, pending state, error display and retry preserve values.
+- [ ] Generalize the existing component with explicit create/edit inputs and
+      labels while keeping one Zod schema and one field tree.
+- [ ] Reset the form only when opening a new create/edit target; do not erase an
+      in-progress retry state due to unrelated parent renders.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- 'src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx'`.
+
+## Chunk 3: RED/GREEN - Row Action And Mutation Ownership
+
+- [ ] Add shell tests that open an edit action from the intended dossier row,
+      never from another row.
+- [ ] Add tests for cancel, success, pending lock, API error and stale revision.
+- [ ] Create one icon/menu row-action component with accessible labels and
+      tooltips consistent with the existing UI system.
+- [ ] Create an action-state hook that owns selected edit target, dialog state,
+      update mutation and success/error transitions.
+- [ ] Keep `TechnicalConfigurationsClient.tsx` focused on page/query/workspace
+      orchestration. Recheck the 350-line extraction threshold after integration.
+- [ ] On success: - update the matching item in the dossier-list cache - update the selected/open dossier when IDs match - preserve current page and workspace - invalidate only the dossier query root needed for reconciliation
+- [ ] Do not introduce optimistic metadata values before server success.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- 'src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx'`.
+
+## Chunk 4: Refactor And Gate
+
+- [ ] Run `code-deduplication` against existing row-action hooks, side-sheet
+      forms and query-cache update patterns before keeping new helpers.
+- [ ] Verify P15B imports no delete RPC manifest, delete adapter or
+      `can_delete`.
+- [ ] Verify baseline lock does not disable edit metadata in UI tests.
+- [ ] Run in repository order through one context-mode batch.
+
+  ```bash
+  rtk node scripts/npm-run.js run format:check
+  rtk node scripts/npm-run.js run verify:no-explicit-any
+  rtk node scripts/npm-run.js run verify:dedupe
+  rtk node scripts/npm-run.js run typecheck
+  # Run the three focused Vitest files above.
+  rtk node scripts/npm-run.js run react-doctor
+  rtk openspec validate add-technical-configuration-comparison --strict
+  ```
+
+- [ ] Run browser verification at desktop and narrow widths for row action,
+      side sheet, validation and no-overlap behavior.
+- [ ] Request code review, triage findings and rerun affected gates.
+
+## Exit Gate
+
+P15B is independently deployable when active metadata edit is complete and
+revision-safe, the create workflow remains green and no hard-delete surface is
+reachable. P15C may reuse the row-action seam but must not be folded into this
+leaf.

--- a/openspec/changes/add-technical-configuration-comparison/p15c-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p15c-tdd-plan.md
@@ -1,0 +1,151 @@
+# P15C TDD Plan - Guarded Dossier Delete Activation
+
+> **For agentic workers:** Execute test-first with
+> `superpowers:test-driven-development`, `karpathy-coding-heuristics`,
+> `next-best-practices`, `vercel-react-best-practices` and
+> `code-deduplication`. Do not edit or reapply the P15A migration in this leaf.
+
+## Goal
+
+Activate the already-applied P15A hard-delete RPC through the proxy, typed
+client and P15B row-action surface. The UI warns that deletion is permanent,
+uses `can_delete` only as an affordance and changes cache/workspace state only
+after an authoritative server success.
+
+**Tracking issue:** [#865](https://github.com/thienchi2109/qltbyt-nam-phong/issues/865)
+
+## Hard Entry Gate
+
+- P15A is merged, applied and its rollback-only SQL phase gate is green.
+- P15B is merged and its metadata edit regressions are green.
+- Live read-only inspection confirms the exact P15A function signature, grants,
+  `can_delete` response and migration version.
+- If any P15A evidence is missing or differs from the frozen contract, stop and
+  fix P15A through its own follow-up leaf instead of widening P15C.
+
+## Frozen Product And Client Contract
+
+- Add `can_delete: boolean` to each dossier list wire item.
+- Add delete args:
+  `{ p_id: string, p_expected_revision: number }`.
+- Add delete response: `{ data: { id: string } }`.
+- Add one dedicated dossier RPC-name manifest and allowlist exactly
+  `technical_configuration_dossiers_delete`.
+- Never send the mutation before explicit destructive confirmation.
+- Keep the delete action visible but disabled when `can_delete=false`, with
+  accessible explanation text stating that a locked baseline permanently
+  preserves the dossier.
+- The server remains authoritative. Handle `locked_dossier`, `stale_revision`,
+  `archived_dossier` and `not_found` even when the list previously reported
+  `can_delete=true`.
+- Success removes the matching dossier from cache, clears an open matching
+  workspace and moves from page N to N-1 when the deletion empties page N and
+  `N > 1`.
+- Failure leaves list, workspace and page unchanged.
+- Archive remains separate; P15C adds no archive or restore action.
+
+## Planned Files
+
+- Create: `src/lib/technical-configuration-dossier-rpcs.ts`
+- Create:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierDeleteDialog.tsx`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-delete-dialog.test.tsx`
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Modify:
+  `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+- Modify: `src/app/(app)/technical-configurations/types.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-rpc.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx`
+
+## Chunk 1: RED - Proxy Manifest And Typed Adapter
+
+- [ ] Add whitelist tests that require a dedicated dossier RPC manifest and one
+      new allowed function.
+- [ ] Prove no other dossier/archive/baseline name is added accidentally.
+- [ ] Add type/adapter tests for `can_delete`, exact delete args and
+      `{ data: { id } }`.
+- [ ] Prove typed error preservation for every authoritative conflict.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts 'src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts'`.
+- [ ] Confirm RED because the manifest, allowlist entry, types and adapter are
+      missing.
+- [ ] Add the smallest manifest/allowlist/type/adapter implementation.
+- [ ] Rerun and confirm GREEN.
+
+## Chunk 2: RED/GREEN - Destructive Confirmation Dialog
+
+- [ ] Add user-event tests for open, cancel, close, confirm, pending, error and
+      retry.
+- [ ] Assert the dossier name is visible and the copy states deletion is
+      permanent.
+- [ ] Assert no backend callback before explicit confirm.
+- [ ] Assert pending prevents duplicate submit and unsafe close.
+- [ ] Assert server error keeps the dialog open and does not claim deletion.
+- [ ] Build one focused dialog component using existing alert-dialog primitives
+      and lucide destructive-action icons.
+- [ ] Keep query/mutation/cache knowledge outside the dialog.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- 'src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-delete-dialog.test.tsx'`.
+
+## Chunk 3: RED/GREEN - Row Eligibility And Authoritative Mutation
+
+- [ ] Extend shell tests for `can_delete=true` action availability and
+      `can_delete=false` visible-disabled behavior with accessible explanation.
+- [ ] Keep the edit action independently available and cover no mutation before
+      confirmation, success removal, changed eligibility, `locked_dossier`,
+      stale, archived, not-found and network errors.
+- [ ] Extend the P15B action-state hook instead of creating a second competing
+      mutation owner.
+- [ ] Send the current row revision at confirmation time.
+- [ ] Do not optimistic-remove the dossier.
+- [ ] After success, atomically reconcile: - matching list cache item removal - dossier query-root invalidation - selected/open workspace reset when IDs match - previous-page fallback when the current non-first page becomes empty
+- [ ] Ignore or cancel obsolete completion after route/unmount/target change
+      according to existing TanStack Query patterns.
+- [ ] Run:
+      `rtk node scripts/npm-run.js run test -- 'src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx'`.
+
+## Chunk 4: Regression, Refactor And Visual Gate
+
+- [ ] Rerun P15A migration-source and whitelist tests to prove proxy activation
+      matches the deployed DB signature without changing its SQL contract.
+- [ ] Rerun P15B form/edit tests to prove delete integration did not couple or
+      regress metadata editing.
+- [ ] Use `code-deduplication` for mutation-state, page-fallback and destructive
+      dialog patterns.
+- [ ] Recheck `TechnicalConfigurationsClient.tsx` and extracted action files
+      against the 350/450-line limits.
+- [ ] Run in repository order through one context-mode batch.
+
+  ```bash
+  rtk node scripts/npm-run.js run format:check
+  rtk node scripts/npm-run.js run verify:no-explicit-any
+  rtk node scripts/npm-run.js run verify:dedupe
+  rtk node scripts/npm-run.js run typecheck
+  # Run focused whitelist/RPC/form/dialog/shell tests.
+  rtk node scripts/npm-run.js run react-doctor
+  rtk openspec validate add-technical-configuration-comparison --strict
+  ```
+
+- [ ] Run browser verification at desktop and narrow widths for menu placement,
+      dialog focus, text fit, pending/error states and post-delete navigation.
+- [ ] Request code review, triage findings and rerun affected gates.
+
+## Exit Gate
+
+P15C is complete when hard-delete is reachable only through the gated RPC,
+never executes before confirmation, never deletes a locked-history dossier and
+reconciles UI state only after server success. Metadata edit and archive remain
+independent lifecycle operations.

--- a/openspec/changes/add-technical-configuration-comparison/proposal.md
+++ b/openspec/changes/add-technical-configuration-comparison/proposal.md
@@ -7,6 +7,9 @@ Hệ thống cần một module độc lập để lập cấu hình kỹ thuậ
 ## What Changes
 
 - Thêm module "Phân tích cấu hình kỹ thuật" độc lập với `thiet_bi`; mỗi hồ sơ phân tích chỉ đại diện cho một loại thiết bị và một cấu hình cơ sở.
+- Cho phép sửa metadata của hồ sơ active gồm loại thiết bị, tên hồ sơ và mô tả bằng explicit save cùng optimistic revision guard; việc sửa metadata không thay đổi nội dung của các phiên bản cơ sở đã khóa.
+- Cho phép hard-delete vĩnh viễn một hồ sơ chỉ khi hồ sơ chưa từng có bất kỳ phiên bản cơ sở `locked` nào. Backend kiểm tra điều kiện dưới dossier row lock, xóa aggregate root cùng toàn bộ dữ liệu nháp/dữ liệu làm việc phụ thuộc qua cascade và từ chối fail-closed với `locked_dossier` sau lần khóa đầu tiên.
+- Giữ archive là lifecycle riêng: hồ sơ archived vẫn đọc được và bất biến như contract hiện tại; hard-delete không thay thế archive và không tạo restore.
 - Giới hạn toàn bộ module cho người dùng `admin/global`, sử dụng `isGlobalRole()` tại các biên ngoài RPC proxy và kiểm tra quyền tương ứng tại backend.
 - Cho phép xây dựng cấu hình cơ sở theo mô hình text-first gồm hai cấp `Nhóm cấu hình -> Tiêu chí`. Bản nháp mới có bốn nhóm gợi ý từ dữ liệu khảo sát: `Yêu cầu chung`, `Yêu cầu cấu hình cung cấp`, `Yêu cầu kỹ thuật` và `Yêu cầu khác`; đây là template mặc định có thể thêm, đổi tên, xóa và sắp xếp, không phải danh mục khóa cứng.
 - Giữ cấu trúc tiêu chí tối thiểu và ổn định thay vì cho tạo cột nội dung tùy ý. Người dùng có thể tạo không giới hạn số nhóm/tiêu chí theo quy tắc nghiệp vụ, nhập text nhiều dòng, nhập nhanh, sắp xếp và import template Excel chuẩn của hệ thống.
@@ -28,6 +31,10 @@ Hệ thống cần một module độc lập để lập cấu hình kỹ thuậ
 - Gói delivery export này mang tên `P14`, độc lập với P13 đang defer và được
   tách thành tám leaf PR deploy-safe: P14A1, P14A2, P14A3, P14A4, P14B1, P14B2,
   P14C1 và P14C2.
+- Gói lifecycle follow-up mang tên `P15` và được tách thành ba leaf deploy-safe:
+  P15A thêm contract DB hard-delete cùng eligibility read model nhưng chưa kích
+  hoạt UI/proxy; P15B chỉ thêm sửa metadata; P15C mới kích hoạt hard-delete qua
+  proxy, row actions và dialog xác nhận.
 - Không đưa AI vào MVP: không có nút AI, API call, job, cache, quota, cột AI hoặc bảng AI chưa sử dụng. Mô hình dữ liệu giữ ID ổn định và tách rõ yêu cầu, phản hồi, bằng chứng, đánh giá để có thể bổ sung AI bằng một OpenSpec change riêng sau này.
 
 ## Impact
@@ -36,11 +43,12 @@ Hệ thống cần một module độc lập để lập cấu hình kỹ thuậ
   - `technical-configuration-comparison` (new capability)
 - Anticipated affected code:
   - Route và UI mới dưới `src/app/(app)/technical-configurations/`
+  - Row actions, form sửa metadata và dialog hard-delete có xác nhận trên danh sách hồ sơ
   - Data hooks, types và baseline/option Excel codec dành riêng cho module
   - Read-only result-export RPCs, stable snapshot collector, workbook codec và export-scope dialog dành riêng cho module
   - Shared Excel primitives được trích từ pipeline Equipment với compatibility exports và regression coverage
   - Shared URL attachment primitives được trích xuất từ pattern Equipment khi triển khai
-  - Supabase migration mới cho hồ sơ, phiên bản cấu hình cơ sở, nhóm/tiêu chí, nhà cung cấp, phương án, phản hồi, URL tài liệu, trích dẫn, đánh giá thủ công và read-only canonical result-export snapshot
+  - Supabase migration mới cho hồ sơ, phiên bản cấu hình cơ sở, nhóm/tiêu chí, nhà cung cấp, phương án, phản hồi, URL tài liệu, trích dẫn, đánh giá thủ công, read-only canonical result-export snapshot và guarded hard-delete contract
   - Sidebar/navigation và route authorization cho `admin/global`
 - Existing data:
   - Không migrate dữ liệu từ `thiet_bi`

--- a/openspec/changes/add-technical-configuration-comparison/specs/technical-configuration-comparison/spec.md
+++ b/openspec/changes/add-technical-configuration-comparison/specs/technical-configuration-comparison/spec.md
@@ -23,6 +23,27 @@ Hệ thống SHALL cung cấp hồ sơ phân tích cấu hình kỹ thuật đ�
 - **AND** backend từ chối mọi mutation đối với hồ sơ, phiên bản cơ sở, nhóm, tiêu chí, sản phẩm tham chiếu, tài liệu, trích dẫn, nhà cung cấp, phương án, phản hồi và đánh giá thuộc hồ sơ đó
 - **AND** MVP không cung cấp thao tác restore
 
+#### Scenario: Edit active dossier metadata
+
+- **WHEN** người dùng `admin/global` mở thao tác sửa metadata của một hồ sơ active
+- **THEN** người dùng có thể sửa loại thiết bị, tên hồ sơ và mô tả rồi explicit save với dossier revision hiện tại
+- **AND** backend chưa nhận mutation trước khi người dùng bấm lưu
+- **AND** việc sửa metadata không thay đổi nội dung hoặc trạng thái của bất kỳ phiên bản cơ sở đã khóa nào
+
+#### Scenario: Permanently delete a never-locked dossier
+
+- **WHEN** người dùng `admin/global` xác nhận xóa một hồ sơ active chưa từng có bất kỳ phiên bản cơ sở `locked` nào
+- **THEN** backend hard-delete dossier aggregate root cùng toàn bộ dữ liệu nháp và dữ liệu làm việc phụ thuộc trong cùng transaction
+- **AND** hồ sơ không còn đọc được qua list/get và không được chuyển sang trạng thái archived
+- **AND** UI phải cảnh báo thao tác là vĩnh viễn và chỉ gửi mutation sau xác nhận rõ ràng
+
+#### Scenario: Reject deletion after the first locked baseline
+
+- **WHEN** UI hoặc caller trực tiếp yêu cầu hard-delete một hồ sơ đã có ít nhất một phiên bản cơ sở `locked`
+- **THEN** backend từ chối với conflict `locked_dossier`
+- **AND** dossier cùng toàn bộ dữ liệu con không thay đổi
+- **AND** hồ sơ không bao giờ trở lại trạng thái có thể hard-delete, kể cả khi sau đó có thêm một bản nháp mới
+
 ### Requirement: Global administrator access boundary
 
 Hệ thống SHALL chỉ cho phép người dùng có semantics `admin/global` truy cập và thay đổi dữ liệu của module.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -5,7 +5,7 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 ## Execution Rules
 
 - Mỗi **leaf phase** (`P0`, `P1`, `P3A`...) tương ứng một GitHub issue, một branch, một PR và một phiên triển khai chính.
-- Các phase cha như `P3`, `P7`, `P8`, `P9`, `P10`, `P12`, `P13`, `P14`
+- Các phase cha như `P3`, `P7`, `P8`, `P9`, `P10`, `P12`, `P13`, `P14`, `P15`
   chỉ dùng để nhóm roadmap, không phải đơn vị triển khai.
 - Không bắt đầu leaf phase khi dependency chưa được merge và xác minh trên `main`.
 - Trước khi sửa code, leaf phase phải có implementation plan TDD riêng với file path và test command chính xác theo code/live DB tại thời điểm đó.
@@ -75,7 +75,10 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 | [P14B2](./implementation-plan.md#phase-p14b2---approved-exceljs-workbook-rendering)                       | Render ExcelJS đúng mockup đã duyệt            | P14B1F                                           | TC-21-S03, S04, S05, S09                               |
 | [P14C1](./implementation-plan.md#phase-p14c1---export-scope-dialog-and-state-machine)                     | Dialog chọn nội dung và phạm vi export         | P14B2                                            | TC-21-S01, S02, S04                                    |
 | [P14C2](./implementation-plan.md#phase-p14c2---export-orchestration-download-and-workspace-activation)    | Mount trigger, orchestration và download       | P14C1                                            | TC-21                                                  |
-| [P13C](./implementation-plan.md#phase-p13c---release-openspec-and-ai-boundary-audit)                      | Release, OpenSpec và audit AI boundary         | P13A-V, P13B, P7A2, P9A3, P14C2                  | TC-19                                                  |
+| [P15A](./implementation-plan.md#phase-p15a---dormant-dossier-hard-delete-contract)                        | Contract DB hard-delete dormant và can_delete  | P3A, P4                                          | TC-01, TC-02, TC-06, TC-20                             |
+| [P15B](./implementation-plan.md#phase-p15b---active-dossier-metadata-editing)                             | Sửa metadata hồ sơ active                      | P3A                                              | TC-01, TC-04, TC-20                                    |
+| [P15C](./implementation-plan.md#phase-p15c---guarded-dossier-delete-activation)                           | Kích hoạt hard-delete qua proxy và UI          | P15A applied/gated, P15B                         | TC-01, TC-02, TC-04, TC-06, TC-20                      |
+| [P13C](./implementation-plan.md#phase-p13c---release-openspec-and-ai-boundary-audit)                      | Release, OpenSpec và audit AI boundary         | P13A-V, P13B, P7A2, P9A3, P14C2, P15C            | TC-19                                                  |
 
 ## Phase P0 - Discovery And Contract Freeze
 
@@ -837,8 +840,8 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       trong leaf này; nếu có gap, tạo exact blocking fix leaf, dừng P13A-V và
       rerun từ đầu sau khi fix được phase-gated.
 - [ ] P13A-V.7 Accepted TC-02 + final TC-20 evidence chỉ thỏa dependency P13A của
-      P13C; P13C vẫn blocked cho đến khi P13B, P7A2, P9A3 và P14C2 cũng hoàn
-      tất.
+      P13C; P13C vẫn blocked cho đến khi P13B, P7A2, P9A3, P14C2 và P15C cũng
+      hoàn tất.
 
 ## Phase P13B - UI, Accessibility And Regression Hardening
 
@@ -961,6 +964,53 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       evaluation/ranking regressions, React Doctor và strict OpenSpec; không
       thêm P13B real-browser gate.
 
+## Phase P15A - Dormant Dossier Hard-Delete Contract
+
+- [ ] P15A.1 Rà migration order và live DB read-only cho dossier RPCs, grants,
+      baseline indexes và toàn bộ FK cascade.
+- [ ] P15A.2 Khóa RED cho signature delete, list `can_delete`, guard/row-lock
+      order, `locked_dossier` và trạng thái chưa allowlist.
+- [ ] P15A.3 Thêm migration additive tạo delete RPC và thay list RPC bằng
+      eligibility set-based, không thêm table/index suy đoán.
+- [ ] P15A.4 Thêm rollback-only SQL phase gate cho quyền, stale/archive,
+      never-locked cascade, locked-history retention và list/get disappearance.
+- [ ] P15A.5 Chạy two-session gate qua hai Supabase MCP sessions cho cả
+      delete-first và lock-first; đúng một thao tác commit và fixture được dọn.
+- [ ] P15A.6 Chỉ apply/gate live DB sau quyền ghi cụ thể; sau apply chạy security
+      và performance advisors.
+- [ ] P15A.7 Giữ delete RPC dormant: không manifest, không proxy, không adapter,
+      không UI.
+
+## Phase P15B - Active Dossier Metadata Editing
+
+- [ ] P15B.1 Khóa RED cho typed update adapter và row edit flow gồm prefill,
+      cancel/no mutation, explicit save, validation, error và stale revision.
+- [ ] P15B.2 Tổng quát hóa dossier form cho create/edit mà không nhân đôi schema
+      hoặc field definitions.
+- [ ] P15B.3 Thêm row-action component và action-state hook riêng; giữ client
+      chính dưới ngưỡng extract 350 dòng.
+- [ ] P15B.4 Adopt revision mới vào list/detail cache và giữ workspace đang mở
+      đồng bộ sau khi sửa.
+- [ ] P15B.5 Xác minh metadata vẫn sửa được sau baseline lock nhưng baseline,
+      archive và delete contracts không đổi.
+- [ ] P15B.6 Chạy TypeScript/React gates, focused RPC/form/shell tests, React
+      Doctor và strict OpenSpec.
+
+## Phase P15C - Guarded Dossier Delete Activation
+
+- [ ] P15C.1 Xác minh P15A đã apply/gated và P15B đã landed trước khi sửa
+      allowlist.
+- [ ] P15C.2 Khóa RED cho manifest/allowlist, action xóa visible-disabled kèm
+      giải thích khi `can_delete=false`, confirmation, no-preconfirm mutation,
+      conflicts, retry và page fallback.
+- [ ] P15C.3 Thêm typed delete contract/adapter và allowlist đúng một RPC P15A.
+- [ ] P15C.4 Mở rộng row actions bằng delete affordance và dialog cảnh báo vĩnh
+      viễn; archive vẫn là lifecycle riêng.
+- [ ] P15C.5 Sau success, cập nhật cache, clear workspace khớp và lùi trang khi
+      xóa item cuối của trang > 1; server error không được optimistic remove.
+- [ ] P15C.6 Chạy TypeScript/React gates, focused RPC/dialog/shell tests, React
+      Doctor, browser desktop/narrow và strict OpenSpec.
+
 ## Phase P13C - Release, OpenSpec And AI Boundary Audit
 
 - [ ] P13C.1 Chạy full quality gates và `openspec validate ... --strict`.
@@ -972,4 +1022,6 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       change và lưu archived-state evidence.
 - [ ] P13C.7 Xác minh P14A1-P14C2 đã landed và result workbook vẫn read-only,
       snapshot-stable, không scoring/award semantics.
-- [ ] P13C.8 Cập nhật OpenSpec tasks theo trạng thái landed và hoàn tất release review.
+- [ ] P13C.8 Xác minh P15A/P15B đã merge độc lập, P15A đã apply/gated, P15C chỉ
+      activate delete sau đó và locked-history dossier không thể hard-delete.
+- [ ] P13C.9 Cập nhật OpenSpec tasks theo trạng thái landed và hoàn tất release review.

--- a/openspec/changes/add-technical-configuration-comparison/test-matrix.md
+++ b/openspec/changes/add-technical-configuration-comparison/test-matrix.md
@@ -3,7 +3,7 @@
 ## Contract
 
 - Inventory source: requirement and scenario headings in [spec.md](./specs/technical-configuration-comparison/spec.md).
-- Scenario count: 103 normative scenarios plus 2 explicit P5 implementation
+- Scenario count: 106 normative scenarios plus 2 explicit P5 implementation
   regression obligations (`TC-05-S06`, `TC-05-S07`).
 - Every normative scenario has one row, one primary implementation leaf and one
   regression owner. The two named P5 implementation rows use the same ownership
@@ -23,6 +23,8 @@
 - [x] Every entity, RPC and error has one primary leaf owner in [contracts.md](./contracts.md).
 - [x] No unresolved placeholder remains in the P0 contract pack.
 - [x] Archive behavior is covered at P1 and must be rerun across every descendant mutation leaf.
+- [x] Hard-delete is permanently blocked after the first locked baseline and is
+      staged through dormant DB, independent metadata-edit and UI activation leaves.
 - [x] Criterion code generation, delete non-reuse, reorder, copy and Excel behavior have explicit owners.
 - [x] The option-nine boundary proves total options remain unlimited while one request selects at most eight.
 - [x] P10A1 performance verification uses 500 criteria, 50 total options and 8 selected options.
@@ -86,12 +88,22 @@ user-visible completion/regression owner. Representative workbook scale uses
 in-memory fixtures larger than 100 options x 102 criteria, never seed/live DB.
 P14 has no real-browser gate; P14C2 uses React integration and the approved
 Stitch layouts, while deferred P13B retains browser/accessibility ownership.
+TC-01-S04 is completed by P15B and rerun when P15C extends the same row-action
+surface. TC-01-S05 is staged: P15A owns the dormant authoritative delete
+contract and P15C is the single end-to-end completion owner after allowlist,
+confirmation and cache behavior are mounted. TC-01-S06 completes at P15A's
+guarded database boundary and reruns through P15C direct-error/UI integration.
+P15A and P15B may land independently; P15C requires both and must not activate
+the delete RPC before P15A is applied and phase-gated.
 
 | Scenario ID | Requirement / scenario                                                                                 | Primary leaf | Regression leaf | Test layer                            | Role / setup                                                                                                                                                                     | Expected result                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ----------- | ------------------------------------------------------------------------------------------------------ | ------------ | --------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | TC-01-S01   | Independent technical configuration dossier / Create a dossier for one device type                     | P1           | P3A             | SQL + Vitest contract                 | global; người dùng có quyền tạo hồ sơ và nhập tên loại thiết bị cùng thông tin hồ sơ                                                                                             | hệ thống tạo một hồ sơ có ID ổn định cho đúng loại thiết bị đó; không yêu cầu chọn hoặc tạo bản ghi `thiet_bi`                                                                                                                                                                                                                                                                                                              |
 | TC-01-S02   | Independent technical configuration dossier / Prevent multiple device configurations in one dossier    | P1           | P3A             | SQL + Vitest contract                 | global; người dùng đang làm việc trong một hồ sơ                                                                                                                                 | mọi phiên bản cơ sở thuộc cùng một lineage cấu hình cho cùng loại thiết bị; hệ thống từ chối tạo lineage cấu hình cơ sở thứ hai hoặc thêm loại thiết bị thứ hai vào hồ sơ                                                                                                                                                                                                                                                   |
 | TC-01-S03   | Independent technical configuration dossier / Archive a dossier                                        | P1           | P13A-V          | SQL + Vitest contract                 | global; người dùng archive một hồ sơ                                                                                                                                             | hồ sơ bị ẩn khỏi danh sách mặc định nhưng vẫn đọc được khi truy cập trực tiếp hoặc yêu cầu gồm hồ sơ đã archive; backend từ chối mọi mutation đối với hồ sơ, phiên bản cơ sở, nhóm, tiêu chí, sản phẩm tham chiếu, tài liệu, trích dẫn, nhà cung cấp, phương án, phản hồi và đánh giá thuộc hồ sơ đó; MVP không cung cấp thao tác restore                                                                                   |
+| TC-01-S04   | Independent technical configuration dossier / Edit active dossier metadata                             | P15B         | P15C            | Vitest adapter + React integration    | global/admin; mở row action sửa trên hồ sơ active, thay đổi loại thiết bị/tên/mô tả và giữ revision hiện tại                                                                     | form được prefill; cancel không gọi backend; explicit save gọi update RPC đúng một lần, nhận revision mới và không thay đổi nội dung/trạng thái của baseline đã khóa                                                                                                                                                                                                                                                        |
+| TC-01-S05   | Independent technical configuration dossier / Permanently delete a never-locked dossier                | P15C         | P13C            | SQL gate + Vitest + React integration | global/admin; hồ sơ active chưa từng có baseline `locked`; P15A đã applied/gated; người dùng mở delete action                                                                    | UI cảnh báo xóa vĩnh viễn và không mutate trước confirm; backend xóa root cùng descendants qua cascade; list/get không còn hồ sơ, không archive; cache/workspace/page được reconcile chỉ sau success                                                                                                                                                                                                                        |
+| TC-01-S06   | Independent technical configuration dossier / Reject deletion after the first locked baseline          | P15A         | P15C            | SQL gate + Vitest integration         | global/admin hoặc direct caller; hồ sơ đã từng có ít nhất một baseline `locked`, kể cả hiện có draft mới                                                                         | delete trả `PT409/locked_dossier`; dossier và descendants không đổi; `can_delete=false`; UI giữ action xóa visible-disabled kèm giải thích accessible, không coi affordance là authority và vẫn giữ nguyên state nếu server từ chối                                                                                                                                                                                         |
 | TC-02-S01   | Global administrator access boundary / Global role accesses the module                                 | P1           | P13A-V          | SQL + Vitest contract                 | global; session có role `global`                                                                                                                                                 | người dùng được phép truy cập route và các operation đã định nghĩa của module                                                                                                                                                                                                                                                                                                                                               |
 | TC-02-S02   | Global administrator access boundary / Legacy admin role accesses the module                           | P1           | P13A-V          | SQL + Vitest contract                 | raw `admin`; dùng user ID hợp lệ của một global user                                                                                                                             | hệ thống dùng `isGlobalRole()` ngoài RPC proxy và áp dụng cùng quyền như `global`                                                                                                                                                                                                                                                                                                                                           |
 | TC-02-S03   | Global administrator access boundary / Other role calls the backend directly                           | P1           | P13A-V          | SQL + Vitest contract                 | role bị từ chối hoặc thiếu claim; gọi route, RPC hoặc data operation trực tiếp                                                                                                   | backend từ chối fail-closed; không trả dữ liệu hồ sơ trong response lỗi                                                                                                                                                                                                                                                                                                                                                     |
@@ -229,6 +241,14 @@ accessibility and screenshot matrix for the complete TC-18 flow.
 | P14C1 | open/reset/confirm/cancel; three content modes; all/current option and criterion scopes; paginated confirmation; dossier/baseline reset; focus/validation                    | pure state + React user-event tests; existing evaluation workspace regressions; standard TypeScript/React gates; React Doctor; strict OpenSpec                       | unmounted dialog emits one validated request, defaults to complete universe and has no RPC/ExcelJS/Blob side effect                  |
 | P14C2 | mounted trigger; requested-surface calls; loading/error/retry; stale/context switch; final manifest mismatch; serialize/download exactly once; no partial file               | collector + renderer + React integration; existing Excel/Equipment/evaluation/ranking regressions; standard TypeScript/React gates; React Doctor; strict OpenSpec    | user-visible export downloads only a complete stable workbook; P14 adds no real-browser gate and remains independent of deferred P13 |
 
+## P15 Leaf Acceptance Gates
+
+| Leaf | RED seams before implementation                                                                                     | Focused quality gate                                                                                                                                               | Exit evidence                                                                                                      |
+| ---- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| P15A | missing delete migration/RPC; list lacks `can_delete`; no locked-history, row-lock, cascade, grant or dormant proof | migration/source tests; rollback-only authorization/cascade gate; two-session delete-first/lock-first MCP gate after explicit approvals; advisors; strict OpenSpec | database contract is complete but delete remains absent from manifests, proxy allowlist, adapters and UI           |
+| P15B | no update adapter; create-only form; no row edit action; cancel/error/cache semantics untested                      | typed adapter plus form/shell React tests; standard TypeScript/React gates; React Doctor; strict OpenSpec                                                          | metadata edit is usable and independent of P15A; no delete name or action is exposed                               |
+| P15C | delete blocked by proxy; no delete types/adapter/dialog; eligibility, conflicts and page fallback untested          | allowlist/adapter/dialog/shell tests; standard TypeScript/React gates; React Doctor; desktop/narrow browser; OpenSpec                                              | guarded delete is user-visible only after P15A gate; archive remains separate and locked-history dossiers retained |
+
 ## Cross-Leaf Regression Obligations
 
 ### Archived Dossier Guard
@@ -240,6 +260,24 @@ must prove archived read access and zero side effects. P7A2 must cover TC-08-S01
 and TC-08-S02 as archived-dossier negative-test paths for reference-product and
 criterion-response authoring. P9A1 is codec-only and must prove that it adds no
 RPC, migration or mutation surface.
+P15A must prove the root delete rejects archived dossiers through the common
+guard. P15C reruns the same conflict through the typed adapter and leaves
+client cache/workspace state unchanged.
+
+### Guarded Dossier Hard Delete
+
+- P15A owns the authoritative eligibility check, dossier row lock, permanent
+  locked-history rejection and cascade proof. The list's `can_delete` field is
+  never authorization.
+- P15B must not import, allowlist or conditionally depend on the dormant delete
+  RPC; metadata editing remains independently deployable.
+- P15C may expose delete only after P15A is applied/gated. It must handle
+  `locked_dossier`, `stale_revision`, `archived_dossier` and `not_found`
+  without removing cache state before server success.
+- Baseline lock/delete concurrency remains dossier-row-first: delete-first
+  yields `not_found` to lock; lock-first yields `locked_dossier` to delete.
+- P15A acceptance requires an actual two-session interleaving gate for both
+  winner orders. Static function-definition inspection is insufficient.
 
 ### Criterion Codes
 

--- a/openspec/changes/add-technical-configuration-comparison/verification/P13A-discovery-and-split-decision.md
+++ b/openspec/changes/add-technical-configuration-comparison/verification/P13A-discovery-and-split-decision.md
@@ -90,8 +90,9 @@ reviewable cho ranking ở quy mô đã được phase gate dùng để kiểm t
 Agent-browser và E2E/real-browser verification thuộc **P13B**. P13A chỉ sở hữu DB
 prerequisite và không mở rộng sang desktop/mobile interaction coverage.
 P13A-V chỉ thỏa dependency **DB/P13A** của P13C; final P13C còn bắt buộc P13B,
-P7A2 và P9A3. P13C giữ ownership cho release, final acceptance, OpenSpec archive
-và AI-boundary audit; artifact này không archive OpenSpec change.
+P7A2, P9A3, P14C2 và P15C. P13C giữ ownership cho release, final acceptance,
+OpenSpec archive và AI-boundary audit; artifact này không archive OpenSpec
+change.
 
 ## Dependency DAG
 
@@ -117,8 +118,8 @@ P14C2 final-result Excel export --------------------------------+    release/acc
   P13A-P2 được apply/phase-gated và P13A-P1 rerun green.
 - **P13A path:** Accepted P13A-V evidence chỉ hoàn tất dependency DB/P13A của
   P13C.
-- **Final path:** P13C chỉ được unblock khi P13A-V, P13B, P7A2, P9A3 và P14C2
-  đều hoàn tất; P13C sau đó mới sở hữu release review, final acceptance,
+- **Final path:** P13C chỉ được unblock khi P13A-V, P13B, P7A2, P9A3, P14C2 và
+  P15C đều hoàn tất; P13C sau đó mới sở hữu release review, final acceptance,
   OpenSpec archive và AI-boundary audit.
 
 ## Live-write approval boundaries


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the P15 dossier lifecycle into three leaves (P15A/B/C). Add guarded hard-delete for never-locked dossiers and metadata edits for active dossiers; archive stays unchanged and delete remains dormant until UI activation.

- **New Features**
  - Hard-delete contract: only for active dossiers with no locked baselines; otherwise returns `locked_dossier`; runs under dossier revision/row lock and cascades draft/work data; archive stays a separate, immutable state with no restore.
  - Metadata edit: allow `admin/global` to update device type, name, and description via `technical_configuration_dossiers_update`; locked baseline content is untouched; introduce a shared create/edit form and a row-action seam for P15C.
  - Staged rollout: add `can_delete` to dossier list; keep `technical_configuration_dossiers_delete` dormant in P15A; P15C activates via proxy and typed client; UI warns permanence and updates state only after server success.
  - Docs and planning: updated contracts, design, proposal, and spec (new scenarios); scenario count now 106; added TDD plans for P15A/B/C; refreshed implementation plan and tasks (add P15 parent) and updated verification to include P15C.

<sup>Written for commit 3a8d9085cb434b9b8e7128902b67ed718f1a9830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added active dossier metadata editing with explicit save and revision protection.
  * Added permanent deletion for active dossiers that have never had a locked baseline.
  * Dossier lists now indicate whether each dossier can be deleted.
  * Added confirmation and clear disabled-state messaging for deletion actions.

* **Bug Fixes**
  * Prevented deletion of dossiers with locked history.
  * Added safeguards for stale updates and preserved archived dossiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->