### PR TITLE
[P15B] Add active dossier metadata editing

### DIFF
--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -11,7 +11,11 @@ import { isGlobalRole } from "@/lib/rbac"
 import { TechnicalConfigurationDossierForm } from "./_components/TechnicalConfigurationDossierForm"
 import { TechnicalConfigurationDossierTable } from "./_components/TechnicalConfigurationDossierTable"
 import { TechnicalConfigurationWorkspaceShell } from "./_components/TechnicalConfigurationWorkspaceShell"
-import { useTechnicalConfigurationDossierActions } from "./_hooks/useTechnicalConfigurationDossierActions"
+import {
+  isStaleRevisionError,
+  isStaleRevisionRefreshError,
+  useTechnicalConfigurationDossierActions,
+} from "./_hooks/useTechnicalConfigurationDossierActions"
 import {
   createTechnicalConfigurationDossier,
   getTechnicalConfigurationDossier,
@@ -37,7 +41,11 @@ function getErrorMessage(error: unknown, fallback: string): string {
 }
 
 function getDossierUpdateErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message === "stale_revision") {
+  if (isStaleRevisionRefreshError(error)) {
+    return "Không thể nạp dữ liệu hồ sơ mới nhất sau khi phát hiện xung đột. Kiểm tra kết nối và thử lại."
+  }
+
+  if (isStaleRevisionError(error)) {
     return "Hồ sơ đã được cập nhật ở phiên khác. Dữ liệu mới nhất đã được nạp; kiểm tra và lưu lại để thử lại."
   }
 
@@ -186,7 +194,11 @@ export function TechnicalConfigurationsClient({
         </div>
         <Button
           className="w-full sm:w-auto"
-          disabled={openingDossierId !== null || dossierActions.isUpdating}
+          disabled={
+            openingDossierId !== null ||
+            dossierActions.isUpdating ||
+            dossierActions.editTarget !== null
+          }
           onClick={() => handleCreateOpenChange(true)}
         >
           <Plus className="size-4" aria-hidden="true" />

--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -11,6 +11,7 @@ import { isGlobalRole } from "@/lib/rbac"
 import { TechnicalConfigurationDossierForm } from "./_components/TechnicalConfigurationDossierForm"
 import { TechnicalConfigurationDossierTable } from "./_components/TechnicalConfigurationDossierTable"
 import { TechnicalConfigurationWorkspaceShell } from "./_components/TechnicalConfigurationWorkspaceShell"
+import { useTechnicalConfigurationDossierActions } from "./_hooks/useTechnicalConfigurationDossierActions"
 import {
   createTechnicalConfigurationDossier,
   getTechnicalConfigurationDossier,
@@ -35,6 +36,14 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback
 }
 
+function getDossierUpdateErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message === "stale_revision") {
+    return "Hồ sơ đã được cập nhật ở phiên khác. Dữ liệu mới nhất đã được nạp; kiểm tra và lưu lại để thử lại."
+  }
+
+  return getErrorMessage(error, "Không thể cập nhật hồ sơ.")
+}
+
 /** Orchestrates dossier listing, creation, and workspace selection for global roles. */
 export function TechnicalConfigurationsClient({
   role,
@@ -47,12 +56,13 @@ export function TechnicalConfigurationsClient({
   const [openDossierError, setOpenDossierError] = React.useState<unknown>(null)
   const [selectedDossier, setSelectedDossier] =
     React.useState<TechnicalConfigurationDossierWire | null>(null)
+  const dossierListQueryKey = [
+    ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+    { page, pageSize: DOSSIER_PAGE_SIZE },
+  ] as const
 
   const dossierListQuery = useQuery({
-    queryKey: [
-      ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
-      { page, pageSize: DOSSIER_PAGE_SIZE },
-    ],
+    queryKey: dossierListQueryKey,
     queryFn: ({ signal }) =>
       listTechnicalConfigurationDossiers(
         {
@@ -64,6 +74,10 @@ export function TechnicalConfigurationsClient({
       ),
     enabled: canAccess,
     staleTime: 30_000,
+  })
+  const dossierActions = useTechnicalConfigurationDossierActions({
+    listQueryKey: dossierListQueryKey,
+    onSelectedDossierChange: setSelectedDossier,
   })
 
   const createDossierMutation = useMutation({
@@ -80,7 +94,7 @@ export function TechnicalConfigurationsClient({
 
   const handleCreateOpenChange = React.useCallback(
     (open: boolean) => {
-      if (open && openingDossierId) {
+      if (open && (openingDossierId || dossierActions.editTarget)) {
         return
       }
 
@@ -89,7 +103,7 @@ export function TechnicalConfigurationsClient({
       }
       setIsCreateOpen(open)
     },
-    [createDossierMutation, openingDossierId]
+    [createDossierMutation, dossierActions.editTarget, openingDossierId]
   )
 
   const handleCreate = React.useCallback(
@@ -172,7 +186,7 @@ export function TechnicalConfigurationsClient({
         </div>
         <Button
           className="w-full sm:w-auto"
-          disabled={openingDossierId !== null}
+          disabled={openingDossierId !== null || dossierActions.isUpdating}
           onClick={() => handleCreateOpenChange(true)}
         >
           <Plus className="size-4" aria-hidden="true" />
@@ -212,10 +226,12 @@ export function TechnicalConfigurationsClient({
           <TechnicalConfigurationDossierTable
             dossiers={dossierListQuery.data?.data ?? []}
             isLoading={dossierListQuery.isLoading}
+            isActionPending={dossierActions.isUpdating}
             openingDossierId={openingDossierId}
             page={dossierListQuery.data?.page ?? page}
             pageSize={dossierListQuery.data?.page_size ?? DOSSIER_PAGE_SIZE}
             total={dossierListQuery.data?.total ?? 0}
+            onEdit={dossierActions.openEdit}
             onOpen={(id) => void handleOpen(id)}
             onPageChange={setPage}
           />
@@ -223,6 +239,7 @@ export function TechnicalConfigurationsClient({
       </section>
 
       <TechnicalConfigurationDossierForm
+        mode="create"
         open={isCreateOpen}
         isSubmitting={createDossierMutation.isPending}
         errorMessage={
@@ -233,6 +250,21 @@ export function TechnicalConfigurationsClient({
         onOpenChange={handleCreateOpenChange}
         onSubmit={handleCreate}
       />
+      {dossierActions.editTarget ? (
+        <TechnicalConfigurationDossierForm
+          mode="edit"
+          dossier={dossierActions.editTarget}
+          open
+          isSubmitting={dossierActions.isUpdating}
+          errorMessage={
+            dossierActions.updateError
+              ? getDossierUpdateErrorMessage(dossierActions.updateError)
+              : null
+          }
+          onOpenChange={dossierActions.handleEditOpenChange}
+          onSubmit={dossierActions.submitEdit}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions-cache.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions-cache.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, renderHook } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
@@ -32,6 +32,9 @@ type DossierActionsOptions = {
 }
 
 type DossierActionsResult = {
+  editTarget: TechnicalConfigurationDossierWire | null
+  updateError: unknown
+  openEdit: (dossier: TechnicalConfigurationDossierWire) => void
   submitEdit: (args: TechnicalConfigurationDossierUpdateRpcArgs) => Promise<void>
 }
 
@@ -53,12 +56,54 @@ const dossier: TechnicalConfigurationDossierWire = {
   updated_by: 1,
 }
 
+const listQueryKey = [
+  ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+  { page: 1, pageSize: 20 },
+] as const
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+async function renderDossierActions(queryClient: QueryClient) {
+  const hookModule =
+    (await import("../_hooks/useTechnicalConfigurationDossierActions")) as DossierActionsModuleContract
+  expect(hookModule.useTechnicalConfigurationDossierActions).toEqual(expect.any(Function))
+  if (!hookModule.useTechnicalConfigurationDossierActions) {
+    throw new Error("useTechnicalConfigurationDossierActions is not available")
+  }
+
+  const useDossierActions = hookModule.useTechnicalConfigurationDossierActions
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  return renderHook(
+    () => {
+      const [selectedDossier, setSelectedDossier] =
+        React.useState<TechnicalConfigurationDossierWire | null>(dossier)
+      const actions = useDossierActions({
+        listQueryKey,
+        onSelectedDossierChange: setSelectedDossier,
+      })
+
+      return { actions, selectedDossier }
+    },
+    { wrapper }
+  )
+}
+
 describe("technical configuration dossier action cache", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
   it("adopts the server revision in list, detail and selected state without dropping fields", async () => {
-    const listQueryKey = [
-      ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
-      { page: 1, pageSize: 20 },
-    ] as const
     const listItem = {
       ...dossier,
       future_list_only_field: "keep-list",
@@ -80,12 +125,7 @@ describe("technical configuration dossier action cache", () => {
       p_description: updatedDossier.description,
       p_expected_revision: dossier.revision,
     }
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-        mutations: { retry: false },
-      },
-    })
+    const queryClient = createQueryClient()
     queryClient.setQueryData(listQueryKey, {
       data: [listItem],
       total: 1,
@@ -97,28 +137,7 @@ describe("technical configuration dossier action cache", () => {
     })
     mocks.updateDossier.mockResolvedValue({ data: updatedDossier })
 
-    const hookModule =
-      (await import("../_hooks/useTechnicalConfigurationDossierActions")) as DossierActionsModuleContract
-    expect(hookModule.useTechnicalConfigurationDossierActions).toEqual(expect.any(Function))
-    if (!hookModule.useTechnicalConfigurationDossierActions) return
-
-    const useDossierActions = hookModule.useTechnicalConfigurationDossierActions
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    )
-    const { result } = renderHook(
-      () => {
-        const [selectedDossier, setSelectedDossier] =
-          React.useState<TechnicalConfigurationDossierWire | null>(dossier)
-        const actions = useDossierActions({
-          listQueryKey,
-          onSelectedDossierChange: setSelectedDossier,
-        })
-
-        return { actions, selectedDossier }
-      },
-      { wrapper }
-    )
+    const { result } = await renderDossierActions(queryClient)
 
     await act(async () => {
       await result.current.actions.submitEdit(updateArgs)
@@ -154,6 +173,62 @@ describe("technical configuration dossier action cache", () => {
       id: dossier.id,
       name: updatedDossier.name,
       revision: 8,
+    })
+  })
+
+  it("uses the refreshed revision for retry while preserving submitted metadata in edit state", async () => {
+    const queryClient = createQueryClient()
+    const refreshedDossier: TechnicalConfigurationDossierWire = {
+      ...dossier,
+      name: "Tên mới từ server",
+      description: "Mô tả mới từ server",
+      revision: 8,
+      updated_at: "2026-08-06T01:00:00.000Z",
+    }
+    const updateArgs: TechnicalConfigurationDossierUpdateRpcArgs = {
+      p_id: dossier.id,
+      p_device_type_name: "Máy siêu âm tim",
+      p_name: "Tên đang sửa",
+      p_description: "Mô tả đang sửa",
+      p_expected_revision: dossier.revision,
+    }
+    queryClient.setQueryData(listQueryKey, {
+      data: [dossier],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+    queryClient.setQueryData(technicalConfigurationDossierDetailQueryKey(dossier.id), {
+      data: dossier,
+    })
+    mocks.updateDossier.mockRejectedValueOnce(new Error("stale_revision"))
+    mocks.getDossier.mockResolvedValueOnce({ data: refreshedDossier })
+
+    const { result } = await renderDossierActions(queryClient)
+
+    act(() => {
+      result.current.actions.openEdit(dossier)
+    })
+    await act(async () => {
+      await result.current.actions.submitEdit(updateArgs).catch(() => undefined)
+    })
+
+    expect(result.current.actions.editTarget).toMatchObject({
+      id: dossier.id,
+      device_type_name: updateArgs.p_device_type_name,
+      name: updateArgs.p_name,
+      description: updateArgs.p_description,
+      revision: refreshedDossier.revision,
+      updated_at: refreshedDossier.updated_at,
+    })
+    expect(
+      queryClient.getQueryData<TechnicalConfigurationDossierListWireResponse>(listQueryKey)
+    ).toMatchObject({
+      data: [{ name: refreshedDossier.name, revision: refreshedDossier.revision }],
+    })
+    expect(result.current.selectedDossier).toMatchObject({
+      name: refreshedDossier.name,
+      revision: refreshedDossier.revision,
     })
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions-cache.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions-cache.test.tsx
@@ -1,0 +1,159 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+  technicalConfigurationDossierDetailQueryKey,
+} from "../technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierUpdateRpcArgs,
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
+
+const mocks = vi.hoisted(() => ({
+  getDossier: vi.fn(),
+  updateDossier: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  getTechnicalConfigurationDossier: (...args: unknown[]) => mocks.getDossier(...args),
+  updateTechnicalConfigurationDossier: (...args: unknown[]) => mocks.updateDossier(...args),
+}))
+
+type DossierActionsOptions = {
+  listQueryKey: readonly unknown[]
+  onSelectedDossierChange: React.Dispatch<
+    React.SetStateAction<TechnicalConfigurationDossierWire | null>
+  >
+}
+
+type DossierActionsResult = {
+  submitEdit: (args: TechnicalConfigurationDossierUpdateRpcArgs) => Promise<void>
+}
+
+type DossierActionsModuleContract = {
+  useTechnicalConfigurationDossierActions?: (options: DossierActionsOptions) => DossierActionsResult
+}
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: "Cấu hình chuẩn",
+  revision: 7,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-13T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-13T00:00:00.000Z",
+  updated_by: 1,
+}
+
+describe("technical configuration dossier action cache", () => {
+  it("adopts the server revision in list, detail and selected state without dropping fields", async () => {
+    const listQueryKey = [
+      ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+      { page: 1, pageSize: 20 },
+    ] as const
+    const listItem = {
+      ...dossier,
+      future_list_only_field: "keep-list",
+    }
+    const detailItem = {
+      ...dossier,
+      future_detail_only_field: "keep-detail",
+    }
+    const updatedDossier: TechnicalConfigurationDossierWire = {
+      ...dossier,
+      name: "Cấu hình máy siêu âm tim",
+      description: "Metadata đã cập nhật",
+      revision: 8,
+    }
+    const updateArgs: TechnicalConfigurationDossierUpdateRpcArgs = {
+      p_id: dossier.id,
+      p_device_type_name: dossier.device_type_name,
+      p_name: updatedDossier.name,
+      p_description: updatedDossier.description,
+      p_expected_revision: dossier.revision,
+    }
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    queryClient.setQueryData(listQueryKey, {
+      data: [listItem],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+    queryClient.setQueryData(technicalConfigurationDossierDetailQueryKey(dossier.id), {
+      data: detailItem,
+    })
+    mocks.updateDossier.mockResolvedValue({ data: updatedDossier })
+
+    const hookModule =
+      (await import("../_hooks/useTechnicalConfigurationDossierActions")) as DossierActionsModuleContract
+    expect(hookModule.useTechnicalConfigurationDossierActions).toEqual(expect.any(Function))
+    if (!hookModule.useTechnicalConfigurationDossierActions) return
+
+    const useDossierActions = hookModule.useTechnicalConfigurationDossierActions
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(
+      () => {
+        const [selectedDossier, setSelectedDossier] =
+          React.useState<TechnicalConfigurationDossierWire | null>(dossier)
+        const actions = useDossierActions({
+          listQueryKey,
+          onSelectedDossierChange: setSelectedDossier,
+        })
+
+        return { actions, selectedDossier }
+      },
+      { wrapper }
+    )
+
+    await act(async () => {
+      await result.current.actions.submitEdit(updateArgs)
+    })
+
+    expect(mocks.updateDossier).toHaveBeenCalledTimes(1)
+    expect(mocks.updateDossier).toHaveBeenCalledWith(updateArgs)
+    expect(
+      queryClient.getQueryData<TechnicalConfigurationDossierListWireResponse>(listQueryKey)
+    ).toMatchObject({
+      data: [
+        {
+          id: dossier.id,
+          name: updatedDossier.name,
+          revision: 8,
+          future_list_only_field: "keep-list",
+        },
+      ],
+    })
+    expect(
+      queryClient.getQueryData<TechnicalConfigurationDossierWireResponse>(
+        technicalConfigurationDossierDetailQueryKey(dossier.id)
+      )
+    ).toMatchObject({
+      data: {
+        id: dossier.id,
+        name: updatedDossier.name,
+        revision: 8,
+        future_detail_only_field: "keep-detail",
+      },
+    })
+    expect(result.current.selectedDossier).toMatchObject({
+      id: dossier.id,
+      name: updatedDossier.name,
+      revision: 8,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions.test.tsx
@@ -70,6 +70,8 @@ const defaultList: TechnicalConfigurationDossierListWireResponse = {
 }
 const STALE_REVISION_MESSAGE =
   "Hồ sơ đã được cập nhật ở phiên khác. Dữ liệu mới nhất đã được nạp; kiểm tra và lưu lại để thử lại."
+const STALE_REVISION_REFRESH_FAILED_MESSAGE =
+  "Không thể nạp dữ liệu hồ sơ mới nhất sau khi phát hiện xung đột. Kiểm tra kết nối và thử lại."
 
 function createQueryClient() {
   return new QueryClient({
@@ -130,11 +132,13 @@ describe("technical configuration dossier actions", () => {
     const user = userEvent.setup()
     renderClient()
 
+    const createButton = await screen.findByRole("button", { name: "Tạo hồ sơ" })
     await openEditAction(user, dossierTwo)
 
     expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
     expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("Máy X-quang")
     expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Cấu hình máy X-quang")
+    expect(createButton).toBeDisabled()
     expect(mocks.updateDossier).not.toHaveBeenCalled()
 
     await user.click(screen.getByRole("button", { name: "Hủy" }))
@@ -180,6 +184,24 @@ describe("technical configuration dossier actions", () => {
     expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Tên chưa được lưu")
     expect(screen.getByText(dossierOne.name)).toBeInTheDocument()
     expect(mocks.updateDossier).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports a stale refresh failure without claiming that latest data was loaded", async () => {
+    const user = userEvent.setup()
+    mocks.updateDossier.mockRejectedValueOnce(new Error("stale_revision"))
+    mocks.getDossier.mockRejectedValueOnce(new Error("Mất kết nối"))
+    renderClient()
+
+    await openEditAction(user, dossierOne)
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Tên chưa được lưu")
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    expect(await screen.findByText(STALE_REVISION_REFRESH_FAILED_MESSAGE)).toBeInTheDocument()
+    expect(screen.queryByText(STALE_REVISION_MESSAGE)).not.toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Tên chưa được lưu")
+    expect(mocks.getDossier).toHaveBeenCalledWith(dossierOne.id)
   })
 
   it("keeps edited values visible after stale revision and retries explicitly", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-actions.test.tsx
@@ -1,0 +1,317 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
+import * as clientModule from "../TechnicalConfigurationsClient"
+
+const MODULE_ROOT = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+
+const mocks = vi.hoisted(() => ({
+  listDossiers: vi.fn(),
+  getDossier: vi.fn(),
+  createDossier: vi.fn(),
+  updateDossier: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  listTechnicalConfigurationDossiers: (...args: unknown[]) => mocks.listDossiers(...args),
+  getTechnicalConfigurationDossier: (...args: unknown[]) => mocks.getDossier(...args),
+  createTechnicalConfigurationDossier: (...args: unknown[]) => mocks.createDossier(...args),
+  updateTechnicalConfigurationDossier: (...args: unknown[]) => mocks.updateDossier(...args),
+}))
+
+type TechnicalConfigurationsClientContract = React.ComponentType<{
+  role?: string | null
+}>
+
+const TechnicalConfigurationsClient = (
+  clientModule as { TechnicalConfigurationsClient?: TechnicalConfigurationsClientContract }
+).TechnicalConfigurationsClient
+
+const dossierOne: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: "Cấu hình chuẩn",
+  revision: 7,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-13T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-13T00:00:00.000Z",
+  updated_by: 1,
+}
+
+const dossierTwo: TechnicalConfigurationDossierWire = {
+  ...dossierOne,
+  id: "dossier-2",
+  device_type_name: "Máy X-quang",
+  name: "Cấu hình máy X-quang",
+  description: null,
+  revision: 3,
+}
+
+const defaultList: TechnicalConfigurationDossierListWireResponse = {
+  data: [dossierOne, dossierTwo],
+  total: 2,
+  page: 1,
+  page_size: 20,
+}
+const STALE_REVISION_MESSAGE =
+  "Hồ sơ đã được cập nhật ở phiên khác. Dữ liệu mới nhất đã được nạp; kiểm tra và lưu lại để thử lại."
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function renderClient() {
+  expect(TechnicalConfigurationsClient).toEqual(expect.any(Function))
+  if (!TechnicalConfigurationsClient) {
+    return null
+  }
+
+  const queryClient = createQueryClient()
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TechnicalConfigurationsClient role="global" />
+    </QueryClientProvider>
+  )
+
+  return queryClient
+}
+
+async function openEditAction(
+  user: ReturnType<typeof userEvent.setup>,
+  dossier: TechnicalConfigurationDossierWire
+) {
+  await screen.findByText(dossier.name)
+  await user.click(
+    screen.getByRole("button", {
+      name: `Hành động cho ${dossier.name}`,
+    })
+  )
+  await user.click(await screen.findByRole("menuitem", { name: "Sửa metadata" }))
+}
+
+describe("technical configuration dossier actions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.listDossiers.mockResolvedValue(defaultList)
+  })
+
+  it("keeps row actions and mutation state in focused module files", () => {
+    expect(
+      fs.existsSync(
+        path.join(MODULE_ROOT, "_components/TechnicalConfigurationDossierRowActions.tsx")
+      )
+    ).toBe(true)
+    expect(
+      fs.existsSync(path.join(MODULE_ROOT, "_hooks/useTechnicalConfigurationDossierActions.ts"))
+    ).toBe(true)
+  })
+
+  it("opens edit for the intended row and cancels without mutation", async () => {
+    const user = userEvent.setup()
+    renderClient()
+
+    await openEditAction(user, dossierTwo)
+
+    expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("Máy X-quang")
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Cấu hình máy X-quang")
+    expect(mocks.updateDossier).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+
+    expect(mocks.updateDossier).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Sửa metadata hồ sơ" })).not.toBeInTheDocument()
+    })
+  })
+
+  it("keeps metadata editing available when the dossier carries a locked baseline field", async () => {
+    const user = userEvent.setup()
+    const dossierWithLockedBaseline = {
+      ...dossierOne,
+      baseline_locked_at: "2026-08-05T00:00:00.000Z",
+    }
+    mocks.listDossiers.mockResolvedValueOnce({
+      data: [dossierWithLockedBaseline],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+    renderClient()
+
+    await openEditAction(user, dossierWithLockedBaseline)
+
+    expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue(dossierOne.name)
+    expect(mocks.updateDossier).not.toHaveBeenCalled()
+  })
+
+  it("keeps failed API edits visible without changing the dossier row", async () => {
+    const user = userEvent.setup()
+    mocks.updateDossier.mockRejectedValueOnce(new Error("Mất kết nối"))
+    renderClient()
+
+    await openEditAction(user, dossierOne)
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Tên chưa được lưu")
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    expect(await screen.findByText("Mất kết nối")).toBeInTheDocument()
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Tên chưa được lưu")
+    expect(screen.getByText(dossierOne.name)).toBeInTheDocument()
+    expect(mocks.updateDossier).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps edited values visible after stale revision and retries explicitly", async () => {
+    const user = userEvent.setup()
+    const refreshedDossier: TechnicalConfigurationDossierWire = {
+      ...dossierOne,
+      name: "Tên mới từ phiên làm việc khác",
+      revision: 8,
+    }
+    const updatedDossier: TechnicalConfigurationDossierWire = {
+      ...dossierOne,
+      name: "Cấu hình đang sửa",
+      revision: 9,
+    }
+    mocks.listDossiers
+      .mockResolvedValueOnce({
+        data: [dossierOne],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      .mockResolvedValue({
+        data: [updatedDossier],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+    mocks.getDossier.mockResolvedValue({ data: refreshedDossier })
+    mocks.updateDossier
+      .mockRejectedValueOnce(new Error("stale_revision"))
+      .mockResolvedValueOnce({ data: updatedDossier })
+    renderClient()
+
+    await openEditAction(user, dossierOne)
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), updatedDossier.name)
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    expect(await screen.findByText(STALE_REVISION_MESSAGE)).toBeInTheDocument()
+    expect(mocks.getDossier).toHaveBeenCalledWith(dossierOne.id)
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue(updatedDossier.name)
+    expect(mocks.updateDossier).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    await waitFor(() => expect(mocks.updateDossier).toHaveBeenCalledTimes(2))
+    expect(mocks.updateDossier).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        p_id: dossierOne.id,
+        p_name: updatedDossier.name,
+        p_expected_revision: 8,
+      })
+    )
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Sửa metadata hồ sơ" })).not.toBeInTheDocument()
+    })
+  })
+
+  it("adopts the refreshed row revision before cancel and reopen after a stale conflict", async () => {
+    const user = userEvent.setup()
+    const refreshedDossier: TechnicalConfigurationDossierWire = {
+      ...dossierOne,
+      name: "Tên mới từ phiên làm việc khác",
+      revision: 8,
+    }
+    mocks.listDossiers.mockResolvedValueOnce({
+      data: [dossierOne],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+    mocks.getDossier.mockResolvedValue({ data: refreshedDossier })
+    mocks.updateDossier.mockRejectedValueOnce(new Error("stale_revision")).mockResolvedValueOnce({
+      data: {
+        ...refreshedDossier,
+        revision: 9,
+      },
+    })
+    renderClient()
+
+    await openEditAction(user, dossierOne)
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+    expect(await screen.findByText(STALE_REVISION_MESSAGE)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+    expect(await screen.findByText(refreshedDossier.name)).toBeInTheDocument()
+
+    await openEditAction(user, refreshedDossier)
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    await waitFor(() => expect(mocks.updateDossier).toHaveBeenCalledTimes(2))
+    expect(mocks.updateDossier).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        p_id: dossierOne.id,
+        p_name: refreshedDossier.name,
+        p_expected_revision: 8,
+      })
+    )
+  })
+
+  it("locks edit dismissal while the update is pending", async () => {
+    const user = userEvent.setup()
+    let resolveUpdate: ((response: TechnicalConfigurationDossierWireResponse) => void) | undefined
+    mocks.listDossiers
+      .mockResolvedValueOnce({
+        data: [dossierOne],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      .mockResolvedValue(defaultList)
+    mocks.updateDossier.mockReturnValue(
+      new Promise<TechnicalConfigurationDossierWireResponse>((resolve) => {
+        resolveUpdate = resolve
+      })
+    )
+    renderClient()
+
+    await openEditAction(user, dossierOne)
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    await waitFor(() => expect(mocks.updateDossier).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()
+    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
+
+    await act(async () => {
+      resolveUpdate?.({ data: { ...dossierOne, revision: 8 } })
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Sửa metadata hồ sơ" })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
@@ -3,11 +3,12 @@ import path from "node:path"
 
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationDossierForm } from "../_components/TechnicalConfigurationDossierForm"
+import type { TechnicalConfigurationDossierWire } from "../types"
 
 const TYPE_IMPORT_COMPONENTS = [
   "TechnicalConfigurationDossierForm.tsx",
@@ -19,8 +20,41 @@ const TECHNICAL_CONFIGURATION_ROOT = path.resolve(
   "src/app/(app)/technical-configurations"
 )
 
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: "Cấu hình chuẩn",
+  revision: 7,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-13T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-13T00:00:00.000Z",
+  updated_by: 1,
+}
+
 function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
   const props = {
+    mode: "create" as const,
+    open: true,
+    isSubmitting: false,
+    errorMessage: null,
+    onOpenChange: vi.fn(),
+    onSubmit,
+  }
+  const view = render(<TechnicalConfigurationDossierForm {...props} />)
+
+  return { ...view, onSubmit, props }
+}
+
+function renderEditForm(
+  onSubmit = vi.fn().mockResolvedValue(undefined),
+  target: TechnicalConfigurationDossierWire = dossier
+) {
+  const props = {
+    mode: "edit" as const,
+    dossier: target,
     open: true,
     isSubmitting: false,
     errorMessage: null,
@@ -70,7 +104,7 @@ describe("technical configuration dossier form", () => {
     ]) {
       const source = fs.readFileSync(path.join(TECHNICAL_CONFIGURATION_ROOT, file), "utf8")
 
-      expect(source).toContain('<div className="w-full">')
+      expect(source).toContain("w-full")
       expect(source).not.toContain(
         '<main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">'
       )
@@ -112,5 +146,101 @@ describe("technical configuration dossier form", () => {
 
     expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("")
     expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("")
+  })
+
+  it("prefills the selected dossier in edit mode", () => {
+    renderEditForm()
+
+    expect(screen.getByRole("heading", { name: "Sửa metadata hồ sơ" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("Máy siêu âm")
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Cấu hình máy siêu âm")
+    expect(screen.getByLabelText("Mô tả")).toHaveValue("Cấu hình chuẩn")
+  })
+
+  it("submits all editable fields with the selected dossier revision", async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderEditForm()
+
+    await user.clear(screen.getByLabelText("Loại thiết bị"))
+    await user.type(screen.getByLabelText("Loại thiết bị"), "Máy siêu âm tim")
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Cấu hình máy siêu âm tim")
+    await user.clear(screen.getByLabelText("Mô tả"))
+    await user.type(screen.getByLabelText("Mô tả"), "Metadata đã cập nhật")
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        p_id: "dossier-1",
+        p_device_type_name: "Máy siêu âm tim",
+        p_name: "Cấu hình máy siêu âm tim",
+        p_description: "Metadata đã cập nhật",
+        p_expected_revision: 7,
+      })
+    })
+  })
+
+  it("cancels edit without submitting", async () => {
+    const user = userEvent.setup()
+    const { onSubmit, props } = renderEditForm()
+
+    await user.type(screen.getByLabelText("Tên hồ sơ"), " thay đổi")
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+
+    expect(props.onOpenChange).toHaveBeenCalledWith(false)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("preserves edited values across an error render and retry", async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("stale_revision"))
+      .mockResolvedValueOnce(undefined)
+    const { rerender, props } = renderEditForm(onSubmit)
+
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Cấu hình đang sửa")
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    rerender(
+      <TechnicalConfigurationDossierForm
+        {...props}
+        dossier={{
+          ...dossier,
+          name: "Tên mới từ server",
+          revision: 8,
+        }}
+        errorMessage="Hồ sơ đã thay đổi. Vui lòng thử lại."
+      />
+    )
+
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Cấu hình đang sửa")
+    expect(screen.getByText("Hồ sơ đã thay đổi. Vui lòng thử lại.")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2))
+  })
+
+  it("resets edit values when a different dossier target opens", async () => {
+    const user = userEvent.setup()
+    const { rerender, props } = renderEditForm()
+    const nextDossier: TechnicalConfigurationDossierWire = {
+      ...dossier,
+      id: "dossier-2",
+      name: "Cấu hình máy X-quang",
+      device_type_name: "Máy X-quang",
+      description: null,
+      revision: 3,
+    }
+
+    await user.clear(screen.getByLabelText("Tên hồ sơ"))
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Giá trị chưa lưu")
+    rerender(<TechnicalConfigurationDossierForm {...props} dossier={nextDossier} />)
+
+    expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("Máy X-quang")
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("Cấu hình máy X-quang")
+    expect(screen.getByLabelText("Mô tả")).toHaveValue("")
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   listDossiers: vi.fn(),
   getDossier: vi.fn(),
   createDossier: vi.fn(),
+  updateDossier: vi.fn(),
   pageRole: "global",
 }))
 
@@ -49,6 +50,7 @@ vi.mock("../technical-configuration-rpc", () => ({
   listTechnicalConfigurationDossiers: (...args: unknown[]) => mocks.listDossiers(...args),
   getTechnicalConfigurationDossier: (...args: unknown[]) => mocks.getDossier(...args),
   createTechnicalConfigurationDossier: (...args: unknown[]) => mocks.createDossier(...args),
+  updateTechnicalConfigurationDossier: (...args: unknown[]) => mocks.updateDossier(...args),
 }))
 
 type TechnicalConfigurationsClientContract = React.ComponentType<{

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -295,6 +295,7 @@ describe("technical configuration dossier shell", () => {
 
     render(
       <TechnicalConfigurationDossierForm
+        mode="create"
         open
         isSubmitting
         errorMessage={null}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type {
   TechnicalConfigurationDossierCreateRpcArgs,
   TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierUpdateRpcArgs,
 } from "../types"
 import * as rpcModule from "../technical-configuration-rpc"
 
@@ -20,6 +21,10 @@ type RpcModuleContract = {
   ) => Promise<TechnicalConfigurationDossierListWireResponse>
   createTechnicalConfigurationDossier?: (
     args: TechnicalConfigurationDossierCreateRpcArgs,
+    signal?: AbortSignal
+  ) => Promise<unknown>
+  updateTechnicalConfigurationDossier?: (
+    args: TechnicalConfigurationDossierUpdateRpcArgs,
     signal?: AbortSignal
   ) => Promise<unknown>
 }
@@ -107,6 +112,36 @@ describe("technical configuration RPC adapter", () => {
           p_description: null,
           p_expected_revision: 0,
         }),
+      })
+    )
+  })
+
+  it("posts the selected dossier and current revision through the update RPC", async () => {
+    expect(rpc.updateTechnicalConfigurationDossier).toEqual(expect.any(Function))
+    if (!rpc.updateTechnicalConfigurationDossier) return
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: "dossier-1", revision: 8 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const args: TechnicalConfigurationDossierUpdateRpcArgs = {
+      p_id: "dossier-1",
+      p_device_type_name: "Máy siêu âm tim",
+      p_name: "Cấu hình máy siêu âm tim",
+      p_description: "Metadata đã cập nhật",
+      p_expected_revision: 7,
+    }
+
+    await rpc.updateTechnicalConfigurationDossier(args)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/rpc/technical_configuration_dossiers_update",
+      expect.objectContaining({
+        body: JSON.stringify(args),
       })
     )
   })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
@@ -6,7 +6,11 @@ import { AlertCircle, Loader2 } from "lucide-react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
-import type { TechnicalConfigurationDossierCreateRpcArgs } from "@/app/(app)/technical-configurations/types"
+import type {
+  TechnicalConfigurationDossierCreateRpcArgs,
+  TechnicalConfigurationDossierUpdateRpcArgs,
+  TechnicalConfigurationDossierWire,
+} from "@/app/(app)/technical-configurations/types"
 import { SideSheetShell } from "@/components/shared/SideSheetShell"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -21,13 +25,25 @@ import {
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 
-type TechnicalConfigurationDossierFormProps = {
+type TechnicalConfigurationDossierFormCommonProps = {
   open: boolean
   isSubmitting: boolean
   errorMessage: string | null
   onOpenChange: (open: boolean) => void
-  onSubmit: (args: TechnicalConfigurationDossierCreateRpcArgs) => Promise<void>
 }
+
+type TechnicalConfigurationDossierFormProps = TechnicalConfigurationDossierFormCommonProps &
+  (
+    | {
+        mode: "create"
+        onSubmit: (args: TechnicalConfigurationDossierCreateRpcArgs) => Promise<void>
+      }
+    | {
+        mode: "edit"
+        dossier: TechnicalConfigurationDossierWire
+        onSubmit: (args: TechnicalConfigurationDossierUpdateRpcArgs) => Promise<void>
+      }
+  )
 
 const dossierFormSchema = z.object({
   deviceTypeName: z.string().trim().min(1, "Vui lòng nhập loại thiết bị."),
@@ -44,55 +60,93 @@ const EMPTY_FORM: DossierFormValues = {
 }
 const DOSSIER_FORM_ID = "technical-configuration-dossier-form"
 
-/** Renders the explicit-save form for creating a configuration dossier. */
-export function TechnicalConfigurationDossierForm({
-  open,
-  isSubmitting,
-  errorMessage,
-  onOpenChange,
-  onSubmit,
-}: Readonly<TechnicalConfigurationDossierFormProps>) {
+/** Renders the shared explicit-save form for dossier create and metadata edit. */
+export function TechnicalConfigurationDossierForm(
+  props: Readonly<TechnicalConfigurationDossierFormProps>
+) {
+  const editDossier = props.mode === "edit" ? props.dossier : null
+  const initialValues = React.useMemo<DossierFormValues>(
+    () =>
+      editDossier
+        ? {
+            deviceTypeName: editDossier.device_type_name,
+            name: editDossier.name,
+            description: editDossier.description ?? "",
+          }
+        : EMPTY_FORM,
+    [
+      editDossier?.description,
+      editDossier?.device_type_name,
+      editDossier?.id,
+      editDossier?.name,
+      editDossier?.revision,
+    ]
+  )
   const form = useForm<DossierFormValues>({
     resolver: zodResolver(dossierFormSchema),
-    defaultValues: EMPTY_FORM,
+    defaultValues: initialValues,
   })
   const { reset } = form
+  const resetTargetRef = React.useRef<string | null>(null)
+  const resetTarget = props.mode === "edit" ? `edit:${props.dossier.id}` : "create"
 
   React.useEffect(() => {
-    if (!open) {
-      reset(EMPTY_FORM)
+    if (!props.open) {
+      resetTargetRef.current = null
+      return
     }
-  }, [open, reset])
+
+    if (resetTargetRef.current !== resetTarget) {
+      reset(initialValues)
+      resetTargetRef.current = resetTarget
+    }
+  }, [initialValues, props.open, reset, resetTarget])
 
   async function submitForm(values: DossierFormValues) {
+    const metadata = {
+      p_device_type_name: values.deviceTypeName,
+      p_name: values.name,
+      p_description: values.description || null,
+    }
+
     try {
-      await onSubmit({
-        p_device_type_name: values.deviceTypeName,
-        p_name: values.name,
-        p_description: values.description || null,
-        p_expected_revision: 0,
-      })
+      if (props.mode === "create") {
+        await props.onSubmit({
+          ...metadata,
+          p_expected_revision: 0,
+        })
+      } else {
+        await props.onSubmit({
+          ...metadata,
+          p_id: props.dossier.id,
+          p_expected_revision: props.dossier.revision,
+        })
+      }
     } catch {
       // The mutation error is rendered without clearing locally edited values.
     }
   }
 
   function handleOpenChange(nextOpen: boolean) {
-    if (!nextOpen && isSubmitting) {
+    if (!nextOpen && props.isSubmitting) {
       return
     }
 
-    onOpenChange(nextOpen)
+    props.onOpenChange(nextOpen)
   }
 
   return (
     <SideSheetShell
-      open={open}
+      open={props.open}
       onOpenChange={handleOpenChange}
-      title="Tạo hồ sơ cấu hình"
-      description="Hồ sơ là gốc độc lập cho một dòng cấu hình thiết bị."
+      title={props.mode === "create" ? "Tạo hồ sơ cấu hình" : "Sửa metadata hồ sơ"}
+      description={
+        props.mode === "create"
+          ? "Hồ sơ là gốc độc lập cho một dòng cấu hình thiết bị."
+          : "Cập nhật loại thiết bị, tên và mô tả của hồ sơ đang hoạt động."
+      }
       closeLabel="Đóng"
-      hideCloseButton={isSubmitting}
+      hideCloseButton={props.isSubmitting}
       contentClassName="sm:max-w-lg"
       bodyClassName="overflow-y-auto p-4"
       footer={
@@ -100,14 +154,16 @@ export function TechnicalConfigurationDossierForm({
           <Button
             type="button"
             variant="outline"
-            disabled={isSubmitting}
-            onClick={() => onOpenChange(false)}
+            disabled={props.isSubmitting}
+            onClick={() => handleOpenChange(false)}
           >
             Hủy
           </Button>
-          <Button type="submit" form={DOSSIER_FORM_ID} disabled={isSubmitting}>
-            {isSubmitting ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
-            Lưu hồ sơ
+          <Button type="submit" form={DOSSIER_FORM_ID} disabled={props.isSubmitting}>
+            {props.isSubmitting ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : null}
+            {props.mode === "create" ? "Lưu hồ sơ" : "Lưu thay đổi"}
           </Button>
         </div>
       }
@@ -124,7 +180,7 @@ export function TechnicalConfigurationDossierForm({
                   <Input
                     {...field}
                     id="technical-configuration-device-type"
-                    disabled={isSubmitting}
+                    disabled={props.isSubmitting}
                   />
                 </FormControl>
                 <FormMessage />
@@ -139,7 +195,11 @@ export function TechnicalConfigurationDossierForm({
               <FormItem>
                 <FormLabel htmlFor="technical-configuration-name">Tên hồ sơ</FormLabel>
                 <FormControl>
-                  <Input {...field} id="technical-configuration-name" disabled={isSubmitting} />
+                  <Input
+                    {...field}
+                    id="technical-configuration-name"
+                    disabled={props.isSubmitting}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -157,7 +217,7 @@ export function TechnicalConfigurationDossierForm({
                     {...field}
                     id="technical-configuration-description"
                     rows={4}
-                    disabled={isSubmitting}
+                    disabled={props.isSubmitting}
                   />
                 </FormControl>
                 <FormMessage />
@@ -165,10 +225,10 @@ export function TechnicalConfigurationDossierForm({
             )}
           />
 
-          {errorMessage ? (
+          {props.errorMessage ? (
             <Alert variant="destructive">
               <AlertCircle className="size-4" />
-              <AlertDescription>{errorMessage}</AlertDescription>
+              <AlertDescription>{props.errorMessage}</AlertDescription>
             </Alert>
           ) : null}
         </form>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { MoreHorizontal, Pencil } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useDeferredDropdownAction } from "@/components/ui/use-deferred-dropdown-action"
+
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+
+type TechnicalConfigurationDossierRowActionsProps = {
+  dossier: TechnicalConfigurationDossierWire
+  disabled?: boolean
+  onEdit: (dossier: TechnicalConfigurationDossierWire) => void
+}
+
+/** Renders the extendable row-action menu without exposing delete behavior. */
+export function TechnicalConfigurationDossierRowActions({
+  dossier,
+  disabled = false,
+  onEdit,
+}: Readonly<TechnicalConfigurationDossierRowActionsProps>) {
+  const deferDropdownAction = useDeferredDropdownAction()
+  const actionLabel = `Hành động cho ${dossier.name}`
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          disabled={disabled}
+          aria-label={actionLabel}
+          title={actionLabel}
+        >
+          <MoreHorizontal className="size-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Hành động</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => deferDropdownAction(() => onEdit(dossier))}>
+          <Pencil className="mr-2 size-4" aria-hidden="true" />
+          Sửa metadata
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
@@ -13,14 +13,17 @@ import {
 import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
 
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { TechnicalConfigurationDossierRowActions } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions"
 
 type TechnicalConfigurationDossierTableProps = {
   dossiers: TechnicalConfigurationDossierWire[]
   isLoading: boolean
+  isActionPending: boolean
   openingDossierId: string | null
   page: number
   pageSize: number
   total: number
+  onEdit: (dossier: TechnicalConfigurationDossierWire) => void
   onOpen: (id: string) => void
   onPageChange: (page: number) => void
 }
@@ -29,10 +32,12 @@ type TechnicalConfigurationDossierTableProps = {
 export function TechnicalConfigurationDossierTable({
   dossiers,
   isLoading,
+  isActionPending,
   openingDossierId,
   page,
   pageSize,
   total,
+  onEdit,
   onOpen,
   onPageChange,
 }: Readonly<TechnicalConfigurationDossierTableProps>) {
@@ -81,7 +86,7 @@ export function TechnicalConfigurationDossierTable({
               <TableHead>Hồ sơ</TableHead>
               <TableHead>Loại thiết bị</TableHead>
               <TableHead>Cập nhật</TableHead>
-              <TableHead className="w-24 text-right">Thao tác</TableHead>
+              <TableHead className="w-36 text-right">Thao tác</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -101,21 +106,28 @@ export function TechnicalConfigurationDossierTable({
                     {formatVietnamDateTime(dossier.updated_at)}
                   </TableCell>
                   <TableCell className="text-right">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      disabled={openingDossierId !== null}
-                      aria-label={`Mở ${dossier.name}`}
-                      onClick={() => onOpen(dossier.id)}
-                    >
-                      {isOpening ? (
-                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                      ) : (
-                        <ArrowRight className="size-4" aria-hidden="true" />
-                      )}
-                      Mở
-                    </Button>
+                    <div className="flex items-center justify-end gap-1">
+                      <TechnicalConfigurationDossierRowActions
+                        dossier={dossier}
+                        disabled={openingDossierId !== null || isActionPending}
+                        onEdit={onEdit}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={openingDossierId !== null || isActionPending}
+                        aria-label={`Mở ${dossier.name}`}
+                        onClick={() => onOpen(dossier.id)}
+                      >
+                        {isOpening ? (
+                          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <ArrowRight className="size-4" aria-hidden="true" />
+                        )}
+                        Mở
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               )

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts
@@ -1,0 +1,142 @@
+"use client"
+
+import * as React from "react"
+import { type QueryClient, type QueryKey, useMutation, useQueryClient } from "@tanstack/react-query"
+
+import {
+  getTechnicalConfigurationDossier,
+  updateTechnicalConfigurationDossier,
+} from "../technical-configuration-rpc"
+import {
+  TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+  technicalConfigurationDossierDetailQueryKey,
+} from "../technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierUpdateRpcArgs,
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
+
+type UseTechnicalConfigurationDossierActionsOptions = {
+  listQueryKey: QueryKey
+  onSelectedDossierChange: React.Dispatch<
+    React.SetStateAction<TechnicalConfigurationDossierWire | null>
+  >
+}
+
+function mergeDossier<T extends TechnicalConfigurationDossierWire>(
+  current: T,
+  updated: TechnicalConfigurationDossierWire
+): T {
+  return { ...current, ...updated }
+}
+
+function mergeDossierIntoQueryCaches(
+  queryClient: QueryClient,
+  listQueryKey: QueryKey,
+  updatedDossier: TechnicalConfigurationDossierWire
+) {
+  queryClient.setQueryData<TechnicalConfigurationDossierListWireResponse>(
+    listQueryKey,
+    (current) =>
+      current
+        ? {
+            ...current,
+            data: current.data.map((dossier) =>
+              dossier.id === updatedDossier.id ? mergeDossier(dossier, updatedDossier) : dossier
+            ),
+          }
+        : current
+  )
+  queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
+    technicalConfigurationDossierDetailQueryKey(updatedDossier.id),
+    (current) => ({
+      ...(current ?? {}),
+      data: current ? mergeDossier(current.data, updatedDossier) : updatedDossier,
+    })
+  )
+}
+
+function isStaleRevisionError(error: unknown) {
+  return error instanceof Error && error.message === "stale_revision"
+}
+
+/** Owns active dossier metadata edit state, mutation, and cache reconciliation. */
+export function useTechnicalConfigurationDossierActions({
+  listQueryKey,
+  onSelectedDossierChange,
+}: UseTechnicalConfigurationDossierActionsOptions) {
+  const queryClient = useQueryClient()
+  const [editTarget, setEditTarget] = React.useState<TechnicalConfigurationDossierWire | null>(null)
+
+  const updateMutation = useMutation({
+    mutationFn: updateTechnicalConfigurationDossier,
+    onSuccess: async (response) => {
+      const updatedDossier = response.data
+
+      mergeDossierIntoQueryCaches(queryClient, listQueryKey, updatedDossier)
+      onSelectedDossierChange((current) =>
+        current?.id === updatedDossier.id ? mergeDossier(current, updatedDossier) : current
+      )
+      setEditTarget(null)
+
+      await queryClient.invalidateQueries({
+        queryKey: TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
+      })
+    },
+    onError: async (error, args) => {
+      if (!isStaleRevisionError(error)) {
+        return
+      }
+
+      try {
+        const response = await getTechnicalConfigurationDossier(args.p_id)
+        mergeDossierIntoQueryCaches(queryClient, listQueryKey, response.data)
+        onSelectedDossierChange((current) =>
+          current?.id === response.data.id ? mergeDossier(current, response.data) : current
+        )
+        setEditTarget((current) =>
+          current?.id === response.data.id ? mergeDossier(current, response.data) : current
+        )
+      } catch {
+        // Keep the original stale-revision error and locally edited form values.
+      }
+    },
+  })
+
+  const openEdit = React.useCallback(
+    (dossier: TechnicalConfigurationDossierWire) => {
+      updateMutation.reset()
+      setEditTarget(dossier)
+    },
+    [updateMutation]
+  )
+
+  const handleEditOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (open || updateMutation.isPending) {
+        return
+      }
+
+      setEditTarget(null)
+    },
+    [updateMutation.isPending]
+  )
+
+  const submitEdit = React.useCallback(
+    async (args: TechnicalConfigurationDossierUpdateRpcArgs) => {
+      await updateMutation.mutateAsync(args)
+    },
+    [updateMutation]
+  )
+
+  return {
+    editTarget,
+    isUpdating: updateMutation.isPending,
+    updateError: updateMutation.isError ? updateMutation.error : null,
+    openEdit,
+    handleEditOpenChange,
+    submitEdit,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDossierActions.ts
@@ -25,6 +25,9 @@ type UseTechnicalConfigurationDossierActionsOptions = {
   >
 }
 
+const STALE_REVISION_ERROR_CODE = "stale_revision"
+const STALE_REVISION_REFRESH_ERROR_CODE = "stale_revision_refresh_failed"
+
 function mergeDossier<T extends TechnicalConfigurationDossierWire>(
   current: T,
   updated: TechnicalConfigurationDossierWire
@@ -58,8 +61,14 @@ function mergeDossierIntoQueryCaches(
   )
 }
 
-function isStaleRevisionError(error: unknown) {
-  return error instanceof Error && error.message === "stale_revision"
+/** Identifies the optimistic-concurrency error returned by the dossier update RPC. */
+export function isStaleRevisionError(error: unknown) {
+  return error instanceof Error && error.message === STALE_REVISION_ERROR_CODE
+}
+
+/** Identifies a failed refresh while recovering from a stale dossier revision. */
+export function isStaleRevisionRefreshError(error: unknown) {
+  return error instanceof Error && error.message === STALE_REVISION_REFRESH_ERROR_CODE
 }
 
 /** Owns active dossier metadata edit state, mutation, and cache reconciliation. */
@@ -69,12 +78,17 @@ export function useTechnicalConfigurationDossierActions({
 }: UseTechnicalConfigurationDossierActionsOptions) {
   const queryClient = useQueryClient()
   const [editTarget, setEditTarget] = React.useState<TechnicalConfigurationDossierWire | null>(null)
+  const [updateErrorOverride, setUpdateErrorOverride] = React.useState<Error | null>(null)
 
   const updateMutation = useMutation({
     mutationFn: updateTechnicalConfigurationDossier,
+    onMutate: () => {
+      setUpdateErrorOverride(null)
+    },
     onSuccess: async (response) => {
       const updatedDossier = response.data
 
+      setUpdateErrorOverride(null)
       mergeDossierIntoQueryCaches(queryClient, listQueryKey, updatedDossier)
       onSelectedDossierChange((current) =>
         current?.id === updatedDossier.id ? mergeDossier(current, updatedDossier) : current
@@ -92,15 +106,21 @@ export function useTechnicalConfigurationDossierActions({
 
       try {
         const response = await getTechnicalConfigurationDossier(args.p_id)
+        const retryTarget = {
+          ...response.data,
+          device_type_name: args.p_device_type_name,
+          name: args.p_name,
+          description: args.p_description,
+        }
         mergeDossierIntoQueryCaches(queryClient, listQueryKey, response.data)
         onSelectedDossierChange((current) =>
           current?.id === response.data.id ? mergeDossier(current, response.data) : current
         )
         setEditTarget((current) =>
-          current?.id === response.data.id ? mergeDossier(current, response.data) : current
+          current?.id === response.data.id ? mergeDossier(current, retryTarget) : current
         )
       } catch {
-        // Keep the original stale-revision error and locally edited form values.
+        setUpdateErrorOverride(new Error(STALE_REVISION_REFRESH_ERROR_CODE))
       }
     },
   })
@@ -108,6 +128,7 @@ export function useTechnicalConfigurationDossierActions({
   const openEdit = React.useCallback(
     (dossier: TechnicalConfigurationDossierWire) => {
       updateMutation.reset()
+      setUpdateErrorOverride(null)
       setEditTarget(dossier)
     },
     [updateMutation]
@@ -119,6 +140,7 @@ export function useTechnicalConfigurationDossierActions({
         return
       }
 
+      setUpdateErrorOverride(null)
       setEditTarget(null)
     },
     [updateMutation.isPending]
@@ -134,7 +156,7 @@ export function useTechnicalConfigurationDossierActions({
   return {
     editTarget,
     isUpdating: updateMutation.isPending,
-    updateError: updateMutation.isError ? updateMutation.error : null,
+    updateError: updateErrorOverride ?? (updateMutation.isError ? updateMutation.error : null),
     openEdit,
     handleEditOpenChange,
     submitEdit,

--- a/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
@@ -3,6 +3,7 @@ import type {
   TechnicalConfigurationDossierGetRpcArgs,
   TechnicalConfigurationDossierListRpcArgs,
   TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierUpdateRpcArgs,
   TechnicalConfigurationDossierWireResponse,
 } from "./types"
 
@@ -117,4 +118,12 @@ export function createTechnicalConfigurationDossier(
   signal?: AbortSignal
 ): Promise<TechnicalConfigurationDossierWireResponse> {
   return callTechnicalConfigurationRpc("technical_configuration_dossiers_create", args, { signal })
+}
+
+/** Updates active dossier metadata with the caller's current revision. */
+export function updateTechnicalConfigurationDossier(
+  args: TechnicalConfigurationDossierUpdateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationDossierWireResponse> {
+  return callTechnicalConfigurationRpc("technical_configuration_dossiers_update", args, { signal })
 }


### PR DESCRIPTION
## Summary
- add the typed `technical_configuration_dossiers_update` adapter and reuse the dossier form for explicit create/edit metadata saves
- add accessible row actions plus a focused mutation hook with revision-aware retry, localized stale-conflict guidance, and cache adoption that preserves opaque fields
- cover cancel, success, network failure, pending lock, stale retry/cancel-reopen, locked-baseline independence, and list/detail/selected cache reconciliation

## Scope
- P15B only: active dossier metadata editing
- no P15C delete client/UI, adapter, manifest, allowlist, or `can_delete` dependency
- no migration and no live database write

## Test Plan
- [x] `node scripts/npm-run.js run format:check`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] focused Vitest: 5 files, 41 tests
- [x] `node scripts/npm-run.js run react-doctor` (92/100, no findings)
- [x] `openspec validate add-technical-configuration-comparison --strict`
- [x] subagent code review; all actionable findings resolved
- [ ] browser verification not run per user request

Closes #863

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P15B active dossier metadata editing with a row action and an edit side sheet, plus a revision-aware update flow with clear conflict guidance. Meets Linear #863 and keeps list/detail/selected caches in sync while preserving unsaved edits; blocks create/open while an edit is in progress.

- **New Features**
  - Add typed `updateTechnicalConfigurationDossier` for `technical_configuration_dossiers_update` and `useTechnicalConfigurationDossierActions` to own edit state, handle stale-revision refresh + retry, and reconcile list/detail/selected caches without dropping fields.
  - Reuse `TechnicalConfigurationDossierForm` for create/edit via `mode="create" | "edit"`; prefills values, preserves edits across errors, resets when switching dossiers, and locks dismissal during submit with localized messages.
  - Add `TechnicalConfigurationDossierRowActions` with “Sửa metadata”; disables row actions, open, and create while an update is pending; shows specific messages for stale conflicts and refresh failures.

<sup>Written for commit 1fcb45b064f5681e96335942faa7645a78b931ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit technical configuration dossier metadata directly from the dossier table.
  * Edit forms are prefilled with existing values and support cancellation, retries, and switching between dossiers.
  * Updated dossier details and selected records refresh automatically after successful edits.
* **Bug Fixes**
  * Improved handling of outdated revisions by refreshing current data and allowing users to retry safely.
  * Prevented conflicting create, open, and edit actions while updates are in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->