### PR TITLE
[P15A] Add dormant dossier hard-delete contract

### DIFF
--- a/src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts
@@ -17,6 +17,7 @@ const CONCURRENCY_GATE_PATH = path.join(
 const ALLOWED_FUNCTIONS_PATH = path.join(REPO_ROOT, "src/app/api/rpc/[fn]/allowed-functions.ts")
 const RPC_MANIFESTS_DIR = path.join(REPO_ROOT, "src/lib")
 const DELETE_RPC_NAME = "technical_configuration_dossiers_delete"
+const LIST_PREDECESSOR_MIGRATION = "20260712112500_technical_configuration_dossier_foundation.sql"
 const ORDERING_MARKERS = [
   "CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_list",
   "CREATE OR REPLACE FUNCTION public._technical_configuration_require_editable_dossier",
@@ -37,6 +38,15 @@ function getDeleteMigrationFiles(): string[] {
 function getDeleteMigrationSource(): string {
   const migrationFile = getDeleteMigrationFiles()[0]
   return migrationFile ? readFileSync(path.join(MIGRATIONS_DIR, migrationFile), "utf8") : ""
+}
+
+function getMigrationTimestamp(fileName: string): number {
+  const match = /^(\d{14})_/.exec(fileName)
+  if (!match) {
+    throw new Error(`Migration file lacks a timestamp prefix: ${fileName}`)
+  }
+
+  return Number(match[1])
 }
 
 function getFunctionBlock(source: string, functionName: string): string {
@@ -70,9 +80,17 @@ describe("technical configuration dossier P15A delete migration", () => {
     })
 
     expect(predecessorFiles.length).toBeGreaterThan(0)
+    const migrationTimestamp = getMigrationTimestamp(migrationFile)
     for (const predecessorFile of predecessorFiles) {
-      expect(migrationFile.localeCompare(predecessorFile)).toBeGreaterThan(0)
+      expect(migrationTimestamp).toBeGreaterThan(getMigrationTimestamp(predecessorFile))
     }
+  })
+
+  it("documents the forward-only rollback source for the replaced list RPC", () => {
+    expect(migrationSource).toContain(`-- ${LIST_PREDECESSOR_MIGRATION}`)
+    expect(migrationSource).toContain(
+      "DROP FUNCTION public.technical_configuration_dossiers_delete(UUID, BIGINT)"
+    )
   })
 
   it("creates the exact dormant delete RPC with the fixed payload and security boundary", () => {
@@ -122,8 +140,14 @@ describe("technical configuration dossier P15A delete migration", () => {
   })
 
   it("adds non-null can_delete with set-based locked-history existence logic", () => {
+    expect(listBlock).toContain("WITH dossier_page AS MATERIALIZED")
+    expect(listBlock).toContain("locked_dossiers AS")
     expect(listBlock).toMatch(
-      /d\.archived_at IS NULL\s+AND NOT EXISTS \([\s\S]*FROM public\.technical_configuration_baseline_versions v[\s\S]*v\.dossier_id = d\.id[\s\S]*v\.status = 'locked'[\s\S]*\) AS can_delete/
+      /JOIN dossier_page page\s+ON page\.id = v\.dossier_id[\s\S]*WHERE v\.status = 'locked'/
+    )
+    expect(listBlock).toContain("LEFT JOIN locked_dossiers locked")
+    expect(listBlock).toMatch(
+      /page\.archived_at IS NULL\s+AND locked\.dossier_id IS NULL[\s\S]*AS can_delete/
     )
     expect(listBlock).toContain("'can_delete', p.can_delete")
     expect(listBlock).not.toContain("technical_configuration_baseline_versions_list")
@@ -152,11 +176,49 @@ describe("technical configuration dossier P15A delete migration", () => {
     expect(phaseGateSource).toContain("locked_dossier")
     expect(phaseGateSource).toContain("can_delete")
     expect(phaseGateSource).toContain(DELETE_RPC_NAME)
+    expect(phaseGateSource).toContain("pg_get_functiondef(")
+    expect(phaseGateSource).toContain("CREATE FUNCTION pg_temp.expect_list_can_delete")
+    expect(phaseGateSource).toContain("WITH dossier_page AS MATERIALIZED")
+    expect(phaseGateSource).toContain("JOIN dossier_page page")
+    expect(phaseGateSource).toContain("ON page.id = v.dossier_id")
+    expect(phaseGateSource).toContain("list presence failed: % missing")
+    expect(phaseGateSource).toContain("'draft dossier'")
+    expect(phaseGateSource).toContain("'locked dossier'")
+    expect(phaseGateSource).toContain("'archived dossier'")
+    expect(phaseGateSource).toContain(`'$.**."Parent Relationship" ? (@ == "SubPlan")'`)
+    expect(phaseGateSource).toContain(`'$.**."CTE Name" ? (@ == "dossier_page")'`)
+    expect(phaseGateSource).not.toContain(`'$.**."Join Type" ? (@ == "Left")'`)
+    expect(phaseGateSource).not.toMatch(
+      /INSERT INTO public\.technical_configuration_suppliers\s*\([^)]*\bnormalized_name\b/
+    )
 
+    expect(concurrencyGateSource).toContain("CREATE FUNCTION pg_temp.seed_concurrency_aggregate")
     expect(concurrencyGateSource).toContain("delete-first")
     expect(concurrencyGateSource).toContain("lock-first")
     expect(concurrencyGateSource).toContain("PT404")
     expect(concurrencyGateSource).toContain("PT409")
-    expect(concurrencyGateSource).toContain("cleanup")
+    expect(concurrencyGateSource.match(/'55P03'/g)).toHaveLength(2)
+    expect(concurrencyGateSource.match(/'lock_timeout'/g)).toHaveLength(4)
+    expect(concurrencyGateSource).not.toContain("FOR UPDATE;")
+    expect(concurrencyGateSource.match(/pg_advisory_xact_lock/g)).toHaveLength(2)
+    expect(concurrencyGateSource.match(/pg_try_advisory_lock/g)).toHaveLength(2)
+    expect(concurrencyGateSource.match(/pg_advisory_unlock/g)).toHaveLength(2)
+    expect(concurrencyGateSource.match(/FOR v_attempt IN 1\.\.600 LOOP/g)).toHaveLength(2)
+    expect(concurrencyGateSource).toMatch(
+      /DELETE-FIRST \/ SESSION A[\s\S]*technical_configuration_dossiers_delete\(v_dossier_id, 1\);[\s\S]*pg_advisory_xact_lock/
+    )
+    expect(concurrencyGateSource).toMatch(
+      /LOCK-FIRST \/ SESSION A[\s\S]*technical_configuration_baseline_lock\(v_version_id, 1\);[\s\S]*pg_advisory_xact_lock/
+    )
+    expect(concurrencyGateSource).toMatch(
+      /DELETE-FIRST ASSERT[\s\S]*technical_configuration_baseline_groups[\s\S]*technical_configuration_baseline_criteria/
+    )
+    expect(concurrencyGateSource).toMatch(
+      /LOCK-FIRST ASSERT[\s\S]*technical_configuration_baseline_groups[\s\S]*technical_configuration_baseline_criteria/
+    )
+    expect(concurrencyGateSource).toMatch(
+      /-- CLEANUP:[\s\S]*technical_configuration_dossiers[\s\S]*technical_configuration_baseline_versions[\s\S]*technical_configuration_baseline_groups[\s\S]*technical_configuration_baseline_criteria/
+    )
+    expect(concurrencyGateSource).toContain("cleanup failed: fixture residue remains")
   })
 })

--- a/src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-dossier-delete-migration.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = process.cwd()
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_SUFFIX = "_technical_configuration_dossier_delete.sql"
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_dossier_delete_phase_gate.sql"
+)
+const CONCURRENCY_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql"
+)
+const ALLOWED_FUNCTIONS_PATH = path.join(REPO_ROOT, "src/app/api/rpc/[fn]/allowed-functions.ts")
+const RPC_MANIFESTS_DIR = path.join(REPO_ROOT, "src/lib")
+const DELETE_RPC_NAME = "technical_configuration_dossiers_delete"
+const ORDERING_MARKERS = [
+  "CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_list",
+  "CREATE OR REPLACE FUNCTION public._technical_configuration_require_editable_dossier",
+  "CREATE OR REPLACE FUNCTION public._technical_configuration_require_editable_baseline_version",
+  "CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_lock",
+] as const
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getDeleteMigrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(MIGRATION_SUFFIX))
+    .sort()
+}
+
+function getDeleteMigrationSource(): string {
+  const migrationFile = getDeleteMigrationFiles()[0]
+  return migrationFile ? readFileSync(path.join(MIGRATIONS_DIR, migrationFile), "utf8") : ""
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const marker = `CREATE OR REPLACE FUNCTION public.${functionName}`
+  const start = source.lastIndexOf(marker)
+  if (start < 0) {
+    return ""
+  }
+
+  const end = source.indexOf("\n$$;", start + marker.length)
+  return end < 0 ? "" : source.slice(start, end + 4)
+}
+
+describe("technical configuration dossier P15A delete migration", () => {
+  const migrationSource = getDeleteMigrationSource()
+  const deleteBlock = getFunctionBlock(migrationSource, DELETE_RPC_NAME)
+  const listBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_list")
+
+  it("adds one migration after every local list, guard, and baseline-lock predecessor", () => {
+    const migrationFiles = getDeleteMigrationFiles()
+    expect(migrationFiles).toHaveLength(1)
+
+    const migrationFile = migrationFiles[0] ?? ""
+    const predecessorFiles = readdirSync(MIGRATIONS_DIR).filter((file) => {
+      if (!file.endsWith(".sql") || file === migrationFile) {
+        return false
+      }
+
+      const source = readFileSync(path.join(MIGRATIONS_DIR, file), "utf8")
+      return ORDERING_MARKERS.some((marker) => source.includes(marker))
+    })
+
+    expect(predecessorFiles.length).toBeGreaterThan(0)
+    for (const predecessorFile of predecessorFiles) {
+      expect(migrationFile.localeCompare(predecessorFile)).toBeGreaterThan(0)
+    }
+  })
+
+  it("creates the exact dormant delete RPC with the fixed payload and security boundary", () => {
+    expect(migrationSource).toContain("BEGIN;")
+    expect(migrationSource).toContain("COMMIT;")
+    expect(deleteBlock).toMatch(
+      /technical_configuration_dossiers_delete\(\s*p_id UUID,\s*p_expected_revision BIGINT\s*\)/
+    )
+    expect(deleteBlock).toContain("RETURNS JSONB")
+    expect(deleteBlock).toContain("SECURITY DEFINER")
+    expect(deleteBlock).toContain("SET search_path = public, pg_temp")
+    expect(deleteBlock).toMatch(
+      /RETURN jsonb_build_object\(\s*'data',\s*jsonb_build_object\(\s*'id',\s*v_deleted_id\s*\)\s*\);/
+    )
+
+    expect(migrationSource).toMatch(
+      /REVOKE ALL ON FUNCTION public\.technical_configuration_dossiers_delete\(UUID, BIGINT\)\s+FROM PUBLIC, anon, authenticated, service_role;/
+    )
+    expect(migrationSource).toMatch(
+      /GRANT EXECUTE ON FUNCTION public\.technical_configuration_dossiers_delete\(UUID, BIGINT\)\s+TO authenticated;/
+    )
+    expect(migrationSource).not.toMatch(
+      /GRANT EXECUTE ON FUNCTION public\.technical_configuration_dossiers_delete\(UUID, BIGINT\)[\s\S]*TO service_role;/
+    )
+  })
+
+  it("serializes dossier-row-first and rejects locked history before one root delete", () => {
+    const guardIndex = deleteBlock.indexOf(
+      "PERFORM public._technical_configuration_require_editable_dossier("
+    )
+    const lockedHistoryIndex = deleteBlock.indexOf(
+      "FROM public.technical_configuration_baseline_versions"
+    )
+    const deleteIndex = deleteBlock.indexOf("DELETE FROM public.technical_configuration_dossiers")
+
+    expect(guardIndex).toBeGreaterThanOrEqual(0)
+    expect(lockedHistoryIndex).toBeGreaterThan(guardIndex)
+    expect(deleteIndex).toBeGreaterThan(lockedHistoryIndex)
+    expect(deleteBlock).toMatch(
+      /IF EXISTS \([\s\S]*v\.dossier_id = p_id[\s\S]*v\.status = 'locked'[\s\S]*\) THEN/
+    )
+    expect(deleteBlock).toContain("RAISE EXCEPTION 'locked_dossier' USING ERRCODE = 'PT409';")
+    expect(deleteBlock.match(/\bDELETE FROM\b/g)).toHaveLength(1)
+    expect(deleteBlock).not.toMatch(
+      /DELETE FROM public\.technical_configuration_(baseline|comparison|manual|option|reference|supplier)/
+    )
+  })
+
+  it("adds non-null can_delete with set-based locked-history existence logic", () => {
+    expect(listBlock).toMatch(
+      /d\.archived_at IS NULL\s+AND NOT EXISTS \([\s\S]*FROM public\.technical_configuration_baseline_versions v[\s\S]*v\.dossier_id = d\.id[\s\S]*v\.status = 'locked'[\s\S]*\) AS can_delete/
+    )
+    expect(listBlock).toContain("'can_delete', p.can_delete")
+    expect(listBlock).not.toContain("technical_configuration_baseline_versions_list")
+  })
+
+  it("keeps the delete RPC absent from the proxy allowlist and RPC manifests", () => {
+    expect(readFileSync(ALLOWED_FUNCTIONS_PATH, "utf8")).not.toContain(DELETE_RPC_NAME)
+
+    const manifestFiles = readdirSync(RPC_MANIFESTS_DIR).filter(
+      (file) => file.startsWith("technical-configuration") && file.endsWith("-rpcs.ts")
+    )
+    expect(manifestFiles.length).toBeGreaterThan(0)
+
+    for (const manifestFile of manifestFiles) {
+      const manifestSource = readFileSync(path.join(RPC_MANIFESTS_DIR, manifestFile), "utf8")
+      expect(manifestSource).not.toContain(DELETE_RPC_NAME)
+    }
+  })
+
+  it("ships rollback-only runtime and two-session concurrency gates", () => {
+    const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+    const concurrencyGateSource = readIfExists(CONCURRENCY_GATE_PATH)
+
+    expect(phaseGateSource).toContain("BEGIN;")
+    expect(phaseGateSource).toContain("ROLLBACK;")
+    expect(phaseGateSource).toContain("locked_dossier")
+    expect(phaseGateSource).toContain("can_delete")
+    expect(phaseGateSource).toContain(DELETE_RPC_NAME)
+
+    expect(concurrencyGateSource).toContain("delete-first")
+    expect(concurrencyGateSource).toContain("lock-first")
+    expect(concurrencyGateSource).toContain("PT404")
+    expect(concurrencyGateSource).toContain("PT409")
+    expect(concurrencyGateSource).toContain("cleanup")
+  })
+})

