### PR TITLE
feat(technical-config): add P1A additive subgroup schema

### DIFF
--- a/src/app/api/rpc/__tests__/technical-configuration-baseline-subgroups-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-baseline-subgroups-migration.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { basename, join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATIONS_DIR = join(process.cwd(), "supabase", "migrations")
+const MIGRATION_FILE = "20260807091720_technical_configuration_baseline_subgroups.sql"
+const MIGRATION_SUFFIX = "_technical_configuration_baseline_subgroups.sql"
+const PREDECESSOR_FILE = "20260806031201_technical_configuration_dossier_delete_audit.sql"
+
+function listMigrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR, { encoding: "utf8", recursive: true })
+    .filter((file) => file.endsWith(".sql"))
+    .sort()
+}
+
+function getMigrationTimestamp(filePath: string): number {
+  const match = /^(\d{8}|\d{14})_/.exec(basename(filePath))
+  if (!match) {
+    throw new Error(`Migration file lacks a timestamp prefix: ${filePath}`)
+  }
+
+  return Number(match[1].length === 8 ? `${match[1]}000000` : match[1])
+}
+
+const migrationFiles = listMigrationFiles()
+const matchingFiles = migrationFiles.filter((file) => file.endsWith(MIGRATION_SUFFIX))
+const migrationSource =
+  matchingFiles.length === 1 ? readFileSync(join(MIGRATIONS_DIR, matchingFiles[0]), "utf8") : ""
+
+describe("technical configuration baseline P1A subgroup migration", () => {
+  it("adds exactly one correctly ordered migration", () => {
+    expect(matchingFiles).toEqual([MIGRATION_FILE])
+    expect(getMigrationTimestamp(MIGRATION_FILE)).toBeGreaterThan(
+      getMigrationTimestamp(PREDECESSOR_FILE)
+    )
+  })
+
+  it("creates the ordered subgroup schema with scoped ownership", () => {
+    expect(migrationSource).toContain(
+      "CREATE TABLE public.technical_configuration_baseline_subgroups"
+    )
+    expect(migrationSource).toMatch(/id UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/)
+    expect(migrationSource).toMatch(/baseline_version_id UUID NOT NULL/)
+    expect(migrationSource).toMatch(/group_id UUID NOT NULL/)
+    expect(migrationSource).toMatch(/name TEXT NOT NULL CHECK \(btrim\(name\) <> ''\)/)
+    expect(migrationSource).toMatch(/sort_order INTEGER NOT NULL CHECK \(sort_order > 0\)/)
+    expect(migrationSource).toMatch(/created_at TIMESTAMPTZ NOT NULL DEFAULT now\(\)/)
+    expect(migrationSource).toMatch(/created_by BIGINT NOT NULL/)
+    expect(migrationSource).toMatch(/updated_at TIMESTAMPTZ NOT NULL DEFAULT now\(\)/)
+    expect(migrationSource).toMatch(/updated_by BIGINT NOT NULL/)
+    expect(migrationSource).toMatch(
+      /CONSTRAINT tc_baseline_subgroups_id_scope_key\s+UNIQUE \(id, group_id, baseline_version_id\)/
+    )
+    expect(migrationSource).toMatch(
+      /CONSTRAINT tc_baseline_subgroups_group_sort_key\s+UNIQUE \(group_id, sort_order\) DEFERRABLE INITIALLY IMMEDIATE/
+    )
+    expect(migrationSource).toMatch(
+      /CONSTRAINT tc_baseline_subgroups_group_scope_fkey\s+FOREIGN KEY \(group_id, baseline_version_id\)\s+REFERENCES public\.technical_configuration_baseline_groups \(id, baseline_version_id\)\s+ON DELETE CASCADE/
+    )
+  })
+
+  it("keeps existing criteria direct while adding nullable subgroup ownership", () => {
+    expect(migrationSource).toMatch(
+      /ALTER TABLE public\.technical_configuration_baseline_criteria\s+ADD COLUMN subgroup_id UUID;/
+    )
+    expect(migrationSource).not.toMatch(/ADD COLUMN subgroup_id UUID\s+(?:DEFAULT|NOT NULL)/i)
+    expect(migrationSource).not.toMatch(
+      /ALTER TABLE public\.technical_configuration_baseline_criteria\s+ALTER COLUMN subgroup_id\s+SET (?:DEFAULT|NOT NULL)/i
+    )
+    expect(migrationSource).toMatch(
+      /CONSTRAINT tc_baseline_criteria_subgroup_scope_fkey\s+FOREIGN KEY \(subgroup_id, group_id, baseline_version_id\)\s+REFERENCES public\.technical_configuration_baseline_subgroups\s+\(id, group_id, baseline_version_id\)\s+ON DELETE NO ACTION\s+DEFERRABLE INITIALLY DEFERRED/
+    )
+    expect(migrationSource).not.toMatch(
+      /UPDATE\s+public\.technical_configuration_baseline_criteria/i
+    )
+    expect(migrationSource).not.toMatch(
+      /ALTER COLUMN\s+(?:id|baseline_version_id|group_id|criterion_code|sort_order)/i
+    )
+  })
+
+  it("adds only the hierarchy read indexes required by P1A", () => {
+    expect(migrationSource).toContain("CREATE INDEX tc_baseline_subgroups_version_order_idx")
+    expect(migrationSource).toMatch(
+      /ON public\.technical_configuration_baseline_subgroups\s+\(baseline_version_id, group_id, sort_order, id\)/
+    )
+    expect(migrationSource).toContain("CREATE INDEX tc_baseline_criteria_subgroup_order_idx")
+    expect(migrationSource).toMatch(
+      /ON public\.technical_configuration_baseline_criteria\s+\(subgroup_id, sort_order, id\)\s+WHERE subgroup_id IS NOT NULL/
+    )
+  })
+
+  it("keeps subgroup storage RPC-only and deny-by-default", () => {
+    expect(migrationSource).toContain(
+      "ALTER TABLE public.technical_configuration_baseline_subgroups ENABLE ROW LEVEL SECURITY"
+    )
+    expect(migrationSource).toMatch(
+      /CREATE POLICY technical_configuration_baseline_subgroups_no_client_access\s+ON public\.technical_configuration_baseline_subgroups\s+FOR ALL\s+TO anon, authenticated\s+USING \(false\)\s+WITH CHECK \(false\)/
+    )
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON TABLE public.technical_configuration_baseline_subgroups FROM PUBLIC, anon, authenticated"
+    )
+    expect(migrationSource).toContain(
+      "GRANT ALL ON TABLE public.technical_configuration_baseline_subgroups TO service_role"
+    )
+
+    const tablePrivilegeStatements =
+      migrationSource.match(/\b(?:GRANT|REVOKE)\b[^;]*\bON TABLE public\.[^;]+;/gi) ?? []
+    expect(tablePrivilegeStatements).toHaveLength(2)
+    for (const statement of tablePrivilegeStatements) {
+      expect(statement).toContain("public.technical_configuration_baseline_subgroups")
+    }
+  })
+
+  it("does not redefine functions, RPC grants, or existing criterion values", () => {
+    expect(migrationSource).not.toMatch(
+      /\b(?:(?:CREATE(?:\s+OR\s+REPLACE)?|ALTER|DROP)\s+(?:FUNCTION|PROCEDURE)|COMMENT\s+ON\s+(?:FUNCTION|PROCEDURE))\b/i
+    )
+    expect(migrationSource).not.toMatch(/\b(?:GRANT|REVOKE)\b[^;]*\bON\s+FUNCTION\b/i)
+    expect(migrationSource).not.toMatch(
+      /\b(?:INSERT\s+INTO|DELETE\s+FROM|UPDATE|MERGE\s+INTO|TRUNCATE(?:\s+TABLE)?)\s+public\./i
+    )
+    expect(migrationSource).not.toMatch(
+      /ALTER TABLE public\.technical_configuration_(?:dossiers|baseline_versions|baseline_groups)\b/i
+    )
+
+    const criterionAlterStatements =
+      migrationSource.match(
+        /ALTER TABLE public\.technical_configuration_baseline_criteria[\s\S]*?;/g
+      ) ?? []
+    expect(criterionAlterStatements).toHaveLength(2)
+  })
+
+  it("documents the schema-only boundary and data-preserving rollback", () => {
+    expect(migrationSource).toContain("P1A is schema-only")
+    expect(migrationSource).toContain("Existing criteria remain direct children")
+    expect(migrationSource).toContain("Never drop populated hierarchy data")
+  })
+})

