### PR TITLE
feat(technical-configurations): reuse shared dossier pagination

### DIFF
--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, ListChecks, Plus, RefreshCw, ShieldAlert } from "lucide-re
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { useServerPagination } from "@/hooks/useServerPagination"
 import { isGlobalRole } from "@/lib/rbac"
 
 import { TechnicalConfigurationDossierForm } from "./_components/TechnicalConfigurationDossierForm"
@@ -78,15 +79,28 @@ export function TechnicalConfigurationsClient({
 }: Readonly<TechnicalConfigurationsClientProps>) {
   const queryClient = useQueryClient()
   const canAccess = isGlobalRole(role)
-  const [page, setPage] = React.useState(1)
+  const [dossierTotalCount, setDossierTotalCount] = React.useState(0)
+  const dossierPagination = useServerPagination({
+    totalCount: dossierTotalCount,
+    initialPageSize: DOSSIER_PAGE_SIZE,
+  })
   const [isCreateOpen, setIsCreateOpen] = React.useState(false)
   const [openingDossierId, setOpeningDossierId] = React.useState<string | null>(null)
   const [openDossierError, setOpenDossierError] = React.useState<unknown>(null)
   const [selectedDossier, setSelectedDossier] =
     React.useState<TechnicalConfigurationDossierWire | null>(null)
+  const handleDossierPageChange = React.useCallback(
+    (nextPage: number) => {
+      dossierPagination.setPagination((current) => ({
+        ...current,
+        pageIndex: Math.max(0, nextPage - 1),
+      }))
+    },
+    [dossierPagination.setPagination]
+  )
   const dossierListQueryKey = [
     ...TECHNICAL_CONFIGURATION_DOSSIER_QUERY_ROOT,
-    { page, pageSize: DOSSIER_PAGE_SIZE },
+    { page: dossierPagination.page, pageSize: dossierPagination.pageSize },
   ] as const
 
   const dossierListQuery = useQuery({
@@ -94,8 +108,8 @@ export function TechnicalConfigurationsClient({
     queryFn: ({ signal }) =>
       listTechnicalConfigurationDossiers(
         {
-          p_page: page,
-          p_page_size: DOSSIER_PAGE_SIZE,
+          p_page: dossierPagination.page,
+          p_page_size: dossierPagination.pageSize,
           p_include_archived: false,
         },
         signal
@@ -103,10 +117,16 @@ export function TechnicalConfigurationsClient({
     enabled: canAccess,
     staleTime: 30_000,
   })
+  const resolvedDossierTotal = dossierListQuery.data?.total
+  React.useEffect(() => {
+    if (resolvedDossierTotal === undefined) return
+    setDossierTotalCount(resolvedDossierTotal)
+  }, [resolvedDossierTotal])
+
   const dossierActions = useTechnicalConfigurationDossierActions({
     listQueryKey: dossierListQueryKey,
-    page,
-    onPageChange: setPage,
+    page: dossierPagination.page,
+    onPageChange: handleDossierPageChange,
     onSelectedDossierChange: setSelectedDossier,
   })
 
@@ -264,13 +284,16 @@ export function TechnicalConfigurationsClient({
             isLoading={dossierListQuery.isLoading}
             isActionPending={dossierActions.isDeleting || dossierActions.isUpdating}
             openingDossierId={openingDossierId}
-            page={dossierListQuery.data?.page ?? page}
-            pageSize={dossierListQuery.data?.page_size ?? DOSSIER_PAGE_SIZE}
-            total={dossierListQuery.data?.total ?? 0}
+            pagination={{
+              page: dossierPagination.page,
+              pageCount: dossierPagination.pageCount,
+              canPreviousPage: dossierPagination.canPreviousPage,
+              canNextPage: dossierPagination.canNextPage,
+              onPageChange: handleDossierPageChange,
+            }}
             onDelete={dossierActions.openDelete}
             onEdit={dossierActions.openEdit}
             onOpen={(id) => void handleOpen(id)}
-            onPageChange={setPage}
           />
         ) : null}
       </section>

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
@@ -12,8 +12,8 @@ import type {
   TechnicalConfigurationDossierListItemWire,
   TechnicalConfigurationDossierListRpcArgs,
   TechnicalConfigurationDossierListWireResponse,
-} from "../types"
-import { TechnicalConfigurationsClient } from "../TechnicalConfigurationsClient"
+} from "@/app/(app)/technical-configurations/types"
+import { TechnicalConfigurationsClient } from "@/app/(app)/technical-configurations/TechnicalConfigurationsClient"
 import {
   createQueryClient,
   dossier as baseDossier,
@@ -53,7 +53,7 @@ const pageDossiers: Record<number, TechnicalConfigurationDossierListItemWire> = 
   },
 }
 
-function renderClient() {
+function renderClient(): void {
   const queryClient = createQueryClient()
 
   render(
@@ -63,7 +63,7 @@ function renderClient() {
   )
 }
 
-function expectListCall(call: number, page: number) {
+function expectListCall(call: number, page: number): void {
   expect(mocks.listDossiers).toHaveBeenNthCalledWith(
     call,
     {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
@@ -1,6 +1,3 @@
-import fs from "node:fs"
-import path from "node:path"
-
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { QueryClientProvider } from "@tanstack/react-query"
@@ -154,24 +151,5 @@ describe("technical configuration dossier pagination", () => {
           .some(([args]) => (args as TechnicalConfigurationDossierListRpcArgs).p_page === 1)
       ).toBe(true)
     })
-  })
-
-  it("uses the shared navigation and server pagination contracts without local page math", () => {
-    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
-    const tableSource = fs.readFileSync(
-      path.join(moduleRoot, "_components/TechnicalConfigurationDossierTable.tsx"),
-      "utf8"
-    )
-    const clientSource = fs.readFileSync(
-      path.join(moduleRoot, "TechnicalConfigurationsClient.tsx"),
-      "utf8"
-    )
-
-    expect(tableSource).toContain("DataTablePagination.Navigation")
-    expect(tableSource).not.toMatch(/\bChevron(?:Left|Right)\b/)
-    expect(tableSource).not.toContain("Math.ceil")
-    expect(clientSource).toContain("useServerPagination")
-    expect(clientSource).toContain("p_page: dossierPagination.page")
-    expect(clientSource).toContain("p_page_size: dossierPagination.pageSize")
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-pagination.test.tsx
@@ -1,0 +1,177 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  TechnicalConfigurationDossierListItemWire,
+  TechnicalConfigurationDossierListRpcArgs,
+  TechnicalConfigurationDossierListWireResponse,
+} from "../types"
+import { TechnicalConfigurationsClient } from "../TechnicalConfigurationsClient"
+import {
+  createQueryClient,
+  dossier as baseDossier,
+} from "./technical-configuration-dossier-actions-test-harness"
+
+const mocks = vi.hoisted(() => ({
+  listDossiers: vi.fn(),
+  getDossier: vi.fn(),
+  createDossier: vi.fn(),
+  updateDossier: vi.fn(),
+  deleteDossier: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  listTechnicalConfigurationDossiers: (...args: unknown[]) => mocks.listDossiers(...args),
+  getTechnicalConfigurationDossier: (...args: unknown[]) => mocks.getDossier(...args),
+  createTechnicalConfigurationDossier: (...args: unknown[]) => mocks.createDossier(...args),
+  updateTechnicalConfigurationDossier: (...args: unknown[]) => mocks.updateDossier(...args),
+  deleteTechnicalConfigurationDossier: (...args: unknown[]) => mocks.deleteDossier(...args),
+}))
+
+const pageDossiers: Record<number, TechnicalConfigurationDossierListItemWire> = {
+  1: {
+    ...baseDossier,
+    id: "dossier-page-1",
+    name: "Hồ sơ trang 1",
+  },
+  2: {
+    ...baseDossier,
+    id: "dossier-page-2",
+    name: "Hồ sơ trang 2",
+  },
+  3: {
+    ...baseDossier,
+    id: "dossier-page-3",
+    name: "Hồ sơ trang 3",
+  },
+}
+
+function renderClient() {
+  const queryClient = createQueryClient()
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TechnicalConfigurationsClient role="global" />
+    </QueryClientProvider>
+  )
+}
+
+function expectListCall(call: number, page: number) {
+  expect(mocks.listDossiers).toHaveBeenNthCalledWith(
+    call,
+    {
+      p_page: page,
+      p_page_size: 20,
+      p_include_archived: false,
+    },
+    expect.anything()
+  )
+}
+
+describe("technical configuration dossier pagination", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.listDossiers.mockImplementation(
+      ({ p_page = 1 }: TechnicalConfigurationDossierListRpcArgs) =>
+        Promise.resolve({
+          data: [pageDossiers[p_page]],
+          total: 60,
+          page: p_page,
+          page_size: 20,
+        } satisfies TechnicalConfigurationDossierListWireResponse)
+    )
+  })
+
+  it("navigates through shared previous, next, first and last controls with isolated RPC pages", async () => {
+    const user = userEvent.setup()
+    renderClient()
+
+    expect(await screen.findByText(pageDossiers[1].name)).toBeInTheDocument()
+    expectListCall(1, 1)
+
+    await user.click(screen.getByRole("button", { name: "Trang tiếp" }))
+    expect(await screen.findByText(pageDossiers[2].name)).toBeInTheDocument()
+    expectListCall(2, 2)
+
+    await user.click(screen.getByRole("button", { name: "Đến trang cuối" }))
+    expect(await screen.findByText(pageDossiers[3].name)).toBeInTheDocument()
+    expectListCall(3, 3)
+
+    await user.click(screen.getByRole("button", { name: "Trang trước" }))
+    expect(await screen.findByText(pageDossiers[2].name)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Đến trang đầu" }))
+    expect(await screen.findByText(pageDossiers[1].name)).toBeInTheDocument()
+    await waitFor(() => expect(mocks.listDossiers).toHaveBeenCalledTimes(3))
+  })
+
+  it("returns to the previous page after deleting the last row on a later page", async () => {
+    const user = userEvent.setup()
+    let isDeleted = false
+    mocks.listDossiers.mockImplementation(
+      ({ p_page = 1 }: TechnicalConfigurationDossierListRpcArgs) =>
+        Promise.resolve({
+          data: p_page === 2 && isDeleted ? [] : [pageDossiers[p_page]],
+          total: isDeleted ? 20 : 21,
+          page: p_page,
+          page_size: 20,
+        } satisfies TechnicalConfigurationDossierListWireResponse)
+    )
+    mocks.deleteDossier.mockImplementation(async () => {
+      isDeleted = true
+      return { data: { id: pageDossiers[2].id } }
+    })
+    renderClient()
+
+    expect(await screen.findByText(pageDossiers[1].name)).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Trang tiếp" }))
+    expect(await screen.findByText(pageDossiers[2].name)).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Hành động cho ${pageDossiers[2].name}`,
+      })
+    )
+    await user.click(await screen.findByRole("menuitem", { name: "Xóa vĩnh viễn" }))
+    await user.click(screen.getByRole("button", { name: "Xóa vĩnh viễn" }))
+
+    expect(mocks.deleteDossier).toHaveBeenCalledWith({
+      p_id: pageDossiers[2].id,
+      p_expected_revision: pageDossiers[2].revision,
+    })
+    expect(await screen.findByText(pageDossiers[1].name)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        mocks.listDossiers.mock.calls
+          .slice(2)
+          .some(([args]) => (args as TechnicalConfigurationDossierListRpcArgs).p_page === 1)
+      ).toBe(true)
+    })
+  })
+
+  it("uses the shared navigation and server pagination contracts without local page math", () => {
+    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+    const tableSource = fs.readFileSync(
+      path.join(moduleRoot, "_components/TechnicalConfigurationDossierTable.tsx"),
+      "utf8"
+    )
+    const clientSource = fs.readFileSync(
+      path.join(moduleRoot, "TechnicalConfigurationsClient.tsx"),
+      "utf8"
+    )
+
+    expect(tableSource).toContain("DataTablePagination.Navigation")
+    expect(tableSource).not.toMatch(/\bChevron(?:Left|Right)\b/)
+    expect(tableSource).not.toContain("Math.ceil")
+    expect(clientSource).toContain("useServerPagination")
+    expect(clientSource).toContain("p_page: dossierPagination.page")
+    expect(clientSource).toContain("p_page_size: dossierPagination.pageSize")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -16,7 +16,6 @@ import type {
 import * as clientModule from "../TechnicalConfigurationsClient"
 import * as pageModule from "../page"
 import { TechnicalConfigurationDossierForm } from "../_components/TechnicalConfigurationDossierForm"
-import { TechnicalConfigurationDossierTable } from "../_components/TechnicalConfigurationDossierTable"
 
 const P3A_FILES = [
   "page.tsx",
@@ -309,28 +308,6 @@ describe("technical configuration dossier shell", () => {
     await user.keyboard("{Escape}")
 
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
-  })
-
-  it("offers a way back when a now-empty later page is returned", async () => {
-    const user = userEvent.setup()
-    const onPageChange = vi.fn()
-
-    render(
-      <TechnicalConfigurationDossierTable
-        dossiers={[]}
-        isLoading={false}
-        openingDossierId={null}
-        page={2}
-        pageSize={20}
-        total={1}
-        onOpen={vi.fn()}
-        onPageChange={onPageChange}
-      />
-    )
-
-    await user.click(screen.getByRole("button", { name: "Quay lại trang trước" }))
-
-    expect(onPageChange).toHaveBeenCalledWith(1)
   })
 
   it("keeps the route and client orchestrators below the extraction threshold", () => {

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
@@ -1,5 +1,6 @@
-import { ArrowRight, ChevronLeft, ChevronRight, FileText, Loader2 } from "lucide-react"
+import { ArrowRight, FileText, Loader2 } from "lucide-react"
 
+import { DataTablePagination } from "@/components/shared/DataTablePagination"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -18,18 +19,23 @@ import type {
 } from "@/app/(app)/technical-configurations/types"
 import { TechnicalConfigurationDossierRowActions } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierRowActions"
 
+type TechnicalConfigurationDossierPagination = {
+  page: number
+  pageCount: number
+  canPreviousPage: boolean
+  canNextPage: boolean
+  onPageChange: (page: number) => void
+}
+
 type TechnicalConfigurationDossierTableProps = {
   dossiers: TechnicalConfigurationDossierListItemWire[]
   isLoading: boolean
   isActionPending: boolean
   openingDossierId: string | null
-  page: number
-  pageSize: number
-  total: number
+  pagination: TechnicalConfigurationDossierPagination
   onDelete: (dossier: TechnicalConfigurationDossierListItemWire) => void
   onEdit: (dossier: TechnicalConfigurationDossierWire) => void
   onOpen: (id: string) => void
-  onPageChange: (page: number) => void
 }
 
 /** Renders the paginated dossier list and open actions. */
@@ -38,16 +44,11 @@ export function TechnicalConfigurationDossierTable({
   isLoading,
   isActionPending,
   openingDossierId,
-  page,
-  pageSize,
-  total,
+  pagination,
   onDelete,
   onEdit,
   onOpen,
-  onPageChange,
 }: Readonly<TechnicalConfigurationDossierTableProps>) {
-  const pageCount = Math.max(1, Math.ceil(total / pageSize))
-
   if (isLoading) {
     return (
       <div className="space-y-3" aria-label="Đang tải hồ sơ cấu hình">
@@ -67,17 +68,6 @@ export function TechnicalConfigurationDossierTable({
         <p className="mt-1 text-sm text-muted-foreground">
           Tạo hồ sơ đầu tiên để bắt đầu không gian làm việc.
         </p>
-        {page > 1 ? (
-          <Button
-            type="button"
-            variant="outline"
-            className="mt-5"
-            onClick={() => onPageChange(page - 1)}
-          >
-            <ChevronLeft className="size-4" aria-hidden="true" />
-            Quay lại trang trước
-          </Button>
-        ) : null}
       </div>
     )
   }
@@ -142,36 +132,18 @@ export function TechnicalConfigurationDossierTable({
         </Table>
       </div>
 
-      {pageCount > 1 ? (
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">
-            Trang {page} / {pageCount}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              aria-label="Trang trước"
-              title="Trang trước"
-              disabled={page <= 1}
-              onClick={() => onPageChange(page - 1)}
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              aria-label="Trang sau"
-              title="Trang sau"
-              disabled={page >= pageCount}
-              onClick={() => onPageChange(page + 1)}
-            >
-              <ChevronRight className="size-4" />
-            </Button>
-          </div>
-        </div>
+      {pagination.pageCount > 1 ? (
+        <DataTablePagination.Navigation
+          currentPage={pagination.page}
+          totalPages={pagination.pageCount}
+          canPreviousPage={pagination.canPreviousPage}
+          canNextPage={pagination.canNextPage}
+          onFirstPage={() => pagination.onPageChange(1)}
+          onPreviousPage={() => pagination.onPageChange(pagination.page - 1)}
+          onNextPage={() => pagination.onPageChange(pagination.page + 1)}
+          onLastPage={() => pagination.onPageChange(pagination.pageCount)}
+          className="sm:justify-between"
+        />
       ) : null}
     </div>
   )


### PR DESCRIPTION
## Summary
- move dossier list paging state to `useServerPagination` while keeping RPC pagination server-side with fixed page size 20
- replace local page math and buttons with `DataTablePagination.Navigation`
- add `user-event` regressions for previous/next/first/last navigation, query isolation, and delete-last-row fallback

## Verification
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe` plus semantic reuse review
- `typecheck`
- 6 focused Vitest files, 51 tests passed
- React Doctor 100/100
- independent review: zero findings

Browser testing was intentionally omitted per request. No SQL migration or live DB write.

Closes #871

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reused shared dossier pagination in Technical Configurations to replace custom paging logic and unify navigation. Keeps server-side pagination with a fixed page size of 20. Addresses Linear #871.

- **Refactors**
  - Switched to `useServerPagination`; RPC `total` drives `pageCount` and next/prev state.
  - Replaced table props with a `pagination` object and `DataTablePagination.Navigation`.
  - Removed custom math, the empty-page back button, and brittle source assertions in tests.

- **Bug Fixes**
  - Keeps RPC page isolation during navigation.
  - Returns to the previous page after deleting the last row on a later page.

<sup>Written for commit c4fe82c9897d763d892eb7ce3b5c873719c461bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated technical configuration dossier lists with server-side pagination for more efficient browsing.
  * Added first, previous, next, and last page navigation.
  * Pagination now stays synchronized with available results and page size.
* **Bug Fixes**
  * Removing the final item from a later page now automatically returns to the previous available page.
  * Improved empty-page handling to prevent users from getting stuck on unavailable pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->