--- a/supabase/migrations/20260805143425_technical_configuration_dossier_delete.sql
+++ b/supabase/migrations/20260805143425_technical_configuration_dossier_delete.sql
@@ -1,3 +1,7 @@
+-- Purpose: add the dormant dossier hard-delete contract and additive can_delete field.
+-- Rollback (forward-only): restore technical_configuration_dossiers_list from
+-- 20260712112500_technical_configuration_dossier_foundation.sql, then
+-- DROP FUNCTION public.technical_configuration_dossiers_delete(UUID, BIGINT).
 BEGIN;
 
 CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_list(
@@ -23,7 +27,7 @@ BEGIN
     RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
   END IF;
 
-  WITH paged AS (
+  WITH dossier_page AS MATERIALIZED (
     SELECT
       d.id,
       d.device_type_name,
@@ -35,21 +39,30 @@ BEGIN
       d.created_at,
       d.created_by,
       d.updated_at,
-      d.updated_by,
-      (
-        d.archived_at IS NULL
-        AND NOT EXISTS (
-          SELECT 1
-          FROM public.technical_configuration_baseline_versions v
-          WHERE v.dossier_id = d.id
-            AND v.status = 'locked'
-        )
-      ) AS can_delete
+      d.updated_by
     FROM public.technical_configuration_dossiers d
     WHERE p_include_archived OR d.archived_at IS NULL
     ORDER BY d.updated_at DESC, d.id
     LIMIT p_page_size
     OFFSET (p_page - 1)::BIGINT * p_page_size
+  ),
+  locked_dossiers AS (
+    SELECT DISTINCT v.dossier_id
+    FROM public.technical_configuration_baseline_versions v
+    JOIN dossier_page page
+      ON page.id = v.dossier_id
+    WHERE v.status = 'locked'
+  ),
+  paged AS (
+    SELECT
+      page.*,
+      (
+        page.archived_at IS NULL
+        AND locked.dossier_id IS NULL
+      ) AS can_delete
+    FROM dossier_page page
+    LEFT JOIN locked_dossiers locked
+      ON locked.dossier_id = page.id
   )
   SELECT jsonb_build_object(
     'data',

--- a/supabase/migrations/20260805143425_technical_configuration_dossier_delete.sql
+++ b/supabase/migrations/20260805143425_technical_configuration_dossier_delete.sql
@@ -1,0 +1,144 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_list(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20,
+  p_include_archived BOOLEAN DEFAULT false
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL
+     OR p_page_size IS NULL
+     OR p_page < 1
+     OR p_page_size < 1
+     OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH paged AS (
+    SELECT
+      d.id,
+      d.device_type_name,
+      d.name,
+      d.description,
+      d.revision,
+      d.archived_at,
+      d.archived_by,
+      d.created_at,
+      d.created_by,
+      d.updated_at,
+      d.updated_by,
+      (
+        d.archived_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.technical_configuration_baseline_versions v
+          WHERE v.dossier_id = d.id
+            AND v.status = 'locked'
+        )
+      ) AS can_delete
+    FROM public.technical_configuration_dossiers d
+    WHERE p_include_archived OR d.archived_at IS NULL
+    ORDER BY d.updated_at DESC, d.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', p.id,
+            'device_type_name', p.device_type_name,
+            'name', p.name,
+            'description', p.description,
+            'revision', p.revision,
+            'archived_at', p.archived_at,
+            'archived_by', p.archived_by,
+            'created_at', p.created_at,
+            'created_by', p.created_by,
+            'updated_at', p.updated_at,
+            'updated_by', p.updated_by,
+            'can_delete', p.can_delete
+          )
+          ORDER BY p.updated_at DESC, p.id
+        )
+        FROM paged p
+      ),
+      '[]'::JSONB
+    ),
+    'total',
+    (
+      SELECT count(*)
+      FROM public.technical_configuration_dossiers d
+      WHERE p_include_archived OR d.archived_at IS NULL
+    ),
+    'page',
+    p_page,
+    'page_size',
+    p_page_size
+  )
+  INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_delete(
+  p_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_deleted_id UUID;
+BEGIN
+  PERFORM public._technical_configuration_require_editable_dossier(
+    p_id,
+    p_expected_revision
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.dossier_id = p_id
+      AND v.status = 'locked'
+  ) THEN
+    RAISE EXCEPTION 'locked_dossier' USING ERRCODE = 'PT409';
+  END IF;
+
+  DELETE FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_id
+  RETURNING d.id INTO v_deleted_id;
+
+  RETURN jsonb_build_object(
+    'data',
+    jsonb_build_object(
+      'id',
+      v_deleted_id
+    )
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_delete(UUID, BIGINT)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_delete(UUID, BIGINT)
+  TO authenticated;
+
+COMMENT ON FUNCTION public.technical_configuration_dossiers_delete(UUID, BIGINT) IS
+  'Hard-deletes an active never-locked technical configuration dossier aggregate.';
+
+COMMIT;

--- a/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
@@ -4,17 +4,72 @@
 -- Do not run this file as one sequential script.
 -- Replace <RUN_TOKEN> globally with one unique token before running any block.
 
--- SETUP: run once and wait for completion.
+-- SETUP: run this whole block once and wait for completion.
+CREATE FUNCTION pg_temp.seed_concurrency_aggregate(
+  p_scenario TEXT,
+  p_run_token TEXT,
+  p_user_id BIGINT,
+  p_description TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_dossier_id UUID := md5('p15a-' || p_scenario || '-dossier:' || p_run_token)::UUID;
+  v_version_id UUID := md5('p15a-' || p_scenario || '-version:' || p_run_token)::UUID;
+  v_group_id UUID := md5('p15a-' || p_scenario || '-group:' || p_run_token)::UUID;
+  v_criterion_id UUID := md5('p15a-' || p_scenario || '-criterion:' || p_run_token)::UUID;
+BEGIN
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, description, created_by, updated_by
+  )
+  VALUES (
+    v_dossier_id,
+    'P15A concurrency ' || p_scenario || ' ' || p_run_token,
+    'P15A concurrency ' || p_scenario || ' ' || p_run_token,
+    p_description,
+    p_user_id,
+    p_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, created_by, updated_by
+  )
+  VALUES (v_version_id, v_dossier_id, 1, 'draft', 2, p_user_id, p_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  )
+  VALUES (v_group_id, v_version_id, initcap(p_scenario) || ' group', 1, p_user_id, p_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id,
+    baseline_version_id,
+    group_id,
+    criterion_code,
+    requirement_text,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    v_criterion_id,
+    v_version_id,
+    v_group_id,
+    'TC-0001',
+    initcap(p_scenario) || ' requirement',
+    1,
+    p_user_id,
+    p_user_id
+  );
+END;
+$gate$;
+
 DO $gate$
 DECLARE
   v_user_id BIGINT;
-  v_dossier_id UUID;
-  v_version_id UUID;
-  v_group_id UUID;
-  v_criterion_id UUID;
 BEGIN
-  SELECT nv.id
-  INTO v_user_id
+  SELECT nv.id INTO v_user_id
   FROM public.nhan_vien nv
   WHERE nv.is_active = true
   ORDER BY nv.id
@@ -23,100 +78,17 @@ BEGIN
     RAISE EXCEPTION 'Setup failed: no active nhan_vien row found';
   END IF;
 
-  v_dossier_id := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
-  v_version_id := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
-  v_group_id := md5('p15a-delete-first-group:<RUN_TOKEN>')::UUID;
-  v_criterion_id := md5('p15a-delete-first-criterion:<RUN_TOKEN>')::UUID;
-
-  INSERT INTO public.technical_configuration_dossiers (
-    id, device_type_name, name, description, created_by, updated_by
-  )
-  VALUES (
-    v_dossier_id,
-    'P15A concurrency delete-first <RUN_TOKEN>',
-    'P15A concurrency delete-first <RUN_TOKEN>',
-    'Delete holds the dossier row lock before baseline lock',
+  PERFORM pg_temp.seed_concurrency_aggregate(
+    'delete-first',
+    '<RUN_TOKEN>',
     v_user_id,
-    v_user_id
+    'Delete holds the dossier row lock before baseline lock'
   );
-
-  INSERT INTO public.technical_configuration_baseline_versions (
-    id, dossier_id, version_number, status, next_criterion_number, created_by, updated_by
-  )
-  VALUES (v_version_id, v_dossier_id, 1, 'draft', 2, v_user_id, v_user_id);
-
-  INSERT INTO public.technical_configuration_baseline_groups (
-    id, baseline_version_id, name, sort_order, created_by, updated_by
-  )
-  VALUES (v_group_id, v_version_id, 'Delete-first group', 1, v_user_id, v_user_id);
-
-  INSERT INTO public.technical_configuration_baseline_criteria (
-    id,
-    baseline_version_id,
-    group_id,
-    criterion_code,
-    requirement_text,
-    sort_order,
-    created_by,
-    updated_by
-  )
-  VALUES (
-    v_criterion_id,
-    v_version_id,
-    v_group_id,
-    'TC-0001',
-    'Delete-first requirement',
-    1,
+  PERFORM pg_temp.seed_concurrency_aggregate(
+    'lock-first',
+    '<RUN_TOKEN>',
     v_user_id,
-    v_user_id
-  );
-
-  v_dossier_id := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
-  v_version_id := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
-  v_group_id := md5('p15a-lock-first-group:<RUN_TOKEN>')::UUID;
-  v_criterion_id := md5('p15a-lock-first-criterion:<RUN_TOKEN>')::UUID;
-
-  INSERT INTO public.technical_configuration_dossiers (
-    id, device_type_name, name, description, created_by, updated_by
-  )
-  VALUES (
-    v_dossier_id,
-    'P15A concurrency lock-first <RUN_TOKEN>',
-    'P15A concurrency lock-first <RUN_TOKEN>',
-    'Baseline lock holds the dossier row lock before delete',
-    v_user_id,
-    v_user_id
-  );
-
-  INSERT INTO public.technical_configuration_baseline_versions (
-    id, dossier_id, version_number, status, next_criterion_number, created_by, updated_by
-  )
-  VALUES (v_version_id, v_dossier_id, 1, 'draft', 2, v_user_id, v_user_id);
-
-  INSERT INTO public.technical_configuration_baseline_groups (
-    id, baseline_version_id, name, sort_order, created_by, updated_by
-  )
-  VALUES (v_group_id, v_version_id, 'Lock-first group', 1, v_user_id, v_user_id);
-
-  INSERT INTO public.technical_configuration_baseline_criteria (
-    id,
-    baseline_version_id,
-    group_id,
-    criterion_code,
-    requirement_text,
-    sort_order,
-    created_by,
-    updated_by
-  )
-  VALUES (
-    v_criterion_id,
-    v_version_id,
-    v_group_id,
-    'TC-0001',
-    'Lock-first requirement',
-    1,
-    v_user_id,
-    v_user_id
+    'Baseline lock holds the dossier row lock before delete'
   );
 END;
 $gate$;
@@ -127,6 +99,8 @@ DO $gate$
 DECLARE
   v_user_id BIGINT;
   v_dossier_id UUID;
+  v_rendezvous_key BIGINT :=
+    hashtextextended('p15a-delete-first-rendezvous:<RUN_TOKEN>', 0);
   v_response JSONB;
 BEGIN
   SELECT nv.id
@@ -156,14 +130,19 @@ BEGIN
     RAISE EXCEPTION 'delete-first session A returned %', v_response;
   END IF;
 
-  PERFORM pg_sleep(8);
+  PERFORM pg_advisory_xact_lock(v_rendezvous_key);
+  PERFORM pg_sleep(20);
 END;
 $gate$;
 
 -- DELETE-FIRST / SESSION B: start while SESSION A is sleeping.
--- Expected outcome after blocking: PT404/not_found, and this block completes successfully.
+-- The first call must time out on SESSION A's dossier-row lock; the retry must return PT404.
 DO $gate$
 DECLARE
+  v_attempt INTEGER;
+  v_observed_session_a BOOLEAN := false;
+  v_rendezvous_key BIGINT :=
+    hashtextextended('p15a-delete-first-rendezvous:<RUN_TOKEN>', 0);
   v_user_id BIGINT;
   v_version_id UUID;
   v_state TEXT;
@@ -188,6 +167,28 @@ BEGIN
 
   v_version_id := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
 
+  FOR v_attempt IN 1..600 LOOP
+    IF pg_try_advisory_lock(v_rendezvous_key) THEN
+      PERFORM pg_advisory_unlock(v_rendezvous_key);
+      PERFORM pg_sleep(0.1);
+    ELSE
+      v_observed_session_a := true;
+      EXIT;
+    END IF;
+  END LOOP;
+  IF NOT v_observed_session_a THEN
+    RAISE EXCEPTION 'delete-first session B did not observe session A';
+  END IF;
+
+  PERFORM set_config('lock_timeout', '2s', true);
+  BEGIN
+    PERFORM public.technical_configuration_baseline_lock(v_version_id, 1);
+    RAISE EXCEPTION 'delete-first session B did not block on the dossier row';
+  EXCEPTION
+    WHEN SQLSTATE '55P03' THEN NULL;
+  END;
+  PERFORM set_config('lock_timeout', '0', true);
+
   BEGIN
     PERFORM public.technical_configuration_baseline_lock(v_version_id, 1);
   EXCEPTION
@@ -210,22 +211,19 @@ DO $gate$
 DECLARE
   v_dossier_id UUID := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
   v_version_id UUID := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
-  v_count BIGINT;
+  v_group_id UUID := md5('p15a-delete-first-group:<RUN_TOKEN>')::UUID;
+  v_criterion_id UUID := md5('p15a-delete-first-criterion:<RUN_TOKEN>')::UUID;
 BEGIN
-  SELECT count(*)
-  INTO v_count
-  FROM public.technical_configuration_dossiers d
-  WHERE d.id = v_dossier_id;
-  IF v_count <> 0 THEN
-    RAISE EXCEPTION 'delete-first assertion failed: dossier survived';
-  END IF;
-
-  SELECT count(*)
-  INTO v_count
-  FROM public.technical_configuration_baseline_versions v
-  WHERE v.id = v_version_id;
-  IF v_count <> 0 THEN
-    RAISE EXCEPTION 'delete-first assertion failed: descendant survived';
+  IF EXISTS (
+    SELECT 1 FROM public.technical_configuration_dossiers WHERE id = v_dossier_id
+  ) OR EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_versions WHERE id = v_version_id
+  ) OR EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_groups WHERE id = v_group_id
+  ) OR EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_criteria WHERE id = v_criterion_id
+  ) THEN
+    RAISE EXCEPTION 'delete-first assertion failed: aggregate survived';
   END IF;
 END;
 $gate$;
@@ -236,6 +234,8 @@ DO $gate$
 DECLARE
   v_user_id BIGINT;
   v_version_id UUID;
+  v_rendezvous_key BIGINT :=
+    hashtextextended('p15a-lock-first-rendezvous:<RUN_TOKEN>', 0);
   v_response JSONB;
 BEGIN
   SELECT nv.id
@@ -262,14 +262,19 @@ BEGIN
     RAISE EXCEPTION 'lock-first session A returned %', v_response;
   END IF;
 
-  PERFORM pg_sleep(8);
+  PERFORM pg_advisory_xact_lock(v_rendezvous_key);
+  PERFORM pg_sleep(20);
 END;
 $gate$;
 
 -- LOCK-FIRST / SESSION B: start while SESSION A is sleeping.
--- Expected outcome after blocking: PT409/locked_dossier, and this block completes successfully.
+-- The first call must time out on SESSION A's dossier-row lock; the retry must return PT409.
 DO $gate$
 DECLARE
+  v_attempt INTEGER;
+  v_observed_session_a BOOLEAN := false;
+  v_rendezvous_key BIGINT :=
+    hashtextextended('p15a-lock-first-rendezvous:<RUN_TOKEN>', 0);
   v_user_id BIGINT;
   v_dossier_id UUID;
   v_state TEXT;
@@ -294,6 +299,28 @@ BEGIN
 
   v_dossier_id := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
 
+  FOR v_attempt IN 1..600 LOOP
+    IF pg_try_advisory_lock(v_rendezvous_key) THEN
+      PERFORM pg_advisory_unlock(v_rendezvous_key);
+      PERFORM pg_sleep(0.1);
+    ELSE
+      v_observed_session_a := true;
+      EXIT;
+    END IF;
+  END LOOP;
+  IF NOT v_observed_session_a THEN
+    RAISE EXCEPTION 'lock-first session B did not observe session A';
+  END IF;
+
+  PERFORM set_config('lock_timeout', '2s', true);
+  BEGIN
+    PERFORM public.technical_configuration_dossiers_delete(v_dossier_id, 1);
+    RAISE EXCEPTION 'lock-first session B did not block on the dossier row';
+  EXCEPTION
+    WHEN SQLSTATE '55P03' THEN NULL;
+  END;
+  PERFORM set_config('lock_timeout', '0', true);
+
   BEGIN
     PERFORM public.technical_configuration_dossiers_delete(v_dossier_id, 1);
   EXCEPTION
@@ -316,6 +343,8 @@ DO $gate$
 DECLARE
   v_dossier_id UUID := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
   v_version_id UUID := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
+  v_group_id UUID := md5('p15a-lock-first-group:<RUN_TOKEN>')::UUID;
+  v_criterion_id UUID := md5('p15a-lock-first-criterion:<RUN_TOKEN>')::UUID;
   v_count BIGINT;
 BEGIN
   IF NOT EXISTS (
@@ -335,6 +364,19 @@ BEGIN
   IF v_count <> 1 THEN
     RAISE EXCEPTION 'lock-first assertion failed: locked aggregate changed';
   END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.id = v_group_id AND g.baseline_version_id = v_version_id
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_criteria c
+    WHERE c.id = v_criterion_id
+      AND c.baseline_version_id = v_version_id
+      AND c.group_id = v_group_id
+  ) THEN
+    RAISE EXCEPTION 'lock-first assertion failed: descendants changed';
+  END IF;
 END;
 $gate$;
 
@@ -342,7 +384,13 @@ $gate$;
 DO $gate$
 DECLARE
   v_delete_first_dossier UUID := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
+  v_delete_first_version UUID := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
+  v_delete_first_group UUID := md5('p15a-delete-first-group:<RUN_TOKEN>')::UUID;
+  v_delete_first_criterion UUID := md5('p15a-delete-first-criterion:<RUN_TOKEN>')::UUID;
   v_lock_first_dossier UUID := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
+  v_lock_first_version UUID := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
+  v_lock_first_group UUID := md5('p15a-lock-first-group:<RUN_TOKEN>')::UUID;
+  v_lock_first_criterion UUID := md5('p15a-lock-first-criterion:<RUN_TOKEN>')::UUID;
 BEGIN
   DELETE FROM public.technical_configuration_dossiers d
   WHERE d.id IN (v_delete_first_dossier, v_lock_first_dossier);
@@ -351,8 +399,20 @@ BEGIN
     SELECT 1
     FROM public.technical_configuration_dossiers d
     WHERE d.id IN (v_delete_first_dossier, v_lock_first_dossier)
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.id IN (v_delete_first_version, v_lock_first_version)
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.id IN (v_delete_first_group, v_lock_first_group)
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_criteria c
+    WHERE c.id IN (v_delete_first_criterion, v_lock_first_criterion)
   ) THEN