--- a/supabase/migrations/20260807091720_technical_configuration_baseline_subgroups.sql
+++ b/supabase/migrations/20260807091720_technical_configuration_baseline_subgroups.sql
@@ -1,0 +1,55 @@
+-- P1A is schema-only: it adds hierarchy storage without changing RPC or runtime behavior.
+CREATE TABLE public.technical_configuration_baseline_subgroups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  baseline_version_id UUID NOT NULL,
+  group_id UUID NOT NULL,
+  name TEXT NOT NULL CHECK (btrim(name) <> ''),
+  sort_order INTEGER NOT NULL CHECK (sort_order > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  CONSTRAINT tc_baseline_subgroups_id_scope_key
+    UNIQUE (id, group_id, baseline_version_id),
+  CONSTRAINT tc_baseline_subgroups_group_sort_key
+    UNIQUE (group_id, sort_order) DEFERRABLE INITIALLY IMMEDIATE,
+  CONSTRAINT tc_baseline_subgroups_group_scope_fkey
+    FOREIGN KEY (group_id, baseline_version_id)
+    REFERENCES public.technical_configuration_baseline_groups (id, baseline_version_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX tc_baseline_subgroups_version_order_idx
+  ON public.technical_configuration_baseline_subgroups
+  (baseline_version_id, group_id, sort_order, id);
+
+ALTER TABLE public.technical_configuration_baseline_subgroups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY technical_configuration_baseline_subgroups_no_client_access
+  ON public.technical_configuration_baseline_subgroups
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.technical_configuration_baseline_subgroups FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.technical_configuration_baseline_subgroups TO service_role;
+
+-- Existing criteria remain direct children because subgroup ownership is nullable and unfilled.
+ALTER TABLE public.technical_configuration_baseline_criteria
+  ADD COLUMN subgroup_id UUID;
+
+ALTER TABLE public.technical_configuration_baseline_criteria
+  ADD CONSTRAINT tc_baseline_criteria_subgroup_scope_fkey
+  FOREIGN KEY (subgroup_id, group_id, baseline_version_id)
+  REFERENCES public.technical_configuration_baseline_subgroups
+    (id, group_id, baseline_version_id)
+  ON DELETE NO ACTION
+  DEFERRABLE INITIALLY DEFERRED;
+
+CREATE INDEX tc_baseline_criteria_subgroup_order_idx
+  ON public.technical_configuration_baseline_criteria
+  (subgroup_id, sort_order, id)
+  WHERE subgroup_id IS NOT NULL;
+
+-- Never drop populated hierarchy data; rollback should retain this additive schema.


### PR DESCRIPTION
## Summary

- add ordered, RPC-only `technical_configuration_baseline_subgroups` storage
- add nullable composite-scoped `technical_configuration_baseline_criteria.subgroup_id`
- add exact constraints, read indexes, audit ownership, RLS deny policy, revokes, and `service_role` grant
- lock the schema-only/additive-only contract with a focused migration test

## Pre-edit P0 gate

- synchronized from `main` commit `195b5be8`
- live read-only counts matched P0: 5 dossiers, 3 versions, 3 drafts, 0 locked, 12 groups, 155 criteria, 0 citations, 0 option responses, 5 manual assessments
- all five integrity checks remained zero
- subgroup table and criterion `subgroup_id` were absent
- relevant RPC signatures, `SECURITY DEFINER`, pinned `search_path`, ACLs, and two-level behavior were unchanged
- Code Review Graph/GitNexus confirmed no runtime execution-flow impact for this two-file schema/test diff

## TDD evidence

- RED: focused test exited 1 because the migration suffix did not exist (`6 failed, 1 passed`)
- GREEN: focused test passed `7/7` after the minimal migration
- independent review findings tightened nullable/default, DML, function/procedure, privilege, and existing-table ALTER guards

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js exec openspec validate revise-technical-configuration-baseline-hierarchy --strict`
- 7 focused/existing migration test files: `65/65` tests passed
- React Doctor changed-file scan: `100/100`
- Lefthook pre-commit and pre-push gates passed

## Deploy boundary

- schema-only and additive-only
- no existing-row DML or criterion backfill
- no RPC/function/grant/runtime/generated-type changes
- existing criteria remain direct main-section children with unchanged identity and linkage
- rollback retains the additive schema; populated hierarchy data must never be dropped

## Authorized live apply and phase gate

- applied through Supabase MCP as `technical_configuration_baseline_subgroups`, live migration version `20260807102425`
- catalog gate passed: 9 expected subgroup columns, nullable/no-default criterion `subgroup_id`, 4 constraints, 2 indexes, RLS deny policy, zero client grants, and all 7 expected `service_role` table privileges
- data gate passed: 0 subgroup rows; all 155 criteria remain direct children; identity digest unchanged at `cc0afe6112991a7750811e3bbb951841`
- RPC gate passed: 15 definitions/signatures/ACLs checked with 0 mismatches
- representative counts: 5 dossiers, 3 baseline versions, 3 drafts, 12 groups, 0 subgroups, 155 criteria
- security advisor reported no P1A subgroup-specific finding
- performance advisor reported INFO notices for the two new FK/index pairs; reviewed as expected linter limitations for composite/partial index coverage and an empty new table, with no contract change required

Issue #876 remains open until this PR merges.

Refs #876


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds schema-only P1A baseline subgroup storage to support hierarchical criteria for technical configuration (supports #876). Introduces `technical_configuration_baseline_subgroups` and a nullable `subgroup_id` on criteria with no runtime or RPC changes.

- **Migration**
  - Created ordered `public.technical_configuration_baseline_subgroups` with composite-scope constraints, FK to groups, RLS deny-by-default, and `service_role` grant.
  - Added read indexes for subgroup listing and criteria-by-subgroup queries.
  - Added nullable `subgroup_id` FK on `technical_configuration_baseline_criteria`; no backfill and existing relationships unchanged.
  - Added focused migration test to verify file ordering, constraints, RLS, and schema-only/additive boundary.

<sup>Written for commit d841d29d4e0f62a06329501602415989c8d771cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for organizing technical configuration baselines into ordered subgroups.
  - Baseline criteria can optionally belong to a subgroup while remaining directly associated with the baseline when unassigned.
  - Added safeguards for subgroup ownership, ordering, and data integrity.

- **Bug Fixes**
  - Existing baseline criteria remain unchanged during the migration.

- **Documentation**
  - Added rollback guidance confirming the migration preserves existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->