### PR TITLE
fix(technical-config): address PR 899 review findings

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p3d-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p3d-tdd-plan.md
@@ -15,8 +15,9 @@ remain unreachable from the production baseline screen until P6B.
   `main`;
 - GitNexus matched `b959e1b8` at preflight and was reindexed against the final
   staged P3D diff before review;
-- no migration, generated database type, Supabase CLI command, or live database
-  read/write is needed for this client-only leaf.
+- this client-only leaf adds no migration, generated database type, Supabase CLI
+  command, or live database write; its server-authoritative preview may invoke
+  the existing read-only RPC path.
 
 ## Scope Decisions
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -208,8 +208,9 @@ production baseline screen.
 
 Depends on: P3B, P3C, and P2B.
 
-Deploy boundary: end-to-end XLSX v2 import is wired and tested but remains unreachable
-on the production baseline screen.
+Deploy boundary: the dormant XLSX v2 preview and client apply contract are wired and
+tested, while production apply remains unreachable and fail-closed on the baseline
+screen.
 
 - [x] P3D.1 Restrict file selection to `.xlsx` and route both legacy and v2 workbooks
       through the compatible parser boundary.

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-lifecycle.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-lifecycle.test.tsx
@@ -60,7 +60,7 @@ async function prepareConfirmedPreview(user: ReturnType<typeof userEvent.setup>)
 
 describe("technical configuration baseline hierarchy import lifecycle", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     compatibleParser.parseFile.mockResolvedValue(createV2ParseResult())
     hierarchyImportRpc.previewHierarchyImport.mockResolvedValue(createHierarchyPreview())
     hierarchyImportRpc.applyHierarchyImport.mockResolvedValue({
@@ -262,13 +262,26 @@ describe("technical configuration baseline hierarchy import lifecycle", () => {
     const user = userEvent.setup()
     const onConflict = vi.fn().mockResolvedValue(undefined)
     const oldPreview = createAuthoritativeHierarchyPreview()
-    const refreshedParsed = createV2ParseResult()
-    refreshedParsed.metadata.baseline_revision = 12
-    const refreshedPreview = createAuthoritativeHierarchyPreview()
-    refreshedPreview.data.metadata = refreshedParsed.metadata
-    const refreshedGroup = refreshedPreview.data.rows[0]
-    if (refreshedGroup?.row_type === "GROUP") {
-      refreshedGroup.group_name = "Mục chính revision 12"
+    const refreshedParsedFixture = createV2ParseResult()
+    const refreshedParsed = {
+      ...refreshedParsedFixture,
+      metadata: {
+        ...refreshedParsedFixture.metadata,
+        baseline_revision: 12,
+      },
+    }
+    const refreshedPreviewFixture = createAuthoritativeHierarchyPreview()
+    const refreshedPreview = {
+      ...refreshedPreviewFixture,
+      data: {
+        ...refreshedPreviewFixture.data,
+        metadata: refreshedParsed.metadata,
+        rows: refreshedPreviewFixture.data.rows.map((row, index) =>
+          index === 0 && row.row_type === "GROUP"
+            ? { ...row, group_name: "Mục chính revision 12" }
+            : row
+        ),
+      },
     }
     const pendingPreview = deferred<typeof refreshedPreview>()
     hierarchyImportRpc.previewHierarchyImport

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-review-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-review-regressions.test.tsx
@@ -59,7 +59,7 @@ async function prepareConfirmedPreview(user: ReturnType<typeof userEvent.setup>)
 
 describe("technical configuration hierarchy import review regressions", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     compatibleParser.parseFile.mockResolvedValue(createV2ParseResult())
     hierarchyImportRpc.previewHierarchyImport.mockResolvedValue(
       createAuthoritativeHierarchyPreview()
@@ -72,10 +72,22 @@ describe("technical configuration hierarchy import review regressions", () => {
   it("keeps preview-conflict evidence until the replacement preview succeeds", async () => {
     const user = userEvent.setup()
     const onConflict = vi.fn().mockResolvedValue(undefined)
-    const replacementParsed = createV2ParseResult()
-    replacementParsed.metadata.baseline_revision = 12
-    const replacementPreview = createAuthoritativeHierarchyPreview()
-    replacementPreview.data.metadata = replacementParsed.metadata
+    const replacementParsedFixture = createV2ParseResult()
+    const replacementParsed = {
+      ...replacementParsedFixture,
+      metadata: {
+        ...replacementParsedFixture.metadata,
+        baseline_revision: 12,
+      },
+    }
+    const replacementPreviewFixture = createAuthoritativeHierarchyPreview()
+    const replacementPreview = {
+      ...replacementPreviewFixture,
+      data: {
+        ...replacementPreviewFixture.data,
+        metadata: replacementParsed.metadata,
+      },
+    }
     const pendingPreview = deferred<typeof replacementPreview>()
     hierarchyImportRpc.previewHierarchyImport
       .mockRejectedValueOnce(
@@ -145,26 +157,36 @@ describe("technical configuration hierarchy import review regressions", () => {
       />
     )
 
-    const replacementParsed = createV2ParseResult()
-    replacementParsed.metadata.baseline_revision = 12
-    const invalidPreview = createAuthoritativeHierarchyPreview()
-    invalidPreview.data.metadata = replacementParsed.metadata
-    invalidPreview.data.effects = null
-    invalidPreview.errors = [
-      {
-        row: 27,
-        code: "empty_content",
-        column: "content",
-        message: "Nội dung bắt buộc không được để trống.",
+    const replacementParsedFixture = createV2ParseResult()
+    const replacementParsed = {
+      ...replacementParsedFixture,
+      metadata: {
+        ...replacementParsedFixture.metadata,
+        baseline_revision: 12,
       },
-    ]
+    }
+    const invalidPreviewFixture = createAuthoritativeHierarchyPreview()
+    const invalidPreview = {
+      ...invalidPreviewFixture,
+      data: {
+        ...invalidPreviewFixture.data,
+        metadata: replacementParsed.metadata,
+        effects: null,
+      },
+      errors: [
+        {
+          row: 27,
+          code: "empty_content",
+          column: "content",
+          message: "Nội dung bắt buộc không được để trống.",
+        },
+      ],
+    }
     compatibleParser.parseFile.mockResolvedValueOnce(replacementParsed)
     hierarchyImportRpc.previewHierarchyImport.mockResolvedValueOnce(invalidPreview)
 
-    await user.upload(
-      screen.getByLabelText("Chọn workbook cấu hình phân cấp"),
-      createHierarchyImportFile("invalid-replacement.xlsx")
-    )
+    const fileInput = screen.getByLabelText("Chọn workbook cấu hình phân cấp")
+    await user.upload(fileInput, createHierarchyImportFile("invalid-replacement.xlsx"))
 
     expect(
       await screen.findByRole("alert", { name: "Lỗi nhập cấu hình phân cấp" })
@@ -173,6 +195,30 @@ describe("technical configuration hierarchy import review regressions", () => {
     expect(screen.getByText("Mục chính từ máy chủ")).toBeInTheDocument()
     expect(screen.queryByText("invalid-replacement.xlsx")).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Áp dụng thay thế toàn bộ" })).toBeDisabled()
+    expect((fileInput as HTMLInputElement).value).toBe("")
+  })
+
+  it("clears the native file input after a parse failure so the same file can be retried", async () => {
+    const user = userEvent.setup()
+    const file = createHierarchyImportFile("retry-same-file.xlsx")
+    compatibleParser.parseFile
+      .mockRejectedValueOnce(new Error("workbook parse failed"))
+      .mockResolvedValueOnce(createV2ParseResult())
+    render(<HierarchyImportHarness />)
+
+    await user.click(screen.getByRole("button", { name: "Nhập cấu hình phân cấp" }))
+    const fileInput = screen.getByLabelText("Chọn workbook cấu hình phân cấp")
+    await user.upload(fileInput, file)
+
+    expect(
+      await screen.findByRole("alert", { name: "Lỗi nhập cấu hình phân cấp" })
+    ).toHaveTextContent("workbook parse failed")
+    expect((fileInput as HTMLInputElement).value).toBe("")
+
+    await user.upload(fileInput, file)
+
+    await screen.findByRole("group", { name: "Xác nhận thay thế toàn bộ cấu hình" })
+    expect(compatibleParser.parseFile).toHaveBeenCalledTimes(2)
   })
 
   it("announces the destructive apply operation separately from previewing", async () => {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineHierarchyImport.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineHierarchyImport.ts
@@ -212,6 +212,7 @@ export function useTechnicalConfigurationBaselineHierarchyImport({
         if (attempt === parseAttemptRef.current) {
           setIsParsing(false)
           setIsPreviewing(false)
+          if (fileInputRef.current) fileInputRef.current.value = ""
         }
       }
     },


### PR DESCRIPTION
## Summary
- clear the native hierarchy-import file input after each completed parse/preview attempt so the same path can be retried
- preserve the existing React evidence state while adding parse and invalid-replacement regression coverage
- correct P3D database and deploy-boundary wording
- remove fixture mutation and reset one-time mock implementations between lifecycle tests

## PR #899 triage
Accepted: database-scope wording, P3D apply boundary, same-file retry, immutable test fixtures, and resetAllMocks.
Not applied: Next.js skill gate (no Next framework behavior changed), explicit return annotations (no repository rule and nearby RPC client methods use inference), dialog context provider (premature P4+/activation abstraction), and ReactNode annotation (unnecessary contract broadening).

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- focused P3D tests: 63/63
- technical-configuration suite: 750/750
- React Doctor: 100/100
- OpenSpec strict validation

No migration, live DB write, production mount, or P4+ work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the hierarchy-import file input after each parse/preview attempt so the same `.xlsx` can be retried, and keeps evidence state until a replacement preview succeeds. Also fixes P3D wording and strengthens tests by avoiding fixture mutation and using `vi.resetAllMocks()`.

- **Bug Fixes**
  - Clear native file input on parse/preview completion or failure (enables same-file retry).
  - Preserve preview-conflict evidence during replacement flows, including invalid replacements (apply stays disabled).
  - Added regression tests, including parse-failure same-file retry.

- **Refactors**
  - Use `vi.resetAllMocks()` in lifecycle suites and stop mutating fixtures.
  - Update OpenSpec wording: client-only leaf, read-only RPC path, and deploy boundary (preview wired; apply unreachable/fail-closed).

<sup>Written for commit 6914162f30a9ac605c5bc7538dc6a55d94506dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users can now select the same import file again after parsing or preview failures.
  * Invalid replacement previews preserve existing stale evidence while resetting the file selector.
  * Improved recovery when refreshed data is available after a conflict.

* **Tests**
  * Expanded coverage for import retries, parse failures, stale conflicts, and invalid previews.
  * Improved test isolation for more reliable results.

* **Documentation**
  * Clarified that preview and client-side apply remain non-production and fail-closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->