-    RAISE EXCEPTION 'cleanup failed';
+    RAISE EXCEPTION 'cleanup failed: fixture residue remains';
   END IF;
 END;
 $gate$;

--- a/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
@@ -1,0 +1,358 @@
+-- supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
+-- Purpose: prove dossier-row-first serialization between P15A delete and P4 baseline lock.
+-- Run the labeled blocks through two concurrent Supabase MCP sessions after live apply approval.
+-- Do not run this file as one sequential script.
+-- Replace <RUN_TOKEN> globally with one unique token before running any block.
+
+-- SETUP: run once and wait for completion.
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_version_id UUID;
+  v_group_id UUID;
+  v_criterion_id UUID;
+BEGIN
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no active nhan_vien row found';
+  END IF;
+
+  v_dossier_id := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
+  v_version_id := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
+  v_group_id := md5('p15a-delete-first-group:<RUN_TOKEN>')::UUID;
+  v_criterion_id := md5('p15a-delete-first-criterion:<RUN_TOKEN>')::UUID;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, description, created_by, updated_by
+  )
+  VALUES (
+    v_dossier_id,
+    'P15A concurrency delete-first <RUN_TOKEN>',
+    'P15A concurrency delete-first <RUN_TOKEN>',
+    'Delete holds the dossier row lock before baseline lock',
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, created_by, updated_by
+  )
+  VALUES (v_version_id, v_dossier_id, 1, 'draft', 2, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  )
+  VALUES (v_group_id, v_version_id, 'Delete-first group', 1, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id,
+    baseline_version_id,
+    group_id,
+    criterion_code,
+    requirement_text,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    v_criterion_id,
+    v_version_id,
+    v_group_id,
+    'TC-0001',
+    'Delete-first requirement',
+    1,
+    v_user_id,
+    v_user_id
+  );
+
+  v_dossier_id := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
+  v_version_id := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
+  v_group_id := md5('p15a-lock-first-group:<RUN_TOKEN>')::UUID;
+  v_criterion_id := md5('p15a-lock-first-criterion:<RUN_TOKEN>')::UUID;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, description, created_by, updated_by
+  )
+  VALUES (
+    v_dossier_id,
+    'P15A concurrency lock-first <RUN_TOKEN>',
+    'P15A concurrency lock-first <RUN_TOKEN>',
+    'Baseline lock holds the dossier row lock before delete',
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, created_by, updated_by
+  )
+  VALUES (v_version_id, v_dossier_id, 1, 'draft', 2, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  )
+  VALUES (v_group_id, v_version_id, 'Lock-first group', 1, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id,
+    baseline_version_id,
+    group_id,
+    criterion_code,
+    requirement_text,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    v_criterion_id,
+    v_version_id,
+    v_group_id,
+    'TC-0001',
+    'Lock-first requirement',
+    1,
+    v_user_id,
+    v_user_id
+  );
+END;
+$gate$;
+
+-- DELETE-FIRST / SESSION A: start this block first.
+-- While this block is sleeping, immediately start DELETE-FIRST / SESSION B.
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_response JSONB;
+BEGIN
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', v_user_id::TEXT,
+      'sub', v_user_id::TEXT
+    )::TEXT,
+    true
+  );
+
+  v_dossier_id := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
+
+  v_response := public.technical_configuration_dossiers_delete(v_dossier_id, 1);
+  IF v_response <> jsonb_build_object(
+    'data',
+    jsonb_build_object('id', v_dossier_id)
+  ) THEN
+    RAISE EXCEPTION 'delete-first session A returned %', v_response;
+  END IF;
+
+  PERFORM pg_sleep(8);
+END;
+$gate$;
+
+-- DELETE-FIRST / SESSION B: start while SESSION A is sleeping.
+-- Expected outcome after blocking: PT404/not_found, and this block completes successfully.
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_version_id UUID;
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', v_user_id::TEXT,
+      'sub', v_user_id::TEXT
+    )::TEXT,
+    true
+  );
+
+  v_version_id := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
+
+  BEGIN
+    PERFORM public.technical_configuration_baseline_lock(v_version_id, 1);
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state = 'PT404' AND v_message = 'not_found' THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION 'delete-first session B expected PT404/not_found, got %/%',
+        v_state, v_message;
+  END;
+  RAISE EXCEPTION 'delete-first session B unexpectedly succeeded';
+END;
+$gate$;
+
+-- DELETE-FIRST ASSERT: run after both delete-first sessions finish.
+DO $gate$
+DECLARE
+  v_dossier_id UUID := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
+  v_version_id UUID := md5('p15a-delete-first-version:<RUN_TOKEN>')::UUID;
+  v_count BIGINT;
+BEGIN
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = v_dossier_id;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'delete-first assertion failed: dossier survived';
+  END IF;
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = v_version_id;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'delete-first assertion failed: descendant survived';
+  END IF;
+END;
+$gate$;
+
+-- LOCK-FIRST / SESSION A: start this block first.
+-- While this block is sleeping, immediately start LOCK-FIRST / SESSION B.
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_version_id UUID;
+  v_response JSONB;
+BEGIN
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', v_user_id::TEXT,
+      'sub', v_user_id::TEXT
+    )::TEXT,
+    true
+  );
+
+  v_version_id := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
+
+  v_response := public.technical_configuration_baseline_lock(v_version_id, 1);
+  IF v_response#>>'{data,status}' <> 'locked' THEN
+    RAISE EXCEPTION 'lock-first session A returned %', v_response;
+  END IF;
+
+  PERFORM pg_sleep(8);
+END;
+$gate$;
+
+-- LOCK-FIRST / SESSION B: start while SESSION A is sleeping.
+-- Expected outcome after blocking: PT409/locked_dossier, and this block completes successfully.
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', v_user_id::TEXT,
+      'sub', v_user_id::TEXT
+    )::TEXT,
+    true
+  );
+
+  v_dossier_id := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
+
+  BEGIN
+    PERFORM public.technical_configuration_dossiers_delete(v_dossier_id, 1);
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state = 'PT409' AND v_message = 'locked_dossier' THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION 'lock-first session B expected PT409/locked_dossier, got %/%',
+        v_state, v_message;
+  END;
+  RAISE EXCEPTION 'lock-first session B unexpectedly succeeded';
+END;
+$gate$;
+
+-- LOCK-FIRST ASSERT: run after both lock-first sessions finish.
+DO $gate$
+DECLARE
+  v_dossier_id UUID := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
+  v_version_id UUID := md5('p15a-lock-first-version:<RUN_TOKEN>')::UUID;
+  v_count BIGINT;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_dossiers d
+    WHERE d.id = v_dossier_id
+  ) THEN
+    RAISE EXCEPTION 'lock-first assertion failed: dossier was deleted';
+  END IF;
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = v_version_id
+    AND v.dossier_id = v_dossier_id
+    AND v.status = 'locked';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'lock-first assertion failed: locked aggregate changed';
+  END IF;
+END;
+$gate$;
+
+-- CLEANUP: run once after both scenarios and assertions finish.
+DO $gate$
+DECLARE
+  v_delete_first_dossier UUID := md5('p15a-delete-first-dossier:<RUN_TOKEN>')::UUID;
+  v_lock_first_dossier UUID := md5('p15a-lock-first-dossier:<RUN_TOKEN>')::UUID;
+BEGIN
+  DELETE FROM public.technical_configuration_dossiers d
+  WHERE d.id IN (v_delete_first_dossier, v_lock_first_dossier);
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_dossiers d
+    WHERE d.id IN (v_delete_first_dossier, v_lock_first_dossier)
+  ) THEN
+    RAISE EXCEPTION 'cleanup failed';
+  END IF;
+END;
+$gate$;

--- a/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_concurrency_phase_gate.sql
@@ -183,7 +183,7 @@ BEGIN
   PERFORM set_config('lock_timeout', '2s', true);
   BEGIN
     PERFORM public.technical_configuration_baseline_lock(v_version_id, 1);
-    RAISE EXCEPTION 'delete-first session B did not block on the dossier row';
+    RAISE EXCEPTION 'delete-first session B did not block; session A precondition may have expired';
   EXCEPTION
     WHEN SQLSTATE '55P03' THEN NULL;
   END;
@@ -315,7 +315,7 @@ BEGIN
   PERFORM set_config('lock_timeout', '2s', true);
   BEGIN
     PERFORM public.technical_configuration_dossiers_delete(v_dossier_id, 1);
-    RAISE EXCEPTION 'lock-first session B did not block on the dossier row';
+    RAISE EXCEPTION 'lock-first session B did not block; session A precondition may have expired';
   EXCEPTION
     WHEN SQLSTATE '55P03' THEN NULL;
   END;

--- a/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
@@ -48,6 +48,28 @@ BEGIN
 END;
 $gate$;
 
+CREATE FUNCTION pg_temp.expect_list_can_delete(
+  p_list JSONB, p_dossier_id UUID, p_expected BOOLEAN, p_label TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_actual BOOLEAN;
+BEGIN
+  SELECT (item->>'can_delete')::BOOLEAN INTO v_actual
+  FROM jsonb_array_elements(p_list->'data') item
+  WHERE item->>'id' = p_dossier_id::TEXT;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'list presence failed: % missing', p_label;
+  END IF;
+  IF v_actual IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION 'can_delete failed for %: expected %, got %',
+      p_label, p_expected, v_actual;
+  END IF;
+END;
+$gate$;
+
 CREATE FUNCTION pg_temp.seed_draft_aggregate(p_suffix TEXT, p_user_id BIGINT)
 RETURNS JSONB
 LANGUAGE plpgsql
@@ -145,10 +167,9 @@ BEGIN
   ) RETURNING id INTO v_reference_citation;
 
   INSERT INTO public.technical_configuration_suppliers (
-    dossier_id, name, normalized_name, created_by, updated_by
+    dossier_id, name, created_by, updated_by
   ) VALUES (
-    v_dossier, 'P15A Supplier ' || p_suffix,
-    lower('P15A Supplier ' || p_suffix), p_user_id, p_user_id
+    v_dossier, 'P15A Supplier ' || p_suffix, p_user_id, p_user_id
   ) RETURNING id INTO v_supplier;
 
   INSERT INTO public.technical_configuration_options (
@@ -232,8 +253,8 @@ DECLARE
   v_locked_criterion UUID;
   v_response JSONB;
   v_list JSONB;
-  v_plan JSON;
-  v_can_delete BOOLEAN;
+  v_list_definition TEXT;
+  v_plan JSONB;
   v_count BIGINT;
   v_check RECORD;
 BEGIN
@@ -301,25 +322,20 @@ BEGIN
   ) RETURNING id INTO v_later_draft;
 
   PERFORM pg_temp.set_claims('global', v_user_id);
+  SELECT pg_get_functiondef(
+    'public.technical_configuration_dossiers_list(integer,integer,boolean)'::regprocedure
+  ) INTO v_list_definition;
+  IF position('WITH dossier_page AS MATERIALIZED' IN v_list_definition) = 0
+     OR position('locked_dossiers AS' IN v_list_definition) = 0
+     OR position('JOIN dossier_page page' IN v_list_definition) = 0
+     OR position('ON page.id = v.dossier_id' IN v_list_definition) = 0
+     OR position('LEFT JOIN locked_dossiers locked' IN v_list_definition) = 0 THEN
+    RAISE EXCEPTION 'list definition failed: missing set-based locked dossier join';
+  END IF;
   v_list := public.technical_configuration_dossiers_list(1, 100, true);
-  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
-  FROM jsonb_array_elements(v_list->'data') item
-  WHERE item->>'id' = v_draft_dossier::TEXT;
-  IF v_can_delete IS DISTINCT FROM true THEN
-    RAISE EXCEPTION 'can_delete failed: active draft-only dossier must be true';
-  END IF;
-  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
-  FROM jsonb_array_elements(v_list->'data') item
-  WHERE item->>'id' = v_locked_dossier::TEXT;
-  IF v_can_delete IS DISTINCT FROM false THEN
-    RAISE EXCEPTION 'can_delete failed: locked history with later draft must be false';
-  END IF;
-  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
-  FROM jsonb_array_elements(v_list->'data') item
-  WHERE item->>'id' = v_archived_dossier::TEXT;
-  IF v_can_delete IS DISTINCT FROM false THEN
-    RAISE EXCEPTION 'can_delete failed: archived dossier must be false';
-  END IF;
+  PERFORM pg_temp.expect_list_can_delete(v_list, v_draft_dossier, true, 'draft dossier');
+  PERFORM pg_temp.expect_list_can_delete(v_list, v_locked_dossier, false, 'locked dossier');
+  PERFORM pg_temp.expect_list_can_delete(v_list, v_archived_dossier, false, 'archived dossier');
 
   PERFORM pg_temp.set_claims('qltb_khoa', v_user_id);
   PERFORM pg_temp.expect_error(
@@ -403,20 +419,29 @@ BEGIN
 
   EXECUTE $plan$
     EXPLAIN (FORMAT JSON)
-    SELECT d.id, (
-      d.archived_at IS NULL
-      AND NOT EXISTS (
-        SELECT 1
-        FROM public.technical_configuration_baseline_versions v
-        WHERE v.dossier_id = d.id AND v.status = 'locked'
-      )
-    ) AS can_delete
-    FROM public.technical_configuration_dossiers d
-    ORDER BY d.updated_at DESC, d.id
-    LIMIT 100
+    WITH dossier_page AS MATERIALIZED (
+      SELECT d.id, d.archived_at, d.updated_at
+      FROM public.technical_configuration_dossiers d
+      ORDER BY d.updated_at DESC, d.id
+      LIMIT 100
+    ), locked_dossiers AS (
+      SELECT DISTINCT v.dossier_id
+      FROM public.technical_configuration_baseline_versions v
+      JOIN dossier_page page ON page.id = v.dossier_id
+      WHERE v.status = 'locked'
+    )
+    SELECT page.id,
+      page.archived_at IS NULL AND locked.dossier_id IS NULL AS can_delete
+    FROM dossier_page page
+    LEFT JOIN locked_dossiers locked ON locked.dossier_id = page.id
+    ORDER BY page.updated_at DESC, page.id
   $plan$ INTO v_plan;
-  IF v_plan IS NULL THEN
-    RAISE EXCEPTION 'set-based can_delete plan was not produced';
+  IF jsonb_path_exists(
+    v_plan, '$.**."Parent Relationship" ? (@ == "SubPlan")'
+  ) OR NOT jsonb_path_exists(
+    v_plan, '$.**."CTE Name" ? (@ == "dossier_page")'
+  ) THEN
+    RAISE EXCEPTION 'set-based can_delete plan expected a page CTE without a subplan';
   END IF;
 END;
 $gate$;

--- a/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
@@ -1,0 +1,424 @@
+-- supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
+-- Purpose: prove P15A delete authorization, locked-history, cascade, and list contracts.
+-- Non-destructive: all fixture writes are wrapped in a transaction and rolled back.
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT, p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state = p_expected_state AND v_message = p_expected_message THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION '%: expected %/%, got %/%',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.seed_draft_aggregate(p_suffix TEXT, p_user_id BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_dossier UUID;
+  v_version UUID;
+  v_group UUID;
+  v_criterion UUID;
+  v_baseline_document UUID;
+  v_baseline_citation UUID;
+  v_reference_product UUID;
+  v_reference_response UUID;
+  v_reference_document UUID;
+  v_reference_citation UUID;
+  v_supplier UUID;
+  v_option UUID;
+  v_comparison_set UUID;
+  v_option_response UUID;
+  v_option_document UUID;
+  v_option_citation UUID;
+  v_assessment UUID;
+BEGIN
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name, name, description, created_by, updated_by
+  ) VALUES (
+    'P15A draft device ' || p_suffix,
+    'P15A draft aggregate ' || p_suffix,
+    'Draft-only aggregate for cascade verification',
+    p_user_id,
+    p_user_id
+  ) RETURNING id INTO v_dossier;
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    dossier_id, version_number, status, next_criterion_number, created_by, updated_by
+  ) VALUES (v_dossier, 1, 'draft', 2, p_user_id, p_user_id)
+  RETURNING id INTO v_version;
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES (v_version, 'P15A draft group', 1, p_user_id, p_user_id)
+  RETURNING id INTO v_group;
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    baseline_version_id, group_id, criterion_code, title, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES (
+    v_version, v_group, 'TC-0001', 'P15A criterion',
+    'P15A cascade requirement', 1, p_user_id, p_user_id
+  ) RETURNING id INTO v_criterion;
+
+  INSERT INTO public.technical_configuration_baseline_documents (
+    baseline_version_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_version, 'P15A baseline document',
+    'https://example.com/p15a-baseline.pdf', p_user_id, p_user_id
+  ) RETURNING id INTO v_baseline_document;
+
+  INSERT INTO public.technical_configuration_baseline_citations (
+    baseline_version_id, baseline_document_id, criterion_id, page_section,
+    excerpt, created_by, updated_by
+  ) VALUES (
+    v_version, v_baseline_document, v_criterion, '1',
+    'P15A baseline citation', p_user_id, p_user_id
+  ) RETURNING id INTO v_baseline_citation;
+
+  INSERT INTO public.technical_configuration_reference_products (
+    baseline_version_id, model, manufacturer, description, created_by, updated_by
+  ) VALUES (
+    v_version, 'P15A reference model', 'P15A manufacturer',
+    'P15A reference product', p_user_id, p_user_id
+  ) RETURNING id INTO v_reference_product;
+
+  INSERT INTO public.technical_configuration_reference_responses (
+    baseline_version_id, reference_product_id, criterion_id, response_text,
+    created_by, updated_by
+  ) VALUES (
+    v_version, v_reference_product, v_criterion,
+    'P15A reference response', p_user_id, p_user_id
+  ) RETURNING id INTO v_reference_response;
+
+  INSERT INTO public.technical_configuration_reference_documents (
+    baseline_version_id, reference_product_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_version, v_reference_product, 'P15A reference document',
+    'https://example.com/p15a-reference.pdf', p_user_id, p_user_id
+  ) RETURNING id INTO v_reference_document;
+
+  INSERT INTO public.technical_configuration_reference_citations (
+    baseline_version_id, reference_document_id, criterion_id, page_section,
+    excerpt, created_by, updated_by
+  ) VALUES (
+    v_version, v_reference_document, v_criterion, '2',
+    'P15A reference citation', p_user_id, p_user_id
+  ) RETURNING id INTO v_reference_citation;
+
+  INSERT INTO public.technical_configuration_suppliers (
+    dossier_id, name, normalized_name, created_by, updated_by
+  ) VALUES (
+    v_dossier, 'P15A Supplier ' || p_suffix,
+    lower('P15A Supplier ' || p_suffix), p_user_id, p_user_id
+  ) RETURNING id INTO v_supplier;
+
+  INSERT INTO public.technical_configuration_options (
+    dossier_id, supplier_id, model, manufacturer, option_name, created_by, updated_by
+  ) VALUES (
+    v_dossier, v_supplier, 'P15A option model', 'P15A option manufacturer',
+    'P15A option', p_user_id, p_user_id
+  ) RETURNING id INTO v_option;
+
+  INSERT INTO public.technical_configuration_comparison_sets (
+    dossier_id, option_id, baseline_version_id, created_by, updated_by
+  ) VALUES (v_dossier, v_option, v_version, p_user_id, p_user_id)
+  RETURNING id INTO v_comparison_set;
+
+  INSERT INTO public.technical_configuration_option_responses (
+    comparison_set_id, baseline_version_id, criterion_id, response_text,
+    supplementary_information, created_by, updated_by
+  ) VALUES (
+    v_comparison_set, v_version, v_criterion, 'P15A option response',
+    'P15A supplementary information', p_user_id, p_user_id
+  ) RETURNING id INTO v_option_response;
+
+  INSERT INTO public.technical_configuration_option_documents (
+    option_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_option, 'P15A option document',
+    'https://example.com/p15a-option.pdf', p_user_id, p_user_id
+  ) RETURNING id INTO v_option_document;
+
+  INSERT INTO public.technical_configuration_option_citations (
+    option_id, baseline_version_id, comparison_set_id, option_document_id,
+    criterion_id, page_section, excerpt, created_by, updated_by
+  ) VALUES (
+    v_option, v_version, v_comparison_set, v_option_document, v_criterion,
+    '3', 'P15A option citation', p_user_id, p_user_id
+  ) RETURNING id INTO v_option_citation;
+
+  INSERT INTO public.technical_configuration_manual_assessments (
+    comparison_set_id, baseline_version_id, criterion_id, technical_axis,
+    evidence_axis, notes, created_by, updated_by
+  ) VALUES (
+    v_comparison_set, v_version, v_criterion, 'meets', 'complete',
+    'P15A manual assessment', p_user_id, p_user_id
+  ) RETURNING id INTO v_assessment;
+
+  RETURN jsonb_build_object(
+    'technical_configuration_dossiers', v_dossier,
+    'technical_configuration_baseline_versions', v_version,
+    'technical_configuration_baseline_groups', v_group,
+    'technical_configuration_baseline_criteria', v_criterion,
+    'technical_configuration_baseline_documents', v_baseline_document,
+    'technical_configuration_baseline_citations', v_baseline_citation,
+    'technical_configuration_reference_products', v_reference_product,
+    'technical_configuration_reference_responses', v_reference_response,
+    'technical_configuration_reference_documents', v_reference_document,
+    'technical_configuration_reference_citations', v_reference_citation,
+    'technical_configuration_suppliers', v_supplier,
+    'technical_configuration_options', v_option,
+    'technical_configuration_comparison_sets', v_comparison_set,
+    'technical_configuration_option_responses', v_option_response,
+    'technical_configuration_option_documents', v_option_document,
+    'technical_configuration_option_citations', v_option_citation,
+    'technical_configuration_manual_assessments', v_assessment
+  );
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_fixture JSONB;
+  v_draft_dossier UUID;
+  v_admin_dossier UUID;
+  v_locked_dossier UUID;
+  v_archived_dossier UUID;
+  v_missing_dossier UUID := gen_random_uuid();
+  v_locked_version UUID;
+  v_later_draft UUID;
+  v_locked_group UUID;
+  v_locked_criterion UUID;
+  v_response JSONB;
+  v_list JSONB;
+  v_plan JSON;
+  v_can_delete BOOLEAN;
+  v_count BIGINT;
+  v_check RECORD;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_dossier_delete_phase_gate')
+  );
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no active nhan_vien row found';
+  END IF;
+
+  v_fixture := pg_temp.seed_draft_aggregate(v_suffix, v_user_id);
+  v_draft_dossier := (v_fixture->>'technical_configuration_dossiers')::UUID;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name, name, description, created_by, updated_by
+  ) VALUES (
+    'P15A admin device ' || v_suffix, 'P15A raw admin delete ' || v_suffix,
+    'Never-locked aggregate for raw admin semantics', v_user_id, v_user_id
+  ) RETURNING id INTO v_admin_dossier;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name, name, description, created_by, updated_by
+  ) VALUES (
+    'P15A locked device ' || v_suffix, 'P15A locked history ' || v_suffix,
+    'Locked baseline followed by a later draft', v_user_id, v_user_id
+  ) RETURNING id INTO v_locked_dossier;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name, name, description, archived_at, archived_by,
+    created_by, updated_by
+  ) VALUES (
+    'P15A archived device ' || v_suffix, 'P15A archived dossier ' || v_suffix,
+    'Archived dossier must remain undeletable', now(), v_user_id,
+    v_user_id, v_user_id
+  ) RETURNING id INTO v_archived_dossier;
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    dossier_id, version_number, status, next_criterion_number, revision,
+    locked_at, locked_by, created_by, updated_by
+  ) VALUES (
+    v_locked_dossier, 1, 'locked', 2, 2, now(), v_user_id, v_user_id, v_user_id
+  ) RETURNING id INTO v_locked_version;
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES (v_locked_version, 'P15A locked group', 1, v_user_id, v_user_id)
+  RETURNING id INTO v_locked_group;
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    baseline_version_id, group_id, criterion_code, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES (
+    v_locked_version, v_locked_group, 'TC-0001', 'P15A locked requirement',
+    1, v_user_id, v_user_id
+  ) RETURNING id INTO v_locked_criterion;
+  INSERT INTO public.technical_configuration_baseline_versions (
+    dossier_id, version_number, status, source_baseline_version_id,
+    next_criterion_number, created_by, updated_by
+  ) VALUES (
+    v_locked_dossier, 2, 'draft', v_locked_version, 2, v_user_id, v_user_id
+  ) RETURNING id INTO v_later_draft;
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  v_list := public.technical_configuration_dossiers_list(1, 100, true);
+  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
+  FROM jsonb_array_elements(v_list->'data') item
+  WHERE item->>'id' = v_draft_dossier::TEXT;
+  IF v_can_delete IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'can_delete failed: active draft-only dossier must be true';
+  END IF;
+  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
+  FROM jsonb_array_elements(v_list->'data') item
+  WHERE item->>'id' = v_locked_dossier::TEXT;
+  IF v_can_delete IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'can_delete failed: locked history with later draft must be false';
+  END IF;
+  SELECT (item->>'can_delete')::BOOLEAN INTO v_can_delete
+  FROM jsonb_array_elements(v_list->'data') item
+  WHERE item->>'id' = v_archived_dossier::TEXT;
+  IF v_can_delete IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'can_delete failed: archived dossier must be false';
+  END IF;
+
+  PERFORM pg_temp.set_claims('qltb_khoa', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'denied role',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 1)', v_draft_dossier),
+    '42501', 'permission_denied'
+  );
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 1)', v_draft_dossier),
+    '42501', 'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'stale revision',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 2)', v_draft_dossier),
+    'PT409', 'stale_revision'
+  );
+  PERFORM pg_temp.expect_error(
+    'archived dossier',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 1)', v_archived_dossier),
+    'PT409', 'archived_dossier'
+  );
+  PERFORM pg_temp.expect_error(
+    'missing dossier',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 1)', v_missing_dossier),
+    'PT404', 'not_found'
+  );
+  PERFORM pg_temp.expect_error(
+    'locked dossier',
+    format('SELECT public.technical_configuration_dossiers_delete(%L::uuid, 1)', v_locked_dossier),
+    'PT409', 'locked_dossier'
+  );
+
+  SELECT count(*) INTO v_count
+  FROM public.technical_configuration_baseline_versions
+  WHERE dossier_id = v_locked_dossier;
+  IF v_count <> 2 OR NOT EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_groups WHERE id = v_locked_group
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.technical_configuration_baseline_criteria WHERE id = v_locked_criterion
+  ) THEN
+    RAISE EXCEPTION 'locked rejection failed: aggregate changed';
+  END IF;
+
+  v_response := public.technical_configuration_dossiers_delete(v_draft_dossier, 1);
+  IF v_response <> jsonb_build_object('data', jsonb_build_object('id', v_draft_dossier)) THEN
+    RAISE EXCEPTION 'global delete failed: unexpected response %', v_response;
+  END IF;
+  FOR v_check IN SELECT key AS table_name, value::UUID AS row_id
+    FROM jsonb_each_text(v_fixture)
+  LOOP
+    EXECUTE format('SELECT count(*) FROM public.%I WHERE id = $1', v_check.table_name)
+      INTO v_count USING v_check.row_id;
+    IF v_count <> 0 THEN
+      RAISE EXCEPTION 'cascade failed: % still contains %',
+        v_check.table_name, v_check.row_id;
+    END IF;
+  END LOOP;
+
+  v_list := public.technical_configuration_dossiers_list(1, 100, true);
+  IF EXISTS (
+    SELECT 1 FROM jsonb_array_elements(v_list->'data') item
+    WHERE item->>'id' = v_draft_dossier::TEXT
+  ) THEN
+    RAISE EXCEPTION 'list disappearance failed';
+  END IF;
+  PERFORM pg_temp.expect_error(
+    'get disappearance',
+    format('SELECT public.technical_configuration_dossiers_get(%L::uuid)', v_draft_dossier),
+    'PT404', 'not_found'
+  );
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_response := public.technical_configuration_dossiers_delete(v_admin_dossier, 1);
+  IF v_response <> jsonb_build_object('data', jsonb_build_object('id', v_admin_dossier)) THEN
+    RAISE EXCEPTION 'raw admin delete failed: unexpected response %', v_response;
+  END IF;
+
+  EXECUTE $plan$
+    EXPLAIN (FORMAT JSON)
+    SELECT d.id, (
+      d.archived_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.technical_configuration_baseline_versions v
+        WHERE v.dossier_id = d.id AND v.status = 'locked'
+      )
+    ) AS can_delete
+    FROM public.technical_configuration_dossiers d
+    ORDER BY d.updated_at DESC, d.id
+    LIMIT 100
+  $plan$ INTO v_plan;
+  IF v_plan IS NULL THEN
+    RAISE EXCEPTION 'set-based can_delete plan was not produced';
+  END IF;
+END;
+$gate$;
+
+ROLLBACK;

--- a/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
+++ b/supabase/tests/technical_configuration_dossier_delete_phase_gate.sql
@@ -418,7 +418,8 @@ BEGIN
   END IF;
 
   EXECUTE $plan$
-    EXPLAIN (FORMAT JSON)
+  -- Plan replica of technical_configuration_dossiers_list; keep it aligned with the deployed page-first shape checked above.
+  EXPLAIN (FORMAT JSON)
     WITH dossier_page AS MATERIALIZED (
       SELECT d.id, d.archived_at, d.updated_at
       FROM public.technical_configuration_dossiers d


### PR DESCRIPTION
## Summary
- add the ordered DB-only `technical_configuration_dossiers_delete(UUID, BIGINT)` migration with dossier-row-first serialization and permanent locked-history rejection
- add additive set-based `can_delete` to the dossier list without changing pagination or totals
- add the focused source/dormancy contract test plus rollback-only runtime and two-session concurrency phase gates

## Scope
- no proxy allowlist or RPC manifest changes
- no TypeScript adapter, client, React, or UI changes
- no new table, soft-delete/restore flow, or speculative index

## TDD evidence
- RED: the new contract suite failed 5 tests only because the migration and phase-gate artifacts were absent; the foundation and whitelist regressions stayed green
- GREEN: 3 focused files, 90 tests passed

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest suite: 90 passed
- `node scripts/npm-run.js run react-doctor` (no changed React source files; skipped)
- `openspec validate add-technical-configuration-comparison --strict`
- `git diff --check`

## Live DB
Live Supabase was inspected read-only for function definitions, ACLs, indexes, and dossier-descendant foreign keys. No migration was applied and no live DB write was performed. Issue #864 remains open until an explicitly approved apply and both live phase gates complete.

Refs #864

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P15A dormant dossier hard-delete at the DB layer and a computed can_delete flag in the dossiers list. Tightens ACLs, documents forward-only rollback, and ships phase gates with clearer diagnostics to prove plan shape and delete/lock concurrency; no client or proxy changes. Relates to #864.

- **New Features**
  - Added `technical_configuration_dossiers_delete(UUID, BIGINT)`: SECURITY DEFINER, RETURNS JSONB with fixed payload {data:{id}}; enforces revision, rejects locked history (PT409), and deletes only the root dossier row with dossier-row-first serialization.
  - Dossier list now includes non-null can_delete using a set-based locked_dossiers join over a MATERIALIZED page CTE; pagination and totals unchanged.
  - Access: REVOKE from PUBLIC/anon/authenticated/service_role; GRANT EXECUTE to authenticated only; not in proxy allowlist or `-rpcs.ts` manifests.

- **Migration**
  - One ordered SQL migration after list/guard/baseline-lock predecessors with forward-only rollback notes to restore the prior list RPC and drop the delete RPC.
  - Ships rollback-only runtime and two-session concurrency phase gates with clarified diagnostics; verify auth errors, cascade behavior, set-based list plan (no per-row subplans), and delete/lock outcomes (delete-first → PT404, lock-first → PT409).

<sup>Written for commit bca8fab4d70d17a8b1f9e6959fcf24cbe6d2a28b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

