### PR TITLE
feat(technical-config): add P4C hierarchy authoring controls

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p4c-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p4c-tdd-plan.md
@@ -1,0 +1,205 @@
+# P4C TDD Plan - Hierarchical Authoring Controls
+
+## Goal
+
+Complete subgroup and criterion hierarchy authoring against the P1E mutation
+contracts while keeping every P4C control unmounted from the production baseline
+screen until P6A. Preserve the P4B hierarchy presentation and the existing explicit
+Save, dirty-navigation, conflict, lock, reload, focus, scrolling, validation, pending
+buffer, accessibility, and responsive contracts.
+
+## Preflight
+
+- Base: clean `main` at `89f39c5b`.
+- Tracking issue: `#889`.
+- Branch: `feat/889-p4c-hierarchical-authoring-controls`.
+- Dependencies: P4B `#888` and P1E `#880` are present on the base commit.
+- Code Review Graph and GitNexus were current at `89f39c5b`; reindex after the
+  implementation before final impact review.
+- Read-only live Supabase inspection confirmed the P1E subgroup and hierarchy
+  criterion functions are deployed with `SECURITY DEFINER` and fixed
+  `search_path`, but remain revoked from `authenticated` as required until P6A.
+- No migration, generated database type, RPC function, allowlist activation, grant,
+  or live database write belongs to P4C.
+
+## Scope Decisions
+
+### Keep production authoring unmounted
+
+Hierarchy authoring is an explicit opt-in component capability. Tests mount the
+editor with the capability enabled; `TechnicalConfigurationBaselineTab` continues to
+omit it. Hiding with CSS or rendering disabled controls is insufficient because P6A
+owns production activation.
+
+### Extend the canonical nested draft
+
+All UI actions delegate to the P4A immutable hierarchy helpers. Do not create a
+parallel UI tree or regenerate criterion keys, IDs, or codes when criteria move.
+Direct criteria remain before complete subgroup blocks, and section/subgroup
+ordinals are derived from current array positions after every structural edit.
+
+### Scope multiline state by criterion owner
+
+Reuse `useTechnicalConfigurationBulkEntrySessions` with stable owner session keys:
+
+- a main-section key for direct criteria;
+- a subgroup-qualified key for subgroup criteria.
+
+Pending input remains local until accepted or cancelled, contributes to dirty
+navigation blocking, disables Save, survives collapse/remount, and is cleared only
+for the owner that is deleted or explicitly cancelled.
+
+### Preserve one Save transaction model
+
+Extend the existing baseline save engine and typed RPC client. Do not add a second
+Save button or autosave structural actions. The save sequence must:
+
+1. validate before the first mutation;
+2. create/update required parent rows;
+3. create, update, or move criteria while preserving identity;
+4. move any surviving criteria out of parents that will be removed;
+5. delete removed criteria, then empty removed subgroups, then removed sections;
+6. reorder the complete remaining criterion-owner, subgroup, and section ID sets;
+7. chain every returned revision into the next call;
+8. preserve accepted progress and all remaining local edits on partial failure.
+
+Conflict detection, explicit reload, locked-version read-only rendering, and
+save-resume behavior continue through `useTechnicalConfigurationBaselineEditor`.
+
+### Extract before source files cross the threshold
+
+The current editor, group section, baseline editor hook, and save steps are already
+near the 350-line extraction threshold. Put new hierarchy-specific behavior in
+grep-friendly module files instead of expanding those owners past the threshold.
+No source file may exceed 450 lines.
+
+## File Ownership
+
+Expected production changes:
+
+- `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx`
+  - accept the opt-in authoring capability and route hierarchy callbacks;
+  - preserve the existing scroll container, summary, Save, and focus behavior.
+- `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection.tsx`
+  - mount subgroup add controls only when authoring is enabled;
+  - pass owner-scoped entry and move callbacks without changing direct workflows.
+- `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection.tsx`
+  - support accessible rename/delete/reorder and subgroup entry controls;
+  - preserve independent disclosure and focus acknowledgement.
+- `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria.tsx`
+  and `TechnicalConfigurationCriteriaSpreadsheet.tsx`
+  - expose criterion move actions without duplicating criterion row rendering.
+- New hierarchy-specific component/type files under
+  `src/app/(app)/technical-configurations/_components/`
+  - keep control menus, owner choices, and callback contracts out of near-limit files.
+- `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor.ts`
+  and a new hierarchy-authoring hook
+  - compose subgroup CRUD, criterion moves, owner-scoped entry, focus, and buffer
+    cleanup with existing inline editing.
+- `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions.ts`
+  - synchronize stable direct/subgroup owner session keys.
+- `src/app/(app)/technical-configurations/baseline-types.ts` and
+  `_hooks/useTechnicalConfigurationBaseline.ts`
+  - type the already-deployed P1E mutation paths;
+  - keep their names in a hierarchy-only registry that is not imported by
+    `BASELINE_RPC_FUNCTIONS` or either proxy role set;
+  - assert that the production proxy still rejects those names until P6A.
+- `src/app/(app)/technical-configurations/technical-configuration-baseline-save.ts`,
+  `technical-configuration-baseline-save-mappers.ts`, and extracted hierarchy save
+  steps
+  - diff and persist subgroup rows and criterion ownership/order while preserving
+    partial-save progress.
+
+Expected tests:
+
+- a focused authoring-controls test for subgroup CRUD/reorder, criterion moves,
+  ordinals, keyboard/focus, validation, and responsive layout;
+- an owner-scoped entry test for direct/subgroup single-row and multiline buffers;
+- save-engine tests for RPC choice, revision chaining, identity, canonical order,
+  conflict, deletion-before-reorder, and partial progress after subgroup creation
+  and criterion movement;
+- tab/workflow tests for production isolation, dirty navigation, reload blocking,
+  conflict recovery, structural dirty/pending lock blocking, subgroup-only lock
+  eligibility, lock replacement, and save-resume.
+
+Extract or split test files around 350 lines and never exceed 450 lines. Put P4C save
+cases in a new hierarchy-save module rather than extending the existing oversized
+legacy save test.
+
+## TDD Slices
+
+1. RED: production baseline rendering contains no P4C controls, while an opted-in
+   editor harness expects accessible subgroup create/rename/delete/reorder controls.
+2. GREEN: add the opt-in authoring contract and minimum subgroup controls; keep the
+   production tab call site unchanged.
+3. RED: subgroup edits and criterion moves preserve stable criterion identity,
+   canonical owner order, focus, and normalized Roman/decimal labels.
+4. GREEN: compose the existing P4A hierarchy helpers through a hierarchy-specific
+   inline editor hook and focused UI controls.
+5. RED: direct and subgroup single-row/multiline entry use independent buffers,
+   survive structural collapse, block Save/navigation while pending, and clear only
+   the deleted owner.
+6. GREEN: generalize bulk-session synchronization to stable owner keys and wire
+   subgroup entry through the existing workbench.
+7. RED: save tests require subgroup create/update/delete/reorder plus hierarchy
+   criterion create/move/reorder calls with exact revision chaining,
+   deletion-before-reorder, and no legacy identity replacement.
+8. GREEN: extend the typed client and save-step engine using only deployed P1E
+   function names kept outside the production allowlist; preserve partial progress
+   and conflict classification.
+9. RED: user-event save-resume tests cover successful save, late-step failure,
+   retry immediately after subgroup creation and criterion movement without
+   repeating accepted calls, stale-revision conflict, explicit reload, pending
+   reload/lock blocking, subgroup-only lock eligibility, and locked-version
+   replacement.
+10. GREEN/REFACTOR: preserve current hook orchestration, validation/focus contracts,
+    definite-height scrolling, accessibility, and responsive classes; remove any
+    semantic duplication and keep files within limits.
+
+Each RED must be run and observed failing for the intended missing P4C behavior
+before its production implementation.
+
+## Verification
+
+Run through context-mode in repository order:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js exec vitest run \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.tsx' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx'
+node scripts/npm-run.js exec vitest run \
+  'src/app/(app)/technical-configurations'
+node scripts/npm-run.js run react-doctor
+openspec validate revise-technical-configuration-baseline-hierarchy --strict
+```
+
+Also verify:
+
+- all changed controls are absent from the production baseline tab DOM;
+- the local client uses the exact deployed P1E function names and no server
+  allowlist/grant changed; automated tests prove the hierarchy names remain absent
+  from both proxy role sets;
+- Code Review Graph changed-file impact and GitNexus changed-symbol/process impact
+  after reindexing the implemented branch;
+- semantic deduplication against existing editor controls, disclosure, bulk-entry,
+  focus, ordinal, operation-lock, and conflict/reload helpers;
+- touched source-file line counts and responsive/accessibility regressions;
+- `mix-gpt-5.6-sol` at the highest available reasoning level until the reviewer
+  reports `Zero findings`.
+
+## Completion Boundary
+
+Before reporting:
+
+- mark only P4C tasks complete in `tasks.md`;
+- update Issue `#889` with verification evidence while leaving it open;
+- commit and push the feature branch through enabled Lefthook hooks;
+- do not open/merge a pull request, close the issue, activate P4C controls, change
+  server grants/allowlists, or write to live Supabase before the user reviews the
+  result and authorizes landing.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p4c-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p4c-tdd-plan.md
@@ -165,16 +165,20 @@ Run through context-mode in repository order:
 
 ```bash
 node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:ts-docstrings
 node scripts/npm-run.js run verify:no-explicit-any
 node scripts/npm-run.js run verify:dedupe
 node scripts/npm-run.js run typecheck
 node scripts/npm-run.js exec vitest run \
   'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx' \
-  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.tsx' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts' \
   'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx' \
   'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx'
 node scripts/npm-run.js exec vitest run \
   'src/app/(app)/technical-configurations'
+node scripts/npm-run.js exec vitest run \
+  'src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts'
 node scripts/npm-run.js run react-doctor
 openspec validate revise-technical-configuration-baseline-hierarchy --strict
 ```
@@ -189,6 +193,8 @@ Also verify:
   after reindexing the implemented branch;
 - semantic deduplication against existing editor controls, disclosure, bulk-entry,
   focus, ordinal, operation-lock, and conflict/reload helpers;
+- `next-best-practices` followed by `react-best-practices` for the final
+  Next.js/React diff review;
 - touched source-file line counts and responsive/accessibility regressions;
 - `mix-gpt-5.6-sol` at the highest available reasoning level until the reviewer
   reports `Zero findings`.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -262,12 +262,12 @@ Depends on: P4B and P1E.
 Deploy boundary: complete subgroup authoring is wired against already-deployed
 mutation paths but remains hidden on the production baseline screen until P6A.
 
-- [ ] P4C.1 Add subgroup create/rename/delete/reorder and criterion move controls.
-- [ ] P4C.2 Support direct and subgroup-scoped single-row and multiline criterion entry.
-- [ ] P4C.3 Normalize Roman and decimal display ordinals after every structural edit.
-- [ ] P4C.4 Preserve explicit Save, dirty navigation, conflict recovery, lock blocking,
+- [x] P4C.1 Add subgroup create/rename/delete/reorder and criterion move controls.
+- [x] P4C.2 Support direct and subgroup-scoped single-row and multiline criterion entry.
+- [x] P4C.3 Normalize Roman and decimal display ordinals after every structural edit.
+- [x] P4C.4 Preserve explicit Save, dirty navigation, conflict recovery, lock blocking,
       and reload semantics.
-- [ ] P4C.5 Add user-event workflow and save-resume regression tests.
+- [x] P4C.5 Add user-event workflow and save-resume regression tests.
 
 ## Phase P5A - Aggregate Status Model
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section-fixtures.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react"
+import { render } from "@testing-library/react"
+import { vi } from "vitest"
+
+import {
+  TechnicalConfigurationBaselineGroupSection,
+  type TechnicalConfigurationBaselineGroupSectionProps,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection"
+import type {
+  TechnicalConfigurationEntryMode,
+  TechnicalConfigurationFocusTarget,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
+import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+export const group: TechnicalConfigurationBaselineEditorGroup = {
+  key: "group-2",
+  id: "group-2",
+  name: "Yêu cầu kỹ thuật",
+  criteria: [
+    {
+      key: "criterion-1",
+      id: "criterion-1",
+      criterionCode: "TC-0001",
+      title: "Nguồn điện",
+      requirementText: "Nguồn điện ổn định",
+    },
+    {
+      key: "criterion-2",
+      id: "criterion-2",
+      criterionCode: "TC-0002",
+      title: "Áp lực",
+      requirementText: "",
+    },
+  ],
+}
+
+export const pendingBulkSession: TechnicalConfigurationBulkEntrySession = {
+  input: "Yêu cầu thứ nhất\nYêu cầu thứ hai",
+  preview: null,
+}
+
+type RenderGroupSectionOptions = {
+  groupValue?: TechnicalConfigurationBaselineEditorGroup
+  initialExpanded?: boolean
+  initialMode?: TechnicalConfigurationEntryMode
+  focusTarget?: TechnicalConfigurationFocusTarget
+  disabled?: boolean
+  groupError?: string
+  bulkSession?: TechnicalConfigurationBulkEntrySession
+  hierarchyAuthoring?: TechnicalConfigurationBaselineGroupSectionProps["hierarchyAuthoring"]
+}
+
+type RenderGroupSectionResult = {
+  callbacks: Record<string, ReturnType<typeof vi.fn>>
+  events: string[]
+}
+
+export function renderGroupSection({
+  groupValue = group,
+  initialExpanded = true,
+  initialMode = "row",
+  focusTarget = null,
+  disabled = false,
+  groupError = "Tên nhóm là bắt buộc.",
+  bulkSession = pendingBulkSession,
+  hierarchyAuthoring,
+}: RenderGroupSectionOptions = {}): RenderGroupSectionResult {
+  const events: string[] = []
+  const callbacks = {
+    onExpandedChange: vi.fn(),
+    onModeChange: vi.fn(),
+    onGroupNameChange: vi.fn(),
+    onMoveGroup: vi.fn(),
+    onDeleteGroup: vi.fn(),
+    onCriterionTextChange: vi.fn(),
+    onMoveCriterion: vi.fn(),
+    onDeleteCriterion: vi.fn(),
+    onAddCriterion: vi.fn(),
+    onBulkInputChange: vi.fn(),
+    onBulkPreview: vi.fn(),
+    onBulkCancel: vi.fn(),
+    onBulkAccept: vi.fn(),
+  }
+
+  function Harness(): React.JSX.Element {
+    const [expanded, setExpanded] = useState(initialExpanded)
+    const [mode, setMode] = useState<TechnicalConfigurationEntryMode>(initialMode)
+    const props: TechnicalConfigurationBaselineGroupSectionProps = {
+      group: groupValue,
+      groupIndex: 1,
+      groupCount: 3,
+      expanded,
+      mode,
+      bulkSession,
+      groupError,
+      subgroupErrors: {},
+      criterionErrors: { "criterion-2": "Nội dung yêu cầu là bắt buộc." },
+      summaryErrorCount: 2,
+      pendingInputDescriptionId: "pending-bulk-status",
+      disabled,
+      focusTarget,
+      recentlyAcceptedCriterionKeys: new Set(["criterion-1"]),
+      ownerOptions: [],
+      hierarchyAuthoring,
+      onExpandedChange: (nextExpanded) => {
+        events.push(`expanded:${nextExpanded}`)
+        callbacks.onExpandedChange(nextExpanded)
+        setExpanded(nextExpanded)
+      },
+      onModeChange: (groupKey, nextMode) => {
+        callbacks.onModeChange(groupKey, nextMode)
+        setMode(nextMode)
+      },
+      onGroupNameChange: callbacks.onGroupNameChange,
+      onMoveGroup: callbacks.onMoveGroup,
+      onDeleteGroup: callbacks.onDeleteGroup,
+      onCriterionTextChange: callbacks.onCriterionTextChange,
+      onMoveCriterion: callbacks.onMoveCriterion,
+      onDeleteCriterion: callbacks.onDeleteCriterion,
+      onAddCriterion: (groupKey) => {
+        events.push(`add:${groupKey}`)
+        callbacks.onAddCriterion(groupKey)
+      },
+      onBulkInputChange: callbacks.onBulkInputChange,
+      onBulkPreview: callbacks.onBulkPreview,
+      onBulkCancel: callbacks.onBulkCancel,
+      onBulkAccept: callbacks.onBulkAccept,
+    }
+
+    return <TechnicalConfigurationBaselineGroupSection {...props} />
+  }
+
+  render(<Harness />)
+  return { callbacks, events }
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section-fixtures.tsx
@@ -33,6 +33,7 @@ export const group: TechnicalConfigurationBaselineEditorGroup = {
       requirementText: "",
     },
   ],
+  subgroups: [],
 }
 
 export const pendingBulkSession: TechnicalConfigurationBulkEntrySession = {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section.test.tsx
@@ -1,133 +1,13 @@
-import { useState } from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+import type { TechnicalConfigurationFocusTarget } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
 import {
-  TechnicalConfigurationBaselineGroupSection,
-  type TechnicalConfigurationBaselineGroupSectionProps,
-} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection"
-import type {
-  TechnicalConfigurationEntryMode,
-  TechnicalConfigurationFocusTarget,
-} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
-import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
-import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
-
-const group: TechnicalConfigurationBaselineEditorGroup = {
-  key: "group-2",
-  id: "group-2",
-  name: "Yêu cầu kỹ thuật",
-  criteria: [
-    {
-      key: "criterion-1",
-      id: "criterion-1",
-      criterionCode: "TC-0001",
-      title: "Nguồn điện",
-      requirementText: "Nguồn điện ổn định",
-    },
-    {
-      key: "criterion-2",
-      id: "criterion-2",
-      criterionCode: "TC-0002",
-      title: "Áp lực",
-      requirementText: "",
-    },
-  ],
-}
-
-const pendingBulkSession: TechnicalConfigurationBulkEntrySession = {
-  input: "Yêu cầu thứ nhất\nYêu cầu thứ hai",
-  preview: null,
-}
-
-type RenderGroupSectionOptions = {
-  initialExpanded?: boolean
-  initialMode?: TechnicalConfigurationEntryMode
-  focusTarget?: TechnicalConfigurationFocusTarget
-  disabled?: boolean
-  groupError?: string
-  bulkSession?: TechnicalConfigurationBulkEntrySession
-}
-
-type RenderGroupSectionResult = {
-  callbacks: Record<string, ReturnType<typeof vi.fn>>
-  events: string[]
-}
-
-function renderGroupSection({
-  initialExpanded = true,
-  initialMode = "row",
-  focusTarget = null,
-  disabled = false,
-  groupError = "Tên nhóm là bắt buộc.",
-  bulkSession = pendingBulkSession,
-}: RenderGroupSectionOptions = {}): RenderGroupSectionResult {
-  const events: string[] = []
-  const callbacks = {
-    onExpandedChange: vi.fn(),
-    onModeChange: vi.fn(),
-    onGroupNameChange: vi.fn(),
-    onMoveGroup: vi.fn(),
-    onDeleteGroup: vi.fn(),
-    onCriterionTextChange: vi.fn(),
-    onMoveCriterion: vi.fn(),
-    onDeleteCriterion: vi.fn(),
-    onAddCriterion: vi.fn(),
-    onBulkInputChange: vi.fn(),
-    onBulkPreview: vi.fn(),
-    onBulkCancel: vi.fn(),
-    onBulkAccept: vi.fn(),
-  }
-
-  function Harness(): React.JSX.Element {
-    const [expanded, setExpanded] = useState(initialExpanded)
-    const [mode, setMode] = useState<TechnicalConfigurationEntryMode>(initialMode)
-    const props: TechnicalConfigurationBaselineGroupSectionProps = {
-      group,
-      groupIndex: 1,
-      groupCount: 3,
-      expanded,
-      mode,
-      bulkSession,
-      groupError,
-      criterionErrors: { "criterion-2": "Nội dung yêu cầu là bắt buộc." },
-      summaryErrorCount: 2,
-      pendingInputDescriptionId: "pending-bulk-status",
-      disabled,
-      focusTarget,
-      recentlyAcceptedCriterionKeys: new Set(["criterion-1"]),
-      onExpandedChange: (nextExpanded) => {
-        events.push(`expanded:${nextExpanded}`)
-        callbacks.onExpandedChange(nextExpanded)
-        setExpanded(nextExpanded)
-      },
-      onModeChange: (groupKey, nextMode) => {
-        callbacks.onModeChange(groupKey, nextMode)
-        setMode(nextMode)
-      },
-      onGroupNameChange: callbacks.onGroupNameChange,
-      onMoveGroup: callbacks.onMoveGroup,
-      onDeleteGroup: callbacks.onDeleteGroup,
-      onCriterionTextChange: callbacks.onCriterionTextChange,
-      onMoveCriterion: callbacks.onMoveCriterion,
-      onDeleteCriterion: callbacks.onDeleteCriterion,
-      onAddCriterion: (groupKey) => {
-        events.push(`add:${groupKey}`)
-        callbacks.onAddCriterion(groupKey)
-      },
-      onBulkInputChange: callbacks.onBulkInputChange,
-      onBulkPreview: callbacks.onBulkPreview,
-      onBulkCancel: callbacks.onBulkCancel,
-      onBulkAccept: callbacks.onBulkAccept,
-    }
-
-    return <TechnicalConfigurationBaselineGroupSection {...props} />
-  }
-
-  render(<Harness />)
-  return { callbacks, events }
-}
+  group,
+  pendingBulkSession,
+  renderGroupSection,
+} from "./technical-configuration-baseline-group-section-fixtures"
 
 describe("TechnicalConfigurationBaselineGroupSection", () => {
   it("renders an expanded editable header with counts, validation, and pending status", () => {
@@ -231,6 +111,54 @@ describe("TechnicalConfigurationBaselineGroupSection", () => {
   it("keeps delete focusable but blocks it while the group has pending input", async () => {
     const user = userEvent.setup()
     const { callbacks } = renderGroupSection({ groupError: undefined })
+
+    const deleteButton = screen.getByRole("button", { name: "Xóa nhóm II" })
+    expect(deleteButton).not.toBeDisabled()
+    expect(deleteButton).toHaveAttribute("aria-disabled", "true")
+    expect(deleteButton).toHaveAttribute("aria-describedby", "pending-bulk-status")
+
+    await user.click(deleteButton)
+    expect(callbacks.onDeleteGroup).not.toHaveBeenCalled()
+  })
+
+  it("blocks parent deletion while a subgroup has pending multiline input", async () => {
+    const user = userEvent.setup()
+    const subgroupKey = "subgroup-1"
+    const { callbacks } = renderGroupSection({
+      groupValue: {
+        ...group,
+        subgroups: [
+          {
+            key: subgroupKey,
+            id: subgroupKey,
+            name: "Hạ tầng",
+            criteria: [],
+          },
+        ],
+      },
+      groupError: undefined,
+      bulkSession: { input: "", preview: null },
+      hierarchyAuthoring: {
+        activeOwnerKey: subgroupKey,
+        entryMode: "bulk",
+        getBulkSession: (ownerKey) =>
+          ownerKey === subgroupKey ? pendingBulkSession : { input: "", preview: null },
+        onOwnerModeChange: vi.fn(),
+        onAddSubgroup: vi.fn(),
+        onSubgroupNameChange: vi.fn(),
+        onMoveSubgroup: vi.fn(),
+        onDeleteSubgroup: vi.fn(),
+        onCriterionTextChange: vi.fn(),
+        onMoveCriterionWithinOwner: vi.fn(),
+        onMoveCriterionToOwner: vi.fn(),
+        onDeleteCriterion: vi.fn(),
+        onAddCriterion: vi.fn(),
+        onBulkInputChange: vi.fn(),
+        onBulkPreview: vi.fn(),
+        onBulkCancel: vi.fn(),
+        onBulkAccept: vi.fn(),
+      },
+    })
 
     const deleteButton = screen.getByRole("button", { name: "Xóa nhóm II" })
     expect(deleteButton).not.toBeDisabled()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx
@@ -1,0 +1,292 @@
+import { useState } from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
+import {
+  appendTechnicalConfigurationBaselineEditorSubgroup,
+  moveTechnicalConfigurationBaselineEditorCriterionToOwner,
+  moveTechnicalConfigurationBaselineEditorSubgroup,
+  removeTechnicalConfigurationBaselineEditorSubgroup,
+  type TechnicalConfigurationBaselineEditorCriterionOwner,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import type {
+  TechnicalConfigurationBaselineEditorDraft,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+const emptyValidation: TechnicalConfigurationBaselineEditorValidation = {
+  groupErrors: {},
+  subgroupErrors: {},
+  criterionErrors: {},
+}
+
+const initialDraft: TechnicalConfigurationBaselineEditorDraft = {
+  id: "draft-authoring",
+  dossierId: "dossier-1",
+  status: "draft",
+  revision: 7,
+  groups: [
+    {
+      key: "section-a",
+      id: "section-a",
+      name: "Yêu cầu chung",
+      criteria: [
+        {
+          key: "criterion-direct",
+          id: "criterion-direct",
+          criterionCode: "TC-0001",
+          title: "Nguồn điện",
+          requirementText: "Nguồn điện ổn định",
+        },
+      ],
+      subgroups: [
+        {
+          key: "subgroup-a",
+          id: "subgroup-a",
+          name: "Hạ tầng",
+          criteria: [
+            {
+              key: "criterion-subgroup",
+              id: "criterion-subgroup",
+              criterionCode: "TC-0002",
+              title: "Tiếp địa",
+              requirementText: "Có hệ thống tiếp địa riêng",
+            },
+          ],
+        },
+        {
+          key: "subgroup-b",
+          id: "subgroup-b",
+          name: "Môi trường",
+          criteria: [],
+        },
+      ],
+    },
+    {
+      key: "section-b",
+      id: "section-b",
+      name: "Yêu cầu bổ sung",
+      criteria: [],
+      subgroups: [],
+    },
+  ],
+}
+
+function AuthoringHarness(): React.JSX.Element {
+  const [draft, setDraft] = useState(initialDraft)
+
+  const setSubgroupName = (groupKey: string, subgroupKey: string, name: string) => {
+    setDraft((current) => ({
+      ...current,
+      groups: current.groups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              subgroups: group.subgroups.map((subgroup) =>
+                subgroup.key === subgroupKey ? { ...subgroup, name } : subgroup
+              ),
+            }
+          : group
+      ),
+    }))
+  }
+
+  const moveCriterion = (
+    sourceOwner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionKey: string,
+    targetOwner: TechnicalConfigurationBaselineEditorCriterionOwner
+  ) => {
+    setDraft((current) =>
+      moveTechnicalConfigurationBaselineEditorCriterionToOwner(
+        current,
+        sourceOwner,
+        criterionKey,
+        targetOwner
+      )
+    )
+  }
+
+  return (
+    <TechnicalConfigurationBaselineEditor
+      draft={draft}
+      validation={emptyValidation}
+      summaryValidation={emptyValidation}
+      status={{
+        dirty: true,
+        saving: false,
+        editingDisabled: false,
+        conflict: false,
+        saveStatus: "idle",
+        hasPendingBulkInput: false,
+      }}
+      isFocusMode={false}
+      activeValue="section-a"
+      entryMode="row"
+      getBulkSession={() => ({ input: "", preview: null })}
+      focusTarget={null}
+      recentlyAcceptedCriterionKeys={new Set()}
+      onGroupModeChange={vi.fn()}
+      onAddGroup={vi.fn()}
+      onGroupNameChange={vi.fn()}
+      onMoveGroup={vi.fn()}
+      onDeleteGroup={vi.fn()}
+      onCriterionTextChange={vi.fn()}
+      onMoveCriterion={vi.fn()}
+      onDeleteCriterion={vi.fn()}
+      onAddCriterion={vi.fn()}
+      onBulkInputChange={vi.fn()}
+      onBulkPreview={vi.fn()}
+      onBulkCancel={vi.fn()}
+      onBulkAccept={vi.fn()}
+      onSave={vi.fn()}
+      hierarchyAuthoring={{
+        activeOwnerKey: "section-a",
+        entryMode: "row",
+        getBulkSession: () => ({ input: "", preview: null }),
+        onOwnerModeChange: vi.fn(),
+        onAddSubgroup: (groupKey) =>
+          setDraft((current) =>
+            appendTechnicalConfigurationBaselineEditorSubgroup(current, groupKey)
+          ),
+        onSubgroupNameChange: setSubgroupName,
+        onMoveSubgroup: (groupKey, subgroupIndex, offset) =>
+          setDraft((current) =>
+            moveTechnicalConfigurationBaselineEditorSubgroup(
+              current,
+              groupKey,
+              subgroupIndex,
+              offset
+            )
+          ),
+        onDeleteSubgroup: (groupKey, subgroupKey) =>
+          setDraft((current) =>
+            removeTechnicalConfigurationBaselineEditorSubgroup(current, groupKey, subgroupKey)
+          ),
+        onCriterionTextChange: vi.fn(),
+        onMoveCriterionWithinOwner: vi.fn(),
+        onMoveCriterionToOwner: moveCriterion,
+        onDeleteCriterion: vi.fn(),
+        onAddCriterion: vi.fn(),
+        onBulkInputChange: vi.fn(),
+        onBulkPreview: vi.fn(),
+        onBulkCancel: vi.fn(),
+        onBulkAccept: vi.fn(),
+      }}
+    />
+  )
+}
+
+describe("technical configuration baseline hierarchy authoring controls", () => {
+  it("creates, renames, reorders, and deletes subgroups with normalized ordinals", async () => {
+    const user = userEvent.setup()
+    render(<AuthoringHarness />)
+
+    const firstSection = screen.getByRole("region", { name: "Nhóm tiêu chí I" })
+    await user.click(within(firstSection).getByRole("button", { name: "Thêm nhóm con vào nhóm I" }))
+
+    const newSubgroupName = within(firstSection).getByRole("textbox", {
+      name: "Tên nhóm con 3 của nhóm I",
+    })
+    await user.clear(newSubgroupName)
+    await user.type(newSubgroupName, "An toàn")
+
+    expect(
+      within(firstSection).getByRole("region", {
+        name: "Nhóm con 3 của nhóm I: An toàn",
+      })
+    ).toBeInTheDocument()
+
+    await user.click(
+      within(firstSection).getByRole("button", {
+        name: "Di chuyển nhóm con 3 của nhóm I lên",
+      })
+    )
+
+    expect(
+      within(firstSection).getByRole("textbox", { name: "Tên nhóm con 2 của nhóm I" })
+    ).toHaveValue("An toàn")
+
+    await user.click(
+      within(firstSection).getByRole("button", { name: "Xóa nhóm con 2 của nhóm I" })
+    )
+
+    expect(
+      within(firstSection).queryByRole("textbox", { name: "Tên nhóm con 3 của nhóm I" })
+    ).not.toBeInTheDocument()
+    expect(
+      within(firstSection).getByRole("textbox", { name: "Tên nhóm con 2 của nhóm I" })
+    ).toHaveValue("Môi trường")
+  })
+
+  it("moves a criterion between direct and subgroup owners without changing identity", async () => {
+    const user = userEvent.setup()
+    render(<AuthoringHarness />)
+
+    await user.selectOptions(
+      screen.getByRole("combobox", {
+        name: "Chuyển tiêu chí trực tiếp 1 của nhóm I",
+      }),
+      "section-a:subgroup-a"
+    )
+
+    const subgroup = screen.getByRole("region", {
+      name: "Nhóm con 1 của nhóm I: Hạ tầng",
+    })
+    expect(within(subgroup).getByDisplayValue("Nguồn điện ổn định")).toBeInTheDocument()
+    expect(within(subgroup).getByText("TC-0001")).toBeInTheDocument()
+
+    await user.selectOptions(
+      within(subgroup).getByRole("combobox", {
+        name: "Chuyển tiêu chí 2 của nhóm con 1, nhóm I",
+      }),
+      "section-b:direct"
+    )
+
+    const secondSection = screen.getByRole("region", { name: "Nhóm tiêu chí II" })
+    expect(within(secondSection).getByDisplayValue("Nguồn điện ổn định")).toBeInTheDocument()
+    expect(within(secondSection).getByText("TC-0001")).toBeInTheDocument()
+  })
+
+  it("keeps hierarchy authoring controls absent unless the capability is provided", () => {
+    render(
+      <TechnicalConfigurationBaselineEditor
+        draft={initialDraft}
+        validation={emptyValidation}
+        summaryValidation={emptyValidation}
+        status={{
+          dirty: false,
+          saving: false,
+          editingDisabled: false,
+          conflict: false,
+          saveStatus: "idle",
+          hasPendingBulkInput: false,
+        }}
+        isFocusMode={false}
+        activeValue="section-a"
+        entryMode="row"
+        getBulkSession={() => ({ input: "", preview: null })}
+        focusTarget={null}
+        recentlyAcceptedCriterionKeys={new Set()}
+        onGroupModeChange={vi.fn()}
+        onAddGroup={vi.fn()}
+        onGroupNameChange={vi.fn()}
+        onMoveGroup={vi.fn()}
+        onDeleteGroup={vi.fn()}
+        onCriterionTextChange={vi.fn()}
+        onMoveCriterion={vi.fn()}
+        onDeleteCriterion={vi.fn()}
+        onAddCriterion={vi.fn()}
+        onBulkInputChange={vi.fn()}
+        onBulkPreview={vi.fn()}
+        onBulkCancel={vi.fn()}
+        onBulkAccept={vi.fn()}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("combobox", { name: /Chuyển tiêu chí/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts
@@ -138,6 +138,23 @@ describe("technical configuration baseline hierarchy authoring entry", () => {
     })
   })
 
+  it("uses group-scoped focus targets for direct-owner bulk transitions", async () => {
+    const { result } = renderHierarchyEditor()
+    await waitFor(() => expect(result.current.editor.activeValue).toBe("section-a"))
+
+    act(() => result.current.editor.hierarchyAuthoring.onOwnerModeChange("section-a", "bulk"))
+    expect(result.current.editor.focusTarget).toMatchObject({
+      kind: "bulk-input",
+      key: "section-a",
+    })
+
+    act(() => result.current.editor.hierarchyAuthoring.onBulkCancel("section-a"))
+    expect(result.current.editor.focusTarget).toMatchObject({
+      kind: "group-mode-action",
+      key: "section-a",
+    })
+  })
+
   it("removes only the deleted subgroup buffer during owner synchronization", async () => {
     const { result, rerender } = renderHierarchyEditor()
     await waitFor(() => expect(result.current.editor.activeValue).toBe("section-a"))

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import { useTechnicalConfigurationInlineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor"
+import type {
+  TechnicalConfigurationBaselineEditorDraft,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+const emptyValidation: TechnicalConfigurationBaselineEditorValidation = {
+  groupErrors: {},
+  subgroupErrors: {},
+  criterionErrors: {},
+}
+
+const hierarchyDraft: TechnicalConfigurationBaselineEditorDraft = {
+  id: "draft-hierarchy-entry",
+  dossierId: "dossier-1",
+  status: "draft",
+  revision: 3,
+  groups: [
+    {
+      key: "section-a",
+      id: "section-a",
+      name: "Yêu cầu chung",
+      criteria: [],
+      subgroups: [
+        {
+          key: "subgroup-a",
+          id: "subgroup-a",
+          name: "Hạ tầng",
+          criteria: [],
+        },
+      ],
+    },
+  ],
+}
+
+function renderHierarchyEditor() {
+  const onEditorChange = vi.fn()
+  const rendered = renderHook(
+    ({ draft }: { draft: TechnicalConfigurationBaselineEditorDraft }) => {
+      const bulkSessions = useTechnicalConfigurationBulkEntrySessions()
+      const editor = useTechnicalConfigurationInlineEditor({
+        draft,
+        validation: emptyValidation,
+        saveStatus: "idle",
+        bulkSessions,
+        onEditorChange,
+      })
+      return { bulkSessions, editor }
+    },
+    { initialProps: { draft: hierarchyDraft } }
+  )
+
+  return { ...rendered, onEditorChange }
+}
+
+describe("technical configuration baseline hierarchy authoring entry", () => {
+  it("adds and edits one subgroup criterion through the canonical owner", async () => {
+    const { result, rerender, onEditorChange } = renderHierarchyEditor()
+    await waitFor(() => expect(result.current.editor.activeValue).toBe("section-a"))
+
+    act(() =>
+      result.current.editor.hierarchyAuthoring.onAddCriterion({
+        groupKey: "section-a",
+        subgroupKey: "subgroup-a",
+      })
+    )
+
+    const addedDraft = onEditorChange.mock
+      .lastCall?.[0] as TechnicalConfigurationBaselineEditorDraft
+    const addedCriterion = addedDraft.groups[0].subgroups[0].criteria[0]
+    expect(addedCriterion).toMatchObject({
+      id: null,
+      criterionCode: null,
+      title: "",
+      requirementText: "",
+    })
+    expect(result.current.editor.focusTarget).toMatchObject({
+      kind: "criterion",
+      key: addedCriterion.key,
+    })
+
+    rerender({ draft: addedDraft })
+    onEditorChange.mockClear()
+    act(() =>
+      result.current.editor.hierarchyAuthoring.onCriterionTextChange(
+        { groupKey: "section-a", subgroupKey: "subgroup-a" },
+        addedCriterion.key,
+        "requirementText",
+        "Yêu cầu tiếp địa"
+      )
+    )
+    const editedDraft = onEditorChange.mock
+      .lastCall?.[0] as TechnicalConfigurationBaselineEditorDraft
+    expect(editedDraft.groups[0].subgroups[0].criteria[0].requirementText).toBe("Yêu cầu tiếp địa")
+  })
+
+  it("keeps direct and subgroup multiline buffers independent and accepts only the active owner", async () => {
+    const { result, onEditorChange } = renderHierarchyEditor()
+    await waitFor(() => expect(result.current.editor.activeValue).toBe("section-a"))
+
+    act(() => {
+      result.current.bulkSessions.setInput("section-a", "Yêu cầu trực tiếp đang chờ")
+      result.current.editor.hierarchyAuthoring.onOwnerModeChange("subgroup-a", "bulk")
+      result.current.editor.hierarchyAuthoring.onBulkInputChange(
+        "subgroup-a",
+        "Tiếp địa riêng\nNhiệt độ phòng phù hợp"
+      )
+    })
+
+    act(() => result.current.editor.hierarchyAuthoring.onBulkPreview("subgroup-a"))
+    expect(result.current.bulkSessions.getSession("section-a").input).toBe(
+      "Yêu cầu trực tiếp đang chờ"
+    )
+    expect(result.current.bulkSessions.getSession("subgroup-a").preview?.rows).toHaveLength(2)
+
+    act(() =>
+      result.current.editor.hierarchyAuthoring.onBulkAccept({
+        groupKey: "section-a",
+        subgroupKey: "subgroup-a",
+      })
+    )
+
+    const acceptedDraft = onEditorChange.mock
+      .lastCall?.[0] as TechnicalConfigurationBaselineEditorDraft
+    expect(
+      acceptedDraft.groups[0].subgroups[0].criteria.map((criterion) => criterion.requirementText)
+    ).toEqual(["Tiếp địa riêng", "Nhiệt độ phòng phù hợp"])
+    expect(result.current.bulkSessions.getSession("section-a").input).toBe(
+      "Yêu cầu trực tiếp đang chờ"
+    )
+    expect(result.current.bulkSessions.getSession("subgroup-a")).toEqual({
+      input: "",
+      preview: null,
+    })
+  })
+
+  it("removes only the deleted subgroup buffer during owner synchronization", async () => {
+    const { result, rerender } = renderHierarchyEditor()
+    await waitFor(() => expect(result.current.editor.activeValue).toBe("section-a"))
+
+    act(() => {
+      result.current.bulkSessions.setInput("section-a", "Giữ lại")
+      result.current.bulkSessions.setInput("subgroup-a", "Xóa cùng nhóm con")
+    })
+
+    rerender({
+      draft: {
+        ...hierarchyDraft,
+        groups: [{ ...hierarchyDraft.groups[0], subgroups: [] }],
+      },
+    })
+
+    await waitFor(() => expect(result.current.bulkSessions.getSession("subgroup-a").input).toBe(""))
+    expect(result.current.bulkSessions.getSession("section-a").input).toBe("Giữ lại")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-workflow.test.tsx
@@ -1,0 +1,210 @@
+import "@testing-library/jest-dom"
+import { useState } from "react"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
+import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import { useTechnicalConfigurationInlineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor"
+import type {
+  TechnicalConfigurationBaselineEditorDraft,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+const validation: TechnicalConfigurationBaselineEditorValidation = {
+  groupErrors: {},
+  subgroupErrors: {},
+  criterionErrors: {},
+}
+
+const initialDraft: TechnicalConfigurationBaselineEditorDraft = {
+  id: "draft-hierarchy-workflow",
+  dossierId: "dossier-1",
+  status: "draft",
+  revision: 7,
+  groups: [
+    {
+      key: "section-a",
+      id: "section-a",
+      name: "Yêu cầu chung",
+      criteria: [],
+      subgroups: [
+        {
+          key: "subgroup-a",
+          id: "subgroup-a",
+          name: "Hạ tầng",
+          criteria: [],
+        },
+      ],
+    },
+  ],
+}
+
+const scrollIntoViewMock = vi.fn()
+const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+  Element.prototype,
+  "scrollIntoView"
+)
+
+beforeEach(() => {
+  scrollIntoViewMock.mockClear()
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoViewMock,
+  })
+})
+
+afterAll(() => {
+  if (originalScrollIntoViewDescriptor) {
+    Object.defineProperty(Element.prototype, "scrollIntoView", originalScrollIntoViewDescriptor)
+  } else {
+    Reflect.deleteProperty(Element.prototype, "scrollIntoView")
+  }
+})
+
+function HierarchyAuthoringHarness(): React.JSX.Element {
+  const [draft, setDraft] = useState(initialDraft)
+  const bulkSessions = useTechnicalConfigurationBulkEntrySessions()
+  const inlineEditor = useTechnicalConfigurationInlineEditor({
+    draft,
+    validation,
+    saveStatus: "idle",
+    bulkSessions,
+    onEditorChange: setDraft,
+  })
+
+  return (
+    <TechnicalConfigurationBaselineEditor
+      draft={draft}
+      validation={validation}
+      summaryValidation={validation}
+      status={{
+        dirty: true,
+        saving: false,
+        editingDisabled: false,
+        conflict: false,
+        saveStatus: "idle",
+        hasPendingBulkInput: bulkSessions.hasPendingInput,
+      }}
+      isFocusMode={false}
+      activeValue={inlineEditor.activeValue}
+      entryMode={inlineEditor.entryMode}
+      getBulkSession={bulkSessions.getSession}
+      focusTarget={inlineEditor.focusTarget}
+      recentlyAcceptedCriterionKeys={bulkSessions.recentlyAcceptedCriterionKeys}
+      onGroupModeChange={inlineEditor.setGroupMode}
+      onAddGroup={inlineEditor.addGroup}
+      onGroupNameChange={inlineEditor.setGroupName}
+      onMoveGroup={inlineEditor.moveGroup}
+      onDeleteGroup={inlineEditor.deleteGroup}
+      onCriterionTextChange={inlineEditor.setCriterionText}
+      onMoveCriterion={inlineEditor.moveCriterion}
+      onDeleteCriterion={inlineEditor.deleteCriterion}
+      onAddCriterion={inlineEditor.addCriterion}
+      onBulkInputChange={inlineEditor.setBulkInput}
+      onBulkPreview={inlineEditor.previewBulk}
+      onBulkCancel={inlineEditor.cancelBulk}
+      onBulkAccept={inlineEditor.acceptBulk}
+      onSave={vi.fn()}
+      hierarchyAuthoring={inlineEditor.hierarchyAuthoring}
+    />
+  )
+}
+
+describe("technical configuration baseline hierarchy authoring workflow", () => {
+  it("focuses new subgroup names and new subgroup criterion requirements", async () => {
+    const user = userEvent.setup()
+    render(<HierarchyAuthoringHarness />)
+
+    const section = screen.getByRole("region", { name: "Nhóm tiêu chí I" })
+    await user.click(within(section).getByRole("button", { name: "Thêm nhóm con vào nhóm I" }))
+
+    const newSubgroupName = within(section).getByRole("textbox", {
+      name: "Tên nhóm con 2 của nhóm I",
+    })
+    await waitFor(() => expect(newSubgroupName).toHaveFocus())
+    await user.type(newSubgroupName, "An toàn")
+
+    const newSubgroup = within(section).getByRole("region", {
+      name: "Nhóm con 2 của nhóm I: An toàn",
+    })
+    await user.click(
+      within(newSubgroup).getByRole("button", {
+        name: "Thêm tiêu chí vào nhóm con 2 của nhóm I",
+      })
+    )
+
+    await waitFor(() =>
+      expect(
+        within(newSubgroup).getByRole("textbox", {
+          name: "Nội dung yêu cầu tiêu chí 1 của nhóm con 2, nhóm I",
+        })
+      ).toHaveFocus()
+    )
+    expect(scrollIntoViewMock).toHaveBeenCalled()
+  })
+
+  it("keeps direct and subgroup buffers through collapse and restores focus after cancel", async () => {
+    const user = userEvent.setup()
+    render(<HierarchyAuthoringHarness />)
+
+    const section = screen.getByRole("region", { name: "Nhóm tiêu chí I" })
+    const subgroup = within(section).getByRole("region", {
+      name: "Nhóm con 1 của nhóm I: Hạ tầng",
+    })
+
+    await user.click(
+      within(section).getByRole("button", {
+        name: "Nhập nhiều dòng cho nhóm I: Yêu cầu chung",
+      })
+    )
+    const directInput = within(section).getByRole("textbox", { name: "Nội dung nhập nhanh" })
+    await user.type(directInput, "Yêu cầu trực tiếp đang chờ")
+
+    await user.click(
+      within(subgroup).getByRole("button", {
+        name: "Nhập nhiều dòng cho nhóm con 1 của nhóm I",
+      })
+    )
+    let subgroupInput = within(subgroup).getByRole("textbox", { name: "Nội dung nhập nhanh" })
+    await waitFor(() => expect(subgroupInput).toHaveFocus())
+    await user.type(subgroupInput, "Tiếp địa riêng")
+
+    expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+    expect(
+      screen.getByText("Hoàn tất hoặc hủy phần nhập nhiều dòng trước khi lưu.")
+    ).toBeInTheDocument()
+
+    await user.click(
+      within(subgroup).getByRole("button", {
+        name: "Thu gọn nhóm con 1 của nhóm I: Hạ tầng",
+      })
+    )
+    await user.click(
+      within(subgroup).getByRole("button", {
+        name: "Mở rộng nhóm con 1 của nhóm I: Hạ tầng",
+      })
+    )
+    subgroupInput = within(subgroup).getByRole("textbox", { name: "Nội dung nhập nhanh" })
+    expect(subgroupInput).toHaveValue("Tiếp địa riêng")
+
+    await user.click(within(subgroup).getByRole("button", { name: "Hủy nhập" }))
+    await waitFor(() =>
+      expect(
+        within(subgroup).getByRole("button", {
+          name: "Nhập nhiều dòng cho nhóm con 1 của nhóm I",
+        })
+      ).toHaveFocus()
+    )
+
+    await user.click(
+      within(section).getByRole("button", {
+        name: "Nhập nhiều dòng cho nhóm I: Yêu cầu chung",
+      })
+    )
+    expect(within(section).getByRole("textbox", { name: "Nội dung nhập nhanh" })).toHaveValue(
+      "Yêu cầu trực tiếp đang chờ"
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save-fixtures.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save-fixtures.ts
@@ -1,0 +1,139 @@
+import { vi } from "vitest"
+
+import type {
+  TechnicalConfigurationBaselineCriterionMutationWire,
+  TechnicalConfigurationBaselineDraftWire,
+} from "../baseline-types"
+
+const timestamp = "2026-08-11T00:00:00.000Z"
+
+export function criterion(
+  id: string,
+  code: string,
+  groupId: string,
+  subgroupId: string | null,
+  sortOrder: number
+) {
+  return {
+    id,
+    baseline_version_id: "draft-1",
+    group_id: groupId,
+    subgroup_id: subgroupId,
+    criterion_code: code,
+    title: null,
+    requirement_text: `Yêu cầu ${code}`,
+    sort_order: sortOrder,
+    source_criterion_id: null,
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: timestamp,
+    updated_by: 1,
+  }
+}
+
+export function createDraft(): TechnicalConfigurationBaselineDraftWire {
+  return {
+    id: "draft-1",
+    dossier_id: "dossier-1",
+    version_number: 1,
+    status: "draft",
+    source_baseline_version_id: null,
+    source_version_number: null,
+    next_criterion_number: 4,
+    revision: 4,
+    locked_at: null,
+    locked_by: null,
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: timestamp,
+    updated_by: 1,
+    groups: [
+      {
+        id: "group-1",
+        baseline_version_id: "draft-1",
+        name: "Yêu cầu chung",
+        sort_order: 1,
+        created_at: timestamp,
+        created_by: 1,
+        updated_at: timestamp,
+        updated_by: 1,
+        criteria: [criterion("criterion-1", "TC-0001", "group-1", null, 1)],
+        subgroups: [
+          {
+            id: "subgroup-1",
+            baseline_version_id: "draft-1",
+            group_id: "group-1",
+            name: "Hạ tầng",
+            sort_order: 1,
+            created_at: timestamp,
+            created_by: 1,
+            updated_at: timestamp,
+            updated_by: 1,
+            criteria: [criterion("criterion-2", "TC-0002", "group-1", "subgroup-1", 2)],
+          },
+          {
+            id: "subgroup-2",
+            baseline_version_id: "draft-1",
+            group_id: "group-1",
+            name: "Môi trường",
+            sort_order: 2,
+            created_at: timestamp,
+            created_by: 1,
+            updated_at: timestamp,
+            updated_by: 1,
+            criteria: [criterion("criterion-3", "TC-0003", "group-1", "subgroup-2", 3)],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+export function subgroupMutation(id: string, name: string, sortOrder: number, revision: number) {
+  return {
+    id,
+    baseline_version_id: "draft-1",
+    group_id: "group-1",
+    name,
+    sort_order: sortOrder,
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: timestamp,
+    updated_by: 1,
+    revision,
+  }
+}
+
+export function criterionMutation(
+  id: string,
+  code: string,
+  subgroupId: string | null,
+  sortOrder: number,
+  revision: number,
+  groupId = "group-1"
+): TechnicalConfigurationBaselineCriterionMutationWire {
+  return {
+    ...criterion(id, code, groupId, subgroupId, sortOrder),
+    revision,
+  }
+}
+
+export function createRpc() {
+  return {
+    createGroup: vi.fn(),
+    updateGroup: vi.fn(),
+    deleteGroup: vi.fn(),
+    reorderGroups: vi.fn(),
+    createCriterion: vi.fn(),
+    updateCriterion: vi.fn(),
+    deleteCriterion: vi.fn(),
+    reorderCriteria: vi.fn(),
+    createSubgroup: vi.fn(),
+    updateSubgroup: vi.fn(),
+    deleteSubgroup: vi.fn(),
+    reorderSubgroups: vi.fn(),
+    createHierarchyCriterion: vi.fn(),
+    moveHierarchyCriterion: vi.fn(),
+    reorderHierarchyCriteria: vi.fn(),
+  }
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  BaselineEditorSaveFailure,
+  createTechnicalConfigurationBaselineEditorCriterion,
+  moveTechnicalConfigurationBaselineEditorCriterionToOwner,
+  saveTechnicalConfigurationBaselineEditorDraft,
+  toTechnicalConfigurationBaselineEditorDraft,
+} from "../technical-configuration-baseline-editor"
+import { TechnicalConfigurationRpcError } from "../technical-configuration-rpc"
+import {
+  createDraft,
+  createRpc,
+  criterion,
+  criterionMutation,
+  subgroupMutation,
+} from "./technical-configuration-baseline-hierarchy-save-fixtures"
+
+describe("technical configuration baseline hierarchy save", () => {
+  it("maps a created subgroup ID and resumes without recreating it after a later failure", async () => {
+    const baseDraft = createDraft()
+    const editorDraft = toTechnicalConfigurationBaselineEditorDraft(baseDraft)
+    const newSubgroup = {
+      key: "new-subgroup",
+      id: null,
+      name: "An toàn",
+      criteria: [
+        Object.assign(createTechnicalConfigurationBaselineEditorCriterion("new-criterion"), {
+          requirementText: "Có tiếp địa an toàn",
+        }),
+      ],
+    }
+    editorDraft.groups[0].subgroups.unshift(newSubgroup)
+
+    const rpc = createRpc()
+    rpc.createSubgroup.mockResolvedValue({
+      data: subgroupMutation("subgroup-4", "An toàn", 3, 5),
+    })
+    rpc.createHierarchyCriterion.mockRejectedValueOnce(new Error("network_down"))
+
+    let failure: BaselineEditorSaveFailure | null = null
+    try {
+      await saveTechnicalConfigurationBaselineEditorDraft({ baseDraft, editorDraft, rpc })
+    } catch (error) {
+      failure = error as BaselineEditorSaveFailure
+    }
+
+    expect(failure).toBeInstanceOf(BaselineEditorSaveFailure)
+    expect(failure?.progress.editorDraft.groups[0].subgroups[0]).toMatchObject({
+      key: "new-subgroup",
+      id: "subgroup-4",
+      name: "An toàn",
+    })
+
+    rpc.createHierarchyCriterion.mockResolvedValue({
+      data: criterionMutation("criterion-4", "TC-0004", "subgroup-4", 4, 6),
+    })
+    rpc.reorderSubgroups.mockImplementation(async () => ({
+      data: {
+        ...failure?.progress.baseDraft,
+        revision: 7,
+        groups: [
+          {
+            ...failure?.progress.baseDraft.groups[0],
+            subgroups: [
+              {
+                ...failure?.progress.baseDraft.groups[0].subgroups?.[2],
+                criteria: [criterion("criterion-4", "TC-0004", "group-1", "subgroup-4", 1)],
+              },
+              failure?.progress.baseDraft.groups[0].subgroups?.[0],
+              failure?.progress.baseDraft.groups[0].subgroups?.[1],
+            ],
+          },
+        ],
+      },
+    }))
+
+    if (!failure) throw new Error("Expected hierarchy save failure")
+    const result = await saveTechnicalConfigurationBaselineEditorDraft({
+      baseDraft: failure.progress.baseDraft,
+      editorDraft: failure.progress.editorDraft,
+      rpc,
+    })
+
+    expect(rpc.createSubgroup).toHaveBeenCalledTimes(1)
+    expect(rpc.createHierarchyCriterion).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        p_group_id: "group-1",
+        p_subgroup_id: "subgroup-4",
+        p_expected_revision: 5,
+      })
+    )
+    expect(result.editorDraft.groups[0].subgroups[0].criteria[0]).toMatchObject({
+      id: "criterion-4",
+      criterionCode: "TC-0004",
+    })
+  })
+
+  it("does not repeat an accepted criterion move when retrying the target reorder", async () => {
+    const baseDraft = createDraft()
+    const editorDraft = toTechnicalConfigurationBaselineEditorDraft(baseDraft)
+    const movedDraft = moveTechnicalConfigurationBaselineEditorCriterionToOwner(
+      editorDraft,
+      { groupKey: "group-1", subgroupKey: null },
+      "criterion-1",
+      { groupKey: "group-1", subgroupKey: "subgroup-1" },
+      0
+    )
+    const rpc = createRpc()
+    rpc.moveHierarchyCriterion.mockResolvedValue({
+      data: criterionMutation("criterion-1", "TC-0001", "subgroup-1", 4, 5),
+    })
+    rpc.reorderHierarchyCriteria.mockRejectedValueOnce(new Error("network_down"))
+
+    let failure: BaselineEditorSaveFailure | null = null
+    try {
+      await saveTechnicalConfigurationBaselineEditorDraft({
+        baseDraft,
+        editorDraft: movedDraft,
+        rpc,
+      })
+    } catch (error) {
+      failure = error as BaselineEditorSaveFailure
+    }
+
+    if (!failure) throw new Error("Expected hierarchy move failure")
+    rpc.reorderHierarchyCriteria.mockResolvedValue({
+      data: { ...failure.progress.baseDraft, revision: 6 },
+    })
+    await saveTechnicalConfigurationBaselineEditorDraft({
+      baseDraft: failure.progress.baseDraft,
+      editorDraft: failure.progress.editorDraft,
+      rpc,
+    })
+
+    expect(rpc.moveHierarchyCriterion).toHaveBeenCalledTimes(1)
+    expect(rpc.reorderHierarchyCriteria).toHaveBeenLastCalledWith({
+      p_group_id: "group-1",
+      p_subgroup_id: "subgroup-1",
+      p_criterion_ids: ["criterion-1", "criterion-2"],
+      p_expected_revision: 5,
+    })
+  })
+
+  it("uses the hierarchy move path for direct owner changes without subgroups", async () => {
+    const baseDraft = createDraft()
+    baseDraft.groups[0].subgroups = []
+    baseDraft.groups.push({
+      ...baseDraft.groups[0],
+      id: "group-2",
+      name: "Yêu cầu bổ sung",
+      sort_order: 2,
+      criteria: [],
+      subgroups: [],
+    })
+    const editorDraft = toTechnicalConfigurationBaselineEditorDraft(baseDraft)
+    const movedDraft = moveTechnicalConfigurationBaselineEditorCriterionToOwner(
+      editorDraft,
+      { groupKey: "group-1", subgroupKey: null },
+      "criterion-1",
+      { groupKey: "group-2", subgroupKey: null }
+    )
+    const rpc = createRpc()
+    rpc.moveHierarchyCriterion.mockResolvedValue({
+      data: criterionMutation("criterion-1", "TC-0001", null, 1, 5, "group-2"),
+    })
+
+    const result = await saveTechnicalConfigurationBaselineEditorDraft({
+      baseDraft,
+      editorDraft: movedDraft,
+      rpc,
+    })
+
+    expect(rpc.moveHierarchyCriterion).toHaveBeenCalledWith({
+      p_criterion_id: "criterion-1",
+      p_target_group_id: "group-2",
+      p_target_subgroup_id: null,
+      p_expected_revision: 4,
+    })
+    expect(rpc.deleteCriterion).not.toHaveBeenCalled()
+    expect(rpc.createCriterion).not.toHaveBeenCalled()
+    expect(result.editorDraft.groups[1].criteria[0]).toMatchObject({
+      id: "criterion-1",
+      criterionCode: "TC-0001",
+    })
+  })
+
+  it("deletes removed descendants before subgroup and exact-set reorder calls", async () => {
+    const baseDraft = createDraft()
+    const editorDraft = toTechnicalConfigurationBaselineEditorDraft(baseDraft)
+    editorDraft.groups[0].subgroups = [editorDraft.groups[0].subgroups[0]]
+    const rpc = createRpc()
+    rpc.deleteCriterion.mockResolvedValue({ data: { id: "criterion-3", revision: 5 } })
+    rpc.deleteSubgroup.mockResolvedValue({ data: { id: "subgroup-2", revision: 6 } })
+
+    await saveTechnicalConfigurationBaselineEditorDraft({ baseDraft, editorDraft, rpc })
+
+    expect(rpc.deleteCriterion).toHaveBeenCalledWith({
+      p_criterion_id: "criterion-3",
+      p_expected_revision: 4,
+    })
+    expect(rpc.deleteSubgroup).toHaveBeenCalledWith({
+      p_subgroup_id: "subgroup-2",
+      p_expected_revision: 5,
+    })
+    expect(rpc.deleteCriterion.mock.invocationCallOrder[0]).toBeLessThan(
+      rpc.deleteSubgroup.mock.invocationCallOrder[0]
+    )
+  })
+
+  it("classifies a stale hierarchy mutation as a conflict without losing the local move", async () => {
+    const baseDraft = createDraft()
+    const editorDraft = moveTechnicalConfigurationBaselineEditorCriterionToOwner(
+      toTechnicalConfigurationBaselineEditorDraft(baseDraft),
+      { groupKey: "group-1", subgroupKey: null },
+      "criterion-1",
+      { groupKey: "group-1", subgroupKey: "subgroup-1" }
+    )
+    const rpc = createRpc()
+    rpc.moveHierarchyCriterion.mockRejectedValue(
+      new TechnicalConfigurationRpcError(409, {
+        code: "PT409",
+        message: "stale_revision",
+      })
+    )
+
+    let failure: BaselineEditorSaveFailure | null = null
+    try {
+      await saveTechnicalConfigurationBaselineEditorDraft({ baseDraft, editorDraft, rpc })
+    } catch (error) {
+      failure = error as BaselineEditorSaveFailure
+    }
+
+    expect(failure).toBeInstanceOf(BaselineEditorSaveFailure)
+    expect(failure?.isConflict).toBe(true)
+    expect(failure?.progress.editorDraft.groups[0].criteria).toEqual([])
+    expect(
+      failure?.progress.editorDraft.groups[0].subgroups
+        .find((subgroup) => subgroup.id === "subgroup-1")
+        ?.criteria.map((item) => [item.id, item.criterionCode])
+    ).toEqual([
+      ["criterion-2", "TC-0002"],
+      ["criterion-1", "TC-0001"],
+    ])
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-save.test.ts
@@ -90,6 +90,11 @@ describe("technical configuration baseline hierarchy save", () => {
         p_expected_revision: 5,
       })
     )
+    expect(rpc.reorderSubgroups).toHaveBeenLastCalledWith({
+      p_group_id: "group-1",
+      p_subgroup_ids: ["subgroup-4", "subgroup-1", "subgroup-2"],
+      p_expected_revision: 6,
+    })
     expect(result.editorDraft.groups[0].subgroups[0].criteria[0]).toMatchObject({
       id: "criterion-4",
       criterionCode: "TC-0004",

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom"
+import { screen } from "@testing-library/react"
+import { within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
+
+import {
+  baselineVersionsResponse,
+  createDraft,
+  createLockedVersion,
+  dossier,
+  getBaselineRpcMock,
+  mockVersions,
+  renderTab,
+} from "./technical-configuration-baseline-tab-fixtures"
+
+const rpc = getBaselineRpcMock()
+
+function createSubgroupOnlyDraft() {
+  const draft = createDraft()
+  const directCriterion = draft.groups[0].criteria[0]
+  const firstGroup = draft.groups[0]
+
+  return createDraft({
+    groups: [
+      {
+        ...firstGroup,
+        criteria: [],
+        subgroups: [
+          {
+            id: "subgroup-1",
+            baseline_version_id: draft.id,
+            group_id: firstGroup.id,
+            name: "Hạ tầng",
+            sort_order: 1,
+            created_at: firstGroup.created_at,
+            created_by: firstGroup.created_by,
+            updated_at: firstGroup.updated_at,
+            updated_by: firstGroup.updated_by,
+            criteria: [{ ...directCriterion, subgroup_id: "subgroup-1" }],
+          },
+        ],
+      },
+      ...draft.groups.slice(1),
+    ],
+  })
+}
+
+describe("technical configuration baseline hierarchy tab workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rpc.getDossier.mockResolvedValue({ data: dossier })
+  })
+
+  it("keeps production authoring hidden and allows locking a subgroup-only criterion draft", async () => {
+    const user = userEvent.setup()
+    const draft = createSubgroupOnlyDraft()
+    mockVersions([draft])
+    rpc.lockVersion.mockResolvedValue({ data: createLockedVersion() })
+
+    renderTab()
+
+    expect(await screen.findByText("Hạ tầng")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("combobox", { name: /Chuyển tiêu chí/i })).not.toBeInTheDocument()
+
+    const lockButton = screen.getByRole("button", { name: "Khóa phiên bản" })
+    expect(lockButton).toBeEnabled()
+    await user.click(lockButton)
+    await user.click(screen.getByRole("button", { name: "Khóa vĩnh viễn" }))
+
+    expect(rpc.lockVersion).toHaveBeenCalledWith({
+      p_baseline_version_id: draft.id,
+      p_expected_revision: draft.revision,
+    })
+  })
+
+  it("blocks lock for hierarchy drafts with dirty or pending input", async () => {
+    const user = userEvent.setup()
+    const draft = createSubgroupOnlyDraft()
+    mockVersions([draft])
+
+    renderTab()
+
+    const groupName = await screen.findByDisplayValue("Yêu cầu chung")
+    await user.type(groupName, " đã sửa")
+    expect(screen.getByRole("button", { name: "Khóa phiên bản" })).toBeDisabled()
+    expect(screen.getByText("Lưu thay đổi trước khi khóa phiên bản.")).toBeInTheDocument()
+
+    await user.clear(groupName)
+    await user.type(groupName, "Yêu cầu chung")
+    await user.click(
+      screen.getByRole("button", {
+        name: "Nhập nhiều dòng cho nhóm I: Yêu cầu chung",
+      })
+    )
+    await user.type(screen.getByRole("textbox", { name: "Nội dung nhập nhanh" }), "Đang chờ")
+
+    expect(screen.getByRole("button", { name: "Khóa phiên bản" })).toBeDisabled()
+    expect(
+      screen.getByText("Hoàn tất hoặc hủy nội dung nhập nhanh trước khi khóa.")
+    ).toBeInTheDocument()
+  })
+
+  it("reloads a concurrently locked hierarchy snapshot into read-only history", async () => {
+    const user = userEvent.setup()
+    const draft = createSubgroupOnlyDraft()
+    const locked = createLockedVersion({
+      id: draft.id,
+      groups: draft.groups,
+    })
+    mockVersions([draft])
+    rpc.lockVersion.mockRejectedValue(
+      new TechnicalConfigurationRpcError(409, { message: "locked_version" })
+    )
+
+    renderTab()
+    await screen.findByText("Hạ tầng")
+    await user.click(screen.getByRole("button", { name: "Khóa phiên bản" }))
+    await user.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: "Khóa vĩnh viễn",
+      })
+    )
+
+    expect(await screen.findByText("Xung đột dữ liệu")).toBeInTheDocument()
+    rpc.listVersions.mockResolvedValueOnce(baselineVersionsResponse([locked]))
+    await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+
+    expect(await screen.findByText("Nội dung chỉ đọc")).toBeInTheDocument()
+    expect(screen.getByText("Hạ tầng")).toBeInTheDocument()
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
@@ -16,6 +16,7 @@ describe("technical configuration workspace shell source boundaries", () => {
       "_components/TechnicalConfigurationOptionResponses.tsx",
       "_components/TechnicalConfigurationBaselineTabStates.tsx",
       "_components/TechnicalConfigurationBaselineEditor.tsx",
+      "_components/TechnicalConfigurationBaselineGroupSection.tsx",
       "_components/TechnicalConfigurationCriteriaSpreadsheet.tsx",
       "_components/TechnicalConfigurationBulkEntryWorkbench.tsx",
       "_components/TechnicalConfigurationAllGroupsOverview.tsx",

--- a/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-bulk-entry-sessions.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-bulk-entry-sessions.test.ts
@@ -46,7 +46,7 @@ describe("useTechnicalConfigurationBulkEntrySessions", () => {
     act(() => {
       result.current.setInput("group-1", "Yêu cầu 1")
       result.current.setInput("group-2", "Yêu cầu 2")
-      result.current.syncGroupKeys(["group-1"])
+      result.current.syncOwnerKeys(["group-1"])
     })
 
     expect(result.current.getSession("group-1")).toEqual({

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import type { TechnicalConfigurationBaselineEditorCriterionOwner } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerValue,
+  type TechnicalConfigurationBaselineCriterionOwnerOption,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+
+type TechnicalConfigurationBaselineCriterionOwnerSelectProps = Readonly<{
+  label: string
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  options: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  disabled: boolean
+  onMove: (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => void
+}>
+
+/** Selects a canonical direct or subgroup owner for one criterion. */
+export function TechnicalConfigurationBaselineCriterionOwnerSelect({
+  label,
+  owner,
+  options,
+  disabled,
+  onMove,
+}: TechnicalConfigurationBaselineCriterionOwnerSelectProps): React.JSX.Element {
+  return (
+    <select
+      aria-label={label}
+      className="h-9 w-full min-w-0 rounded-md border border-input bg-background px-2 text-sm"
+      value={getTechnicalConfigurationBaselineCriterionOwnerValue(owner)}
+      disabled={disabled}
+      onChange={(event) => {
+        const target = options.find((option) => option.value === event.target.value)
+        if (target) onMove(target.owner)
+      }}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor.tsx
@@ -8,23 +8,25 @@ import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technic
 import { useTechnicalConfigurationGroupDisclosure } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationGroupDisclosure"
 import type {
   TechnicalConfigurationBaselineEditorDraft,
-  TechnicalConfigurationBaselineEditorGroup,
   TechnicalConfigurationBaselineEditorValidation,
 } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerOptions,
+  type TechnicalConfigurationBaselineHierarchyAuthoring,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+import {
+  countTechnicalConfigurationGroupValidationErrors,
+  getTechnicalConfigurationFocusTargetGroupKey,
+  getTechnicalConfigurationFocusTargetForGroup,
+  type TechnicalConfigurationFocusTarget,
+} from "./TechnicalConfigurationBaselineEditorUtils"
+
 export type TechnicalConfigurationEntryMode = "row" | "bulk"
-export type TechnicalConfigurationFocusTarget =
-  | { kind: "criterion"; key: string; token: number }
-  | { kind: "group-name"; key: string; token: number }
-  | { kind: "group-disclosure"; key: string; token: number }
-  | { kind: "group-mode-action"; key: string; token: number }
-  | { kind: "bulk-input"; token: number }
-  | { kind: "add-group"; token: number }
-  | { kind: "add-criterion"; key: string; token: number }
-  | null
+export type { TechnicalConfigurationFocusTarget } from "./TechnicalConfigurationBaselineEditorUtils"
 
 type CriterionTextField = "title" | "requirementText"
 
@@ -68,57 +70,10 @@ type TechnicalConfigurationBaselineEditorProps = Readonly<{
   onBulkAccept: () => void
   onSave: () => void
   onToggleFocusMode?: () => void
+  hierarchyAuthoring?: TechnicalConfigurationBaselineHierarchyAuthoring
 }>
 
 const PENDING_BULK_STATUS_ID = "technical-configuration-pending-bulk-status"
-
-function groupContainsCriterion(
-  group: TechnicalConfigurationBaselineEditorGroup,
-  criterionKey: string
-): boolean {
-  if (group.criteria.some((criterion) => criterion.key === criterionKey)) return true
-
-  for (const subgroup of group.subgroups ?? []) {
-    if (subgroup.criteria.some((criterion) => criterion.key === criterionKey)) return true
-  }
-
-  return false
-}
-
-function countGroupValidationErrors(
-  group: TechnicalConfigurationBaselineEditorGroup,
-  validation: TechnicalConfigurationBaselineEditorValidation
-): number {
-  let count = validation.groupErrors[group.key] ? 1 : 0
-
-  for (const criterion of group.criteria) {
-    if (validation.criterionErrors[criterion.key]) count += 1
-  }
-
-  for (const subgroup of group.subgroups ?? []) {
-    if (validation.subgroupErrors?.[subgroup.key]) count += 1
-    for (const criterion of subgroup.criteria) {
-      if (validation.criterionErrors[criterion.key]) count += 1
-    }
-  }
-
-  return count
-}
-
-function getFocusTargetForGroup(
-  focusTarget: TechnicalConfigurationFocusTarget,
-  group: TechnicalConfigurationBaselineEditorGroup,
-  activeValue: string
-): TechnicalConfigurationFocusTarget | null {
-  if (!focusTarget || focusTarget.kind === "add-group") return null
-  if (focusTarget.kind === "criterion") {
-    return groupContainsCriterion(group, focusTarget.key) ? focusTarget : null
-  }
-  if (focusTarget.kind === "bulk-input") {
-    return activeValue === group.key ? focusTarget : null
-  }
-  return focusTarget.key === group.key ? focusTarget : null
-}
 
 /** Composes all editable baseline groups in one definite-height hierarchy. */
 export function TechnicalConfigurationBaselineEditor({
@@ -147,6 +102,7 @@ export function TechnicalConfigurationBaselineEditor({
   onBulkAccept,
   onSave,
   onToggleFocusMode,
+  hierarchyAuthoring,
 }: TechnicalConfigurationBaselineEditorProps): React.JSX.Element {
   const {
     dirty: isDirty,
@@ -157,6 +113,10 @@ export function TechnicalConfigurationBaselineEditor({
     hasPendingBulkInput,
   } = status
   const groupKeys = React.useMemo(() => draft.groups.map((group) => group.key), [draft.groups])
+  const ownerOptions = React.useMemo(
+    () => getTechnicalConfigurationBaselineCriterionOwnerOptions(draft),
+    [draft]
+  )
   const disclosure = useTechnicalConfigurationGroupDisclosure(groupKeys)
   const addGroupRef = React.useRef<HTMLButtonElement>(null)
 
@@ -170,15 +130,11 @@ export function TechnicalConfigurationBaselineEditor({
       return () => window.clearTimeout(timeoutId)
     }
 
-    let targetGroupKey: string | null = null
-    if (focusTarget.kind === "criterion") {
-      targetGroupKey =
-        draft.groups.find((group) => groupContainsCriterion(group, focusTarget.key))?.key ?? null
-    } else if (focusTarget.kind === "bulk-input") {
-      targetGroupKey = activeValue
-    } else {
-      targetGroupKey = focusTarget.key
-    }
+    const targetGroupKey = getTechnicalConfigurationFocusTargetGroupKey(
+      focusTarget,
+      draft.groups,
+      activeValue
+    )
 
     if (targetGroupKey) disclosure.expand(targetGroupKey)
   }, [activeValue, disclosure.expand, draft.groups, focusTarget])
@@ -269,7 +225,10 @@ export function TechnicalConfigurationBaselineEditor({
         ) : (
           draft.groups.map((group, groupIndex) => {
             const mode = activeValue === group.key && entryMode === "bulk" ? "bulk" : "row"
-            const summaryErrorCount = countGroupValidationErrors(group, summaryValidation)
+            const summaryErrorCount = countTechnicalConfigurationGroupValidationErrors(
+              group,
+              summaryValidation
+            )
 
             return (
               <TechnicalConfigurationBaselineGroupSection
@@ -286,8 +245,14 @@ export function TechnicalConfigurationBaselineEditor({
                 summaryErrorCount={summaryErrorCount}
                 pendingInputDescriptionId={PENDING_BULK_STATUS_ID}
                 disabled={isEditingDisabled}
-                focusTarget={getFocusTargetForGroup(focusTarget, group, activeValue)}
+                focusTarget={getTechnicalConfigurationFocusTargetForGroup(
+                  focusTarget,
+                  group,
+                  activeValue
+                )}
                 recentlyAcceptedCriterionKeys={recentlyAcceptedCriterionKeys}
+                ownerOptions={ownerOptions}
+                hierarchyAuthoring={hierarchyAuthoring}
                 onExpandedChange={(expanded) => disclosure.setExpanded(group.key, expanded)}
                 onModeChange={onGroupModeChange}
                 onGroupNameChange={onGroupNameChange}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditorUtils.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditorUtils.ts
@@ -1,0 +1,106 @@
+import type {
+  TechnicalConfigurationBaselineEditorGroup,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+export type TechnicalConfigurationFocusTarget =
+  | { kind: "criterion"; key: string; token: number }
+  | { kind: "group-name"; key: string; token: number }
+  | { kind: "group-disclosure"; key: string; token: number }
+  | { kind: "group-mode-action"; key: string; token: number }
+  | { kind: "bulk-input"; token: number }
+  | { kind: "add-group"; token: number }
+  | { kind: "add-criterion"; key: string; token: number }
+  | { kind: "subgroup-name"; key: string; token: number }
+  | { kind: "subgroup-disclosure"; key: string; token: number }
+  | { kind: "subgroup-mode-action"; key: string; token: number }
+  | { kind: "subgroup-bulk-input"; key: string; token: number }
+  | { kind: "add-subgroup"; key: string; token: number }
+  | { kind: "add-subgroup-criterion"; key: string; token: number }
+  | null
+
+function groupContainsCriterion(
+  group: TechnicalConfigurationBaselineEditorGroup,
+  criterionKey: string
+): boolean {
+  if (group.criteria.some((criterion) => criterion.key === criterionKey)) return true
+
+  return (group.subgroups ?? []).some((subgroup) =>
+    subgroup.criteria.some((criterion) => criterion.key === criterionKey)
+  )
+}
+
+function isSubgroupFocusTarget(
+  focusTarget: Exclude<TechnicalConfigurationFocusTarget, null>
+): boolean {
+  return (
+    focusTarget.kind === "subgroup-name" ||
+    focusTarget.kind === "subgroup-disclosure" ||
+    focusTarget.kind === "subgroup-mode-action" ||
+    focusTarget.kind === "subgroup-bulk-input" ||
+    focusTarget.kind === "add-subgroup-criterion"
+  )
+}
+
+/** Resolves the owning group key for a pending baseline-editor focus target. */
+export function getTechnicalConfigurationFocusTargetGroupKey(
+  focusTarget: Exclude<TechnicalConfigurationFocusTarget, null>,
+  groups: readonly TechnicalConfigurationBaselineEditorGroup[],
+  activeValue: string
+): string | null {
+  if (focusTarget.kind === "add-group") return null
+  if (focusTarget.kind === "criterion") {
+    return groups.find((group) => groupContainsCriterion(group, focusTarget.key))?.key ?? null
+  }
+  if (focusTarget.kind === "bulk-input") return activeValue
+  if (isSubgroupFocusTarget(focusTarget)) {
+    return (
+      groups.find((group) =>
+        (group.subgroups ?? []).some((subgroup) => subgroup.key === focusTarget.key)
+      )?.key ?? null
+    )
+  }
+  return focusTarget.key
+}
+
+/** Counts group, subgroup, and criterion validation errors owned by one group. */
+export function countTechnicalConfigurationGroupValidationErrors(
+  group: TechnicalConfigurationBaselineEditorGroup,
+  validation: TechnicalConfigurationBaselineEditorValidation
+): number {
+  let count = validation.groupErrors[group.key] ? 1 : 0
+
+  for (const criterion of group.criteria) {
+    if (validation.criterionErrors[criterion.key]) count += 1
+  }
+
+  for (const subgroup of group.subgroups ?? []) {
+    if (validation.subgroupErrors?.[subgroup.key]) count += 1
+    for (const criterion of subgroup.criteria) {
+      if (validation.criterionErrors[criterion.key]) count += 1
+    }
+  }
+
+  return count
+}
+
+/** Returns the focus target when it belongs to the supplied editor group. */
+export function getTechnicalConfigurationFocusTargetForGroup(
+  focusTarget: TechnicalConfigurationFocusTarget,
+  group: TechnicalConfigurationBaselineEditorGroup,
+  activeValue: string
+): TechnicalConfigurationFocusTarget | null {
+  if (!focusTarget || focusTarget.kind === "add-group") return null
+  if (focusTarget.kind === "criterion") {
+    return groupContainsCriterion(group, focusTarget.key) ? focusTarget : null
+  }
+  if (focusTarget.kind === "bulk-input") {
+    return activeValue === group.key ? focusTarget : null
+  }
+  if (isSubgroupFocusTarget(focusTarget)) {
+    return (group.subgroups ?? []).some((subgroup) => subgroup.key === focusTarget.key)
+      ? focusTarget
+      : null
+  }
+  return focusTarget.key === group.key ? focusTarget : null
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineFocus.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineFocus.ts
@@ -1,0 +1,5 @@
+/** Scrolls a baseline authoring control into view before focusing it. */
+export function focusTechnicalConfigurationBaselineElement(target: HTMLElement | null): void {
+  target?.scrollIntoView?.({ block: "nearest" })
+  target?.focus()
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupContent.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupContent.tsx
@@ -68,7 +68,7 @@ export function TechnicalConfigurationBaselineGroupContent({
 }: TechnicalConfigurationBaselineGroupContentProps): React.JSX.Element {
   return (
     <CollapsibleContent>
-      <div role="region" aria-label={`Nội dung nhóm ${sectionOrdinal}`} className="py-4">
+      <section aria-label={`Nội dung nhóm ${sectionOrdinal}`} className="py-4">
         {mode === "row" ? (
           <TechnicalConfigurationCriteriaSpreadsheet
             group={group}
@@ -129,7 +129,7 @@ export function TechnicalConfigurationBaselineGroupContent({
             onExpandedChange={(expanded) => onSubgroupExpandedChange(subgroup.key, expanded)}
           />
         ))}
-      </div>
+      </section>
     </CollapsibleContent>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupContent.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupContent.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { TechnicalConfigurationBaselineSubgroupSection } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection"
+import { TechnicalConfigurationBulkEntryWorkbench } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBulkEntryWorkbench"
+import { TechnicalConfigurationCriteriaSpreadsheet } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCriteriaSpreadsheet"
+import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import { CollapsibleContent } from "@/components/ui/collapsible"
+
+import type { TechnicalConfigurationBaselineGroupSectionProps } from "./TechnicalConfigurationBaselineGroupSectionTypes"
+
+type TechnicalConfigurationBaselineGroupContentProps = Readonly<
+  Pick<
+    TechnicalConfigurationBaselineGroupSectionProps,
+    | "group"
+    | "mode"
+    | "bulkSession"
+    | "subgroupErrors"
+    | "criterionErrors"
+    | "disabled"
+    | "focusTarget"
+    | "recentlyAcceptedCriterionKeys"
+    | "ownerOptions"
+    | "hierarchyAuthoring"
+    | "pendingInputDescriptionId"
+    | "onCriterionTextChange"
+    | "onMoveCriterion"
+    | "onDeleteCriterion"
+    | "onBulkInputChange"
+    | "onBulkPreview"
+    | "onBulkCancel"
+    | "onBulkAccept"
+  > & {
+    ordinal: number
+    sectionOrdinal: string
+    groupLabel: string
+    subgroups: NonNullable<TechnicalConfigurationBaselineEditorGroup["subgroups"]>
+    expandedSubgroupKeys: ReadonlySet<string>
+    onSubgroupExpandedChange: (subgroupKey: string, expanded: boolean) => void
+  }
+>
+
+/** Renders direct criteria and nested subgroup editors inside one expanded group. */
+export function TechnicalConfigurationBaselineGroupContent({
+  group,
+  ordinal,
+  sectionOrdinal,
+  groupLabel,
+  mode,
+  bulkSession,
+  subgroups,
+  expandedSubgroupKeys,
+  subgroupErrors,
+  criterionErrors,
+  disabled,
+  focusTarget,
+  recentlyAcceptedCriterionKeys,
+  ownerOptions,
+  hierarchyAuthoring,
+  pendingInputDescriptionId,
+  onCriterionTextChange,
+  onMoveCriterion,
+  onDeleteCriterion,
+  onBulkInputChange,
+  onBulkPreview,
+  onBulkCancel,
+  onBulkAccept,
+  onSubgroupExpandedChange,
+}: TechnicalConfigurationBaselineGroupContentProps): React.JSX.Element {
+  return (
+    <CollapsibleContent>
+      <div role="region" aria-label={`Nội dung nhóm ${sectionOrdinal}`} className="py-4">
+        {mode === "row" ? (
+          <TechnicalConfigurationCriteriaSpreadsheet
+            group={group}
+            groupIndex={ordinal}
+            criterionErrors={criterionErrors}
+            disabled={disabled}
+            focusCriterionKey={focusTarget?.kind === "criterion" ? focusTarget.key : null}
+            focusCriterionToken={focusTarget?.kind === "criterion" ? focusTarget.token : null}
+            recentlyAcceptedCriterionKeys={recentlyAcceptedCriterionKeys}
+            onCriterionTextChange={(criterionKey, field, value) =>
+              onCriterionTextChange(group.key, criterionKey, field, value)
+            }
+            onMoveCriterion={(criterionIndex, offset) =>
+              onMoveCriterion(group.key, criterionIndex, offset)
+            }
+            onDeleteCriterion={(criterionKey) => onDeleteCriterion(group.key, criterionKey)}
+            ownerOptions={hierarchyAuthoring ? ownerOptions : undefined}
+            onMoveCriterionToOwner={
+              hierarchyAuthoring
+                ? (criterionKey, owner) =>
+                    hierarchyAuthoring.onMoveCriterionToOwner(
+                      { groupKey: group.key, subgroupKey: null },
+                      criterionKey,
+                      owner
+                    )
+                : undefined
+            }
+          />
+        ) : (
+          <TechnicalConfigurationBulkEntryWorkbench
+            groupName={groupLabel}
+            existingCriterionCount={group.criteria.length}
+            session={bulkSession}
+            disabled={disabled}
+            focusInputToken={focusTarget?.kind === "bulk-input" ? focusTarget.token : null}
+            onInputChange={onBulkInputChange}
+            onPreview={onBulkPreview}
+            onCancel={onBulkCancel}
+            onAccept={onBulkAccept}
+          />
+        )}
+        {subgroups.map((subgroup, subgroupIndex) => (
+          <TechnicalConfigurationBaselineSubgroupSection
+            key={subgroup.key}
+            groupKey={group.key}
+            subgroup={subgroup}
+            sectionOrdinal={sectionOrdinal}
+            subgroupIndex={subgroupIndex}
+            subgroupCount={subgroups.length}
+            expanded={expandedSubgroupKeys.has(subgroup.key)}
+            subgroupError={subgroupErrors[subgroup.key]}
+            criterionErrors={criterionErrors}
+            focusTarget={focusTarget}
+            disabled={disabled}
+            ownerOptions={ownerOptions}
+            pendingInputDescriptionId={pendingInputDescriptionId}
+            authoring={hierarchyAuthoring}
+            onExpandedChange={(expanded) => onSubgroupExpandedChange(subgroup.key, expanded)}
+          />
+        ))}
+      </div>
+    </CollapsibleContent>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSection.tsx
@@ -11,67 +11,23 @@ import {
   Trash2,
 } from "lucide-react"
 
-import type {
-  TechnicalConfigurationEntryMode,
-  TechnicalConfigurationFocusTarget,
-} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
-import { TechnicalConfigurationBaselineSubgroupSection } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection"
-import { TechnicalConfigurationBulkEntryWorkbench } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBulkEntryWorkbench"
-import { TechnicalConfigurationCriteriaSpreadsheet } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCriteriaSpreadsheet"
-import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
 import { useTechnicalConfigurationGroupDisclosure } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationGroupDisclosure"
 import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import { formatTechnicalConfigurationBaselineSectionOrdinal } from "@/app/(app)/technical-configurations/technical-configuration-baseline-ordinals"
 import { hasTechnicalConfigurationBulkEntryInput } from "@/app/(app)/technical-configurations/bulk-entry-utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { Collapsible, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { Input } from "@/components/ui/input"
 
 import { TechnicalConfigurationBaselineEditorIconButton as IconButton } from "./TechnicalConfigurationBaselineEditorControls"
+import { focusTechnicalConfigurationBaselineElement } from "./TechnicalConfigurationBaselineFocus"
+import { TechnicalConfigurationBaselineGroupContent } from "./TechnicalConfigurationBaselineGroupContent"
+import type { TechnicalConfigurationBaselineGroupSectionProps } from "./TechnicalConfigurationBaselineGroupSectionTypes"
 
-type CriterionTextField = "title" | "requirementText"
 const EMPTY_SUBGROUPS: TechnicalConfigurationBaselineEditorGroup["subgroups"] = []
 
-export type TechnicalConfigurationBaselineGroupSectionProps = Readonly<{
-  group: TechnicalConfigurationBaselineEditorGroup
-  groupIndex: number
-  groupCount: number
-  expanded: boolean
-  mode: TechnicalConfigurationEntryMode
-  bulkSession: TechnicalConfigurationBulkEntrySession
-  groupError?: string
-  subgroupErrors: Record<string, string>
-  criterionErrors: Record<string, string>
-  summaryErrorCount: number
-  pendingInputDescriptionId?: string
-  disabled: boolean
-  focusTarget: TechnicalConfigurationFocusTarget
-  recentlyAcceptedCriterionKeys: ReadonlySet<string>
-  onExpandedChange: (expanded: boolean) => void
-  onModeChange: (groupKey: string, mode: TechnicalConfigurationEntryMode) => void
-  onGroupNameChange: (groupKey: string, name: string) => void
-  onMoveGroup: (groupIndex: number, offset: -1 | 1) => void
-  onDeleteGroup: (groupKey: string) => void
-  onCriterionTextChange: (
-    groupKey: string,
-    criterionKey: string,
-    field: CriterionTextField,
-    value: string
-  ) => void
-  onMoveCriterion: (groupKey: string, criterionIndex: number, offset: -1 | 1) => void
-  onDeleteCriterion: (groupKey: string, criterionKey: string) => void
-  onAddCriterion: (groupKey: string) => void
-  onBulkInputChange: (input: string) => void
-  onBulkPreview: () => void
-  onBulkCancel: () => void
-  onBulkAccept: () => void
-}>
-
-function focusElement(target: HTMLElement | null): void {
-  target?.scrollIntoView?.({ block: "nearest" })
-  target?.focus()
-}
+export type { TechnicalConfigurationBaselineGroupSectionProps } from "./TechnicalConfigurationBaselineGroupSectionTypes"
 
 /** Renders one editable, independently collapsible baseline criterion group. */
 export function TechnicalConfigurationBaselineGroupSection({
@@ -89,6 +45,8 @@ export function TechnicalConfigurationBaselineGroupSection({
   disabled,
   focusTarget,
   recentlyAcceptedCriterionKeys,
+  ownerOptions,
+  hierarchyAuthoring,
   onExpandedChange,
   onModeChange,
   onGroupNameChange,
@@ -107,9 +65,17 @@ export function TechnicalConfigurationBaselineGroupSection({
   const sectionOrdinal = formatTechnicalConfigurationBaselineSectionOrdinal(ordinal)
   const groupLabel = group.name.trim() || `Nhóm ${sectionOrdinal}`
   const groupErrorId = groupError ? `baseline-group-${group.key}-error` : undefined
-  const hasPendingBulkInput = hasTechnicalConfigurationBulkEntryInput(bulkSession.input)
   const modeActionLabel = mode === "row" ? "Nhập nhiều dòng" : "Chỉnh từng dòng"
   const subgroups = group.subgroups ?? EMPTY_SUBGROUPS
+  const hasPendingBulkInput =
+    hasTechnicalConfigurationBulkEntryInput(bulkSession.input) ||
+    (hierarchyAuthoring?.getBulkSession
+      ? subgroups.some((subgroup) =>
+          hasTechnicalConfigurationBulkEntryInput(
+            hierarchyAuthoring.getBulkSession(subgroup.key).input
+          )
+        )
+      : false)
   const subgroupKeys = React.useMemo(() => subgroups.map((subgroup) => subgroup.key), [subgroups])
   const {
     expandedGroupKeys: expandedSubgroupKeys,
@@ -134,6 +100,7 @@ export function TechnicalConfigurationBaselineGroupSection({
   const groupNameRef = React.useRef<HTMLInputElement>(null)
   const modeActionRef = React.useRef<HTMLButtonElement>(null)
   const addCriterionRef = React.useRef<HTMLButtonElement>(null)
+  const addSubgroupRef = React.useRef<HTMLButtonElement>(null)
 
   React.useEffect(() => {
     if (!targetSubgroupKey || !targetSubgroupFocusRequest) return
@@ -147,13 +114,15 @@ export function TechnicalConfigurationBaselineGroupSection({
     if (!focusTarget) return
     const timeoutId = window.setTimeout(() => {
       if (focusTarget.kind === "group-name" && focusTarget.key === group.key) {
-        focusElement(groupNameRef.current)
+        focusTechnicalConfigurationBaselineElement(groupNameRef.current)
       } else if (focusTarget.kind === "group-disclosure" && focusTarget.key === group.key) {
-        focusElement(disclosureRef.current)
+        focusTechnicalConfigurationBaselineElement(disclosureRef.current)
       } else if (focusTarget.kind === "group-mode-action" && focusTarget.key === group.key) {
-        focusElement(modeActionRef.current)
+        focusTechnicalConfigurationBaselineElement(modeActionRef.current)
       } else if (focusTarget.kind === "add-criterion" && focusTarget.key === group.key) {
-        focusElement(addCriterionRef.current)
+        focusTechnicalConfigurationBaselineElement(addCriterionRef.current)
+      } else if (focusTarget.kind === "add-subgroup" && focusTarget.key === group.key) {
+        focusTechnicalConfigurationBaselineElement(addSubgroupRef.current)
       }
     }, 0)
     return () => window.clearTimeout(timeoutId)
@@ -248,6 +217,20 @@ export function TechnicalConfigurationBaselineGroupSection({
               <Plus className="size-4" aria-hidden="true" />
               Thêm tiêu chí
             </Button>
+            {hierarchyAuthoring ? (
+              <Button
+                ref={addSubgroupRef}
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                aria-label={`Thêm nhóm con vào nhóm ${sectionOrdinal}`}
+                onClick={() => hierarchyAuthoring.onAddSubgroup(group.key)}
+              >
+                <Plus className="size-4" aria-hidden="true" />
+                Thêm nhóm con
+              </Button>
+            ) : null}
             <IconButton
               label={`Di chuyển nhóm ${sectionOrdinal} lên`}
               title="Di chuyển lên"
@@ -280,53 +263,32 @@ export function TechnicalConfigurationBaselineGroupSection({
           </div>
         </div>
 
-        <CollapsibleContent>
-          <div role="region" aria-label={`Nội dung nhóm ${sectionOrdinal}`} className="py-4">
-            {mode === "row" ? (
-              <TechnicalConfigurationCriteriaSpreadsheet
-                group={group}
-                groupIndex={ordinal}
-                criterionErrors={criterionErrors}
-                disabled={disabled}
-                focusCriterionKey={focusTarget?.kind === "criterion" ? focusTarget.key : null}
-                focusCriterionToken={focusTarget?.kind === "criterion" ? focusTarget.token : null}
-                recentlyAcceptedCriterionKeys={recentlyAcceptedCriterionKeys}
-                onCriterionTextChange={(criterionKey, field, value) =>
-                  onCriterionTextChange(group.key, criterionKey, field, value)
-                }
-                onMoveCriterion={(criterionIndex, offset) =>
-                  onMoveCriterion(group.key, criterionIndex, offset)
-                }
-                onDeleteCriterion={(criterionKey) => onDeleteCriterion(group.key, criterionKey)}
-              />
-            ) : (
-              <TechnicalConfigurationBulkEntryWorkbench
-                groupName={groupLabel}
-                existingCriterionCount={group.criteria.length}
-                session={bulkSession}
-                disabled={disabled}
-                focusInputToken={focusTarget?.kind === "bulk-input" ? focusTarget.token : null}
-                onInputChange={onBulkInputChange}
-                onPreview={onBulkPreview}
-                onCancel={onBulkCancel}
-                onAccept={onBulkAccept}
-              />
-            )}
-            {subgroups.map((subgroup, subgroupIndex) => (
-              <TechnicalConfigurationBaselineSubgroupSection
-                key={subgroup.key}
-                subgroup={subgroup}
-                sectionOrdinal={sectionOrdinal}
-                subgroupIndex={subgroupIndex}
-                expanded={expandedSubgroupKeys.has(subgroup.key)}
-                subgroupError={subgroupErrors[subgroup.key]}
-                criterionErrors={criterionErrors}
-                focusTarget={focusTarget}
-                onExpandedChange={(expanded) => setSubgroupExpanded(subgroup.key, expanded)}
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
+        <TechnicalConfigurationBaselineGroupContent
+          group={group}
+          ordinal={ordinal}
+          sectionOrdinal={sectionOrdinal}
+          groupLabel={groupLabel}
+          mode={mode}
+          bulkSession={bulkSession}
+          subgroups={subgroups}
+          expandedSubgroupKeys={expandedSubgroupKeys}
+          subgroupErrors={subgroupErrors}
+          criterionErrors={criterionErrors}
+          disabled={disabled}
+          focusTarget={focusTarget}
+          recentlyAcceptedCriterionKeys={recentlyAcceptedCriterionKeys}
+          ownerOptions={ownerOptions}
+          hierarchyAuthoring={hierarchyAuthoring}
+          pendingInputDescriptionId={pendingInputDescriptionId}
+          onCriterionTextChange={onCriterionTextChange}
+          onMoveCriterion={onMoveCriterion}
+          onDeleteCriterion={onDeleteCriterion}
+          onBulkInputChange={onBulkInputChange}
+          onBulkPreview={onBulkPreview}
+          onBulkCancel={onBulkCancel}
+          onBulkAccept={onBulkAccept}
+          onSubgroupExpandedChange={setSubgroupExpanded}
+        />
       </section>
     </Collapsible>
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSectionTypes.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineGroupSectionTypes.ts
@@ -1,0 +1,50 @@
+import type {
+  TechnicalConfigurationEntryMode,
+  TechnicalConfigurationFocusTarget,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
+import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+import type {
+  TechnicalConfigurationBaselineCriterionOwnerOption,
+  TechnicalConfigurationBaselineHierarchyAuthoring,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+
+type CriterionTextField = "title" | "requirementText"
+
+export type TechnicalConfigurationBaselineGroupSectionProps = Readonly<{
+  group: TechnicalConfigurationBaselineEditorGroup
+  groupIndex: number
+  groupCount: number
+  expanded: boolean
+  mode: TechnicalConfigurationEntryMode
+  bulkSession: TechnicalConfigurationBulkEntrySession
+  groupError?: string
+  subgroupErrors: Record<string, string>
+  criterionErrors: Record<string, string>
+  summaryErrorCount: number
+  pendingInputDescriptionId?: string
+  disabled: boolean
+  focusTarget: TechnicalConfigurationFocusTarget
+  recentlyAcceptedCriterionKeys: ReadonlySet<string>
+  ownerOptions: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  hierarchyAuthoring?: TechnicalConfigurationBaselineHierarchyAuthoring
+  onExpandedChange: (expanded: boolean) => void
+  onModeChange: (groupKey: string, mode: TechnicalConfigurationEntryMode) => void
+  onGroupNameChange: (groupKey: string, name: string) => void
+  onMoveGroup: (groupIndex: number, offset: -1 | 1) => void
+  onDeleteGroup: (groupKey: string) => void
+  onCriterionTextChange: (
+    groupKey: string,
+    criterionKey: string,
+    field: CriterionTextField,
+    value: string
+  ) => void
+  onMoveCriterion: (groupKey: string, criterionIndex: number, offset: -1 | 1) => void
+  onDeleteCriterion: (groupKey: string, criterionKey: string) => void
+  onAddCriterion: (groupKey: string) => void
+  onBulkInputChange: (input: string) => void
+  onBulkPreview: () => void
+  onBulkCancel: () => void
+  onBulkAccept: () => void
+}>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyAuthoring.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyAuthoring.ts
@@ -1,0 +1,90 @@
+import type { TechnicalConfigurationBulkEntrySession } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import type {
+  TechnicalConfigurationBaselineEditorCriterionOwner,
+  TechnicalConfigurationBaselineEditorDraft,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import { formatTechnicalConfigurationBaselineSectionOrdinal } from "@/app/(app)/technical-configurations/technical-configuration-baseline-ordinals"
+
+type CriterionTextField = "title" | "requirementText"
+
+export type TechnicalConfigurationBaselineCriterionOwnerOption = Readonly<{
+  label: string
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  value: string
+}>
+
+export type TechnicalConfigurationBaselineHierarchyAuthoring = Readonly<{
+  activeOwnerKey: string
+  entryMode: "row" | "bulk"
+  getBulkSession: (ownerKey: string) => TechnicalConfigurationBulkEntrySession
+  onOwnerModeChange: (ownerKey: string, mode: "row" | "bulk") => void
+  onAddSubgroup: (groupKey: string) => void
+  onSubgroupNameChange: (groupKey: string, subgroupKey: string, name: string) => void
+  onMoveSubgroup: (groupKey: string, subgroupIndex: number, offset: -1 | 1) => void
+  onDeleteSubgroup: (groupKey: string, subgroupKey: string) => void
+  onCriterionTextChange: (
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionKey: string,
+    field: CriterionTextField,
+    value: string
+  ) => void
+  onMoveCriterionWithinOwner: (
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionIndex: number,
+    offset: -1 | 1
+  ) => void
+  onMoveCriterionToOwner: (
+    sourceOwner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionKey: string,
+    targetOwner: TechnicalConfigurationBaselineEditorCriterionOwner
+  ) => void
+  onDeleteCriterion: (
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionKey: string
+  ) => void
+  onAddCriterion: (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => void
+  onBulkInputChange: (ownerKey: string, input: string) => void
+  onBulkPreview: (ownerKey: string) => void
+  onBulkCancel: (ownerKey: string) => void
+  onBulkAccept: (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => void
+}>
+
+/** Returns the stable UI/session key for one criterion owner. */
+export function getTechnicalConfigurationBaselineCriterionOwnerKey(
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+): string {
+  return owner.subgroupKey ?? owner.groupKey
+}
+
+/** Returns the form value used by criterion owner selectors. */
+export function getTechnicalConfigurationBaselineCriterionOwnerValue(
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+): string {
+  return `${owner.groupKey}:${owner.subgroupKey ?? "direct"}`
+}
+
+/** Builds canonical direct/subgroup destinations for criterion move controls. */
+export function getTechnicalConfigurationBaselineCriterionOwnerOptions(
+  draft: TechnicalConfigurationBaselineEditorDraft
+): TechnicalConfigurationBaselineCriterionOwnerOption[] {
+  return draft.groups.flatMap((group, groupIndex) => {
+    const sectionOrdinal = formatTechnicalConfigurationBaselineSectionOrdinal(groupIndex + 1)
+    const sectionLabel = group.name.trim() || `Nhóm ${sectionOrdinal}`
+    const directOwner = { groupKey: group.key, subgroupKey: null }
+    const directOption: TechnicalConfigurationBaselineCriterionOwnerOption = {
+      label: `${sectionOrdinal}. ${sectionLabel} - Trực tiếp`,
+      owner: directOwner,
+      value: getTechnicalConfigurationBaselineCriterionOwnerValue(directOwner),
+    }
+    const subgroupOptions = (group.subgroups ?? []).map((subgroup, subgroupIndex) => {
+      const owner = { groupKey: group.key, subgroupKey: subgroup.key }
+      return {
+        label: `${sectionOrdinal}.${subgroupIndex + 1} ${subgroup.name.trim() || `Nhóm con ${subgroupIndex + 1}`}`,
+        owner,
+        value: getTechnicalConfigurationBaselineCriterionOwnerValue(owner),
+      }
+    })
+
+    return [directOption, ...subgroupOptions]
+  })
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria.tsx
@@ -1,11 +1,34 @@
 "use client"
 
 import * as React from "react"
+import { ArrowDown, ArrowUp, Trash2 } from "lucide-react"
 
-import type { TechnicalConfigurationBaselineEditorCriterion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import type {
+  TechnicalConfigurationBaselineEditorCriterion,
+  TechnicalConfigurationBaselineEditorCriterionOwner,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+
+import { TechnicalConfigurationBaselineCriterionOwnerSelect } from "./TechnicalConfigurationBaselineCriterionOwnerSelect"
+import { TechnicalConfigurationBaselineEditorIconButton as IconButton } from "./TechnicalConfigurationBaselineEditorControls"
+import type { TechnicalConfigurationBaselineCriterionOwnerOption } from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+
+type CriterionTextField = "title" | "requirementText"
+
+type SubgroupCriteriaAuthoring = Readonly<{
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  ownerOptions: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  disabled: boolean
+  onCriterionTextChange: (criterionKey: string, field: CriterionTextField, value: string) => void
+  onMoveCriterion: (criterionIndex: number, offset: -1 | 1) => void
+  onMoveCriterionToOwner: (
+    criterionKey: string,
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  ) => void
+  onDeleteCriterion: (criterionKey: string) => void
+}>
 
 type TechnicalConfigurationBaselineSubgroupCriteriaProps = Readonly<{
   criteria: readonly TechnicalConfigurationBaselineEditorCriterion[]
@@ -14,10 +37,13 @@ type TechnicalConfigurationBaselineSubgroupCriteriaProps = Readonly<{
   criterionErrors: Record<string, string>
   focusCriterionKey: string | null
   focusCriterionToken: number | null
+  authoring?: SubgroupCriteriaAuthoring
 }>
 
 const RESPONSIVE_COLUMNS =
   "grid-cols-1 md:grid-cols-2 xl:grid-cols-[3rem_7rem_minmax(0,0.8fr)_minmax(0,2fr)_7rem]"
+const AUTHORING_RESPONSIVE_COLUMNS =
+  "grid-cols-1 md:grid-cols-2 xl:grid-cols-[3rem_7rem_minmax(0,0.8fr)_minmax(0,2fr)_minmax(0,1fr)_7rem_7rem]"
 
 /** Presents subgroup criteria without mounting the P4C authoring controls. */
 export function TechnicalConfigurationBaselineSubgroupCriteria({
@@ -27,9 +53,11 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
   criterionErrors,
   focusCriterionKey,
   focusCriterionToken,
+  authoring,
 }: TechnicalConfigurationBaselineSubgroupCriteriaProps): React.JSX.Element {
   const requirementRefs = React.useRef(new Map<string, HTMLTextAreaElement>())
   const subgroupContext = `nhóm con ${subgroupOrdinal}, nhóm ${sectionOrdinal}`
+  const columns = authoring ? AUTHORING_RESPONSIVE_COLUMNS : RESPONSIVE_COLUMNS
 
   React.useEffect(() => {
     if (!focusCriterionKey) return
@@ -61,7 +89,7 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
               <div
                 key={criterion.key}
                 data-testid="baseline-subgroup-criterion-grid"
-                className={`grid ${RESPONSIVE_COLUMNS} min-w-0 items-start gap-3 bg-background px-3 py-3 md:gap-0 md:px-0 md:py-0`}
+                className={`grid ${columns} min-w-0 items-start gap-3 bg-background px-3 py-3 md:gap-0 md:px-0 md:py-0`}
               >
                 <span className="text-sm font-medium md:px-3 md:py-4 md:text-center">
                   <span className="mr-2 text-xs text-muted-foreground">STT</span>
@@ -82,7 +110,11 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
                     id={`baseline-subgroup-title-${criterion.key}`}
                     aria-label={`Tiêu đề ${criterionLabel}`}
                     value={criterion.title}
-                    readOnly
+                    readOnly={!authoring}
+                    disabled={authoring?.disabled}
+                    onChange={(event) =>
+                      authoring?.onCriterionTextChange(criterion.key, "title", event.target.value)
+                    }
                   />
                 </div>
                 <div className="min-w-0 md:px-2 md:py-2">
@@ -101,9 +133,17 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
                     aria-label={`Nội dung yêu cầu ${criterionLabel}`}
                     className="min-h-20 resize-y whitespace-pre-wrap"
                     value={criterion.requirementText}
-                    readOnly
+                    readOnly={!authoring}
+                    disabled={authoring?.disabled}
                     aria-invalid={Boolean(error)}
                     aria-describedby={errorId}
+                    onChange={(event) =>
+                      authoring?.onCriterionTextChange(
+                        criterion.key,
+                        "requirementText",
+                        event.target.value
+                      )
+                    }
                   />
                   {error ? (
                     <p id={errorId} className="mt-1 text-sm text-destructive">
@@ -111,6 +151,20 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
                     </p>
                   ) : null}
                 </div>
+                {authoring ? (
+                  <div className="min-w-0 md:px-2 md:py-2">
+                    <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                      Vị trí
+                    </span>
+                    <TechnicalConfigurationBaselineCriterionOwnerSelect
+                      label={`Chuyển ${criterionLabel}`}
+                      owner={authoring.owner}
+                      options={authoring.ownerOptions}
+                      disabled={authoring.disabled}
+                      onMove={(owner) => authoring.onMoveCriterionToOwner(criterion.key, owner)}
+                    />
+                  </div>
+                ) : null}
                 <div className="md:px-3 md:py-3">
                   <span className="mb-1 block text-xs font-medium text-muted-foreground">
                     Trạng thái
@@ -119,6 +173,35 @@ export function TechnicalConfigurationBaselineSubgroupCriteria({
                     {error ? "Có lỗi" : "Hợp lệ"}
                   </Badge>
                 </div>
+                {authoring ? (
+                  <div className="flex items-center gap-1 md:justify-center md:px-2 md:py-2">
+                    <IconButton
+                      label={`Di chuyển ${criterionLabel} lên`}
+                      title="Di chuyển lên"
+                      disabled={authoring.disabled || criterionIndex === 0}
+                      onClick={() => authoring.onMoveCriterion(criterionIndex, -1)}
+                    >
+                      <ArrowUp className="size-4" />
+                    </IconButton>
+                    <IconButton
+                      label={`Di chuyển ${criterionLabel} xuống`}
+                      title="Di chuyển xuống"
+                      disabled={authoring.disabled || criterionIndex === criteria.length - 1}
+                      onClick={() => authoring.onMoveCriterion(criterionIndex, 1)}
+                    >
+                      <ArrowDown className="size-4" />
+                    </IconButton>
+                    <IconButton
+                      label={`Xóa ${criterionLabel}`}
+                      title="Xóa tiêu chí"
+                      disabled={authoring.disabled}
+                      destructive
+                      onClick={() => authoring.onDeleteCriterion(criterion.key)}
+                    >
+                      <Trash2 className="size-4" />
+                    </IconButton>
+                  </div>
+                ) : null}
               </div>
             )
           })}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria.tsx
@@ -45,7 +45,7 @@ const RESPONSIVE_COLUMNS =
 const AUTHORING_RESPONSIVE_COLUMNS =
   "grid-cols-1 md:grid-cols-2 xl:grid-cols-[3rem_7rem_minmax(0,0.8fr)_minmax(0,2fr)_minmax(0,1fr)_7rem_7rem]"
 
-/** Presents subgroup criteria without mounting the P4C authoring controls. */
+/** Presents subgroup criteria with optional P4C authoring controls. */
 export function TechnicalConfigurationBaselineSubgroupCriteria({
   criteria,
   sectionOrdinal,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection.tsx
@@ -48,7 +48,7 @@ type TechnicalConfigurationBaselineSubgroupSectionProps = Readonly<{
   onExpandedChange: (expanded: boolean) => void
 }>
 
-/** Renders one presentation-only subgroup structural row and its criteria. */
+/** Renders one subgroup row with optional P4C authoring controls. */
 export function TechnicalConfigurationBaselineSubgroupSection({
   groupKey,
   subgroup,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupSection.tsx
@@ -1,35 +1,68 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ClipboardPaste,
+  ListChecks,
+  Plus,
+  Trash2,
+} from "lucide-react"
 
 import type { TechnicalConfigurationFocusTarget } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
 import { TechnicalConfigurationBaselineSubgroupCriteria } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineSubgroupCriteria"
-import type { TechnicalConfigurationBaselineEditorSubgroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import { TechnicalConfigurationBulkEntryWorkbench } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBulkEntryWorkbench"
+import type {
+  TechnicalConfigurationBaselineEditorCriterionOwner,
+  TechnicalConfigurationBaselineEditorSubgroup,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import { hasTechnicalConfigurationBulkEntryInput } from "@/app/(app)/technical-configurations/bulk-entry-utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { Input } from "@/components/ui/input"
+
+import { TechnicalConfigurationBaselineEditorIconButton as IconButton } from "./TechnicalConfigurationBaselineEditorControls"
+import type {
+  TechnicalConfigurationBaselineCriterionOwnerOption,
+  TechnicalConfigurationBaselineHierarchyAuthoring,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+import { focusTechnicalConfigurationBaselineElement } from "./TechnicalConfigurationBaselineFocus"
 
 type TechnicalConfigurationBaselineSubgroupSectionProps = Readonly<{
+  groupKey: string
   subgroup: TechnicalConfigurationBaselineEditorSubgroup
   sectionOrdinal: string
   subgroupIndex: number
+  subgroupCount: number
   expanded: boolean
   subgroupError?: string
   criterionErrors: Record<string, string>
   focusTarget: TechnicalConfigurationFocusTarget
+  disabled: boolean
+  ownerOptions: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  pendingInputDescriptionId?: string
+  authoring?: TechnicalConfigurationBaselineHierarchyAuthoring
   onExpandedChange: (expanded: boolean) => void
 }>
 
 /** Renders one presentation-only subgroup structural row and its criteria. */
 export function TechnicalConfigurationBaselineSubgroupSection({
+  groupKey,
   subgroup,
   sectionOrdinal,
   subgroupIndex,
+  subgroupCount,
   expanded,
   subgroupError,
   criterionErrors,
   focusTarget,
+  disabled,
+  ownerOptions,
+  pendingInputDescriptionId,
+  authoring,
   onExpandedChange,
 }: TechnicalConfigurationBaselineSubgroupSectionProps): React.JSX.Element {
   const subgroupOrdinal = subgroupIndex + 1
@@ -47,6 +80,37 @@ export function TechnicalConfigurationBaselineSubgroupSection({
   const criterionErrorCount = subgroup.criteria.filter(
     (criterion) => criterionErrors[criterion.key]
   ).length
+  const owner: TechnicalConfigurationBaselineEditorCriterionOwner = {
+    groupKey,
+    subgroupKey: subgroup.key,
+  }
+  const mode =
+    authoring?.activeOwnerKey === subgroup.key && authoring.entryMode === "bulk" ? "bulk" : "row"
+  const bulkSession = authoring?.getBulkSession(subgroup.key)
+  const hasPendingBulkInput = hasTechnicalConfigurationBulkEntryInput(bulkSession?.input ?? "")
+  const modeActionLabel = mode === "row" ? "Nhập nhiều dòng" : "Chỉnh từng dòng"
+  const disclosureRef = React.useRef<HTMLButtonElement>(null)
+  const subgroupNameRef = React.useRef<HTMLInputElement>(null)
+  const modeActionRef = React.useRef<HTMLButtonElement>(null)
+  const addCriterionRef = React.useRef<HTMLButtonElement>(null)
+
+  React.useEffect(() => {
+    if (!focusTarget || !("key" in focusTarget) || focusTarget.key !== subgroup.key) return
+
+    const timeoutId = window.setTimeout(() => {
+      if (focusTarget.kind === "subgroup-name") {
+        focusTechnicalConfigurationBaselineElement(subgroupNameRef.current)
+      } else if (focusTarget.kind === "subgroup-disclosure") {
+        focusTechnicalConfigurationBaselineElement(disclosureRef.current)
+      } else if (focusTarget.kind === "subgroup-mode-action") {
+        focusTechnicalConfigurationBaselineElement(modeActionRef.current)
+      } else if (focusTarget.kind === "add-subgroup-criterion") {
+        focusTechnicalConfigurationBaselineElement(addCriterionRef.current)
+      }
+    }, 0)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [focusTarget, subgroup.key])
 
   return (
     <Collapsible open={expanded} onOpenChange={onExpandedChange}>
@@ -55,10 +119,11 @@ export function TechnicalConfigurationBaselineSubgroupSection({
         data-testid={`baseline-subgroup-${subgroup.key}`}
         className="min-w-0 border-t bg-muted/10"
       >
-        <div className="grid min-w-0 gap-3 px-3 py-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-start">
+        <div className="grid min-w-0 gap-3 px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <div className="flex min-w-0 items-start gap-2">
             <CollapsibleTrigger asChild>
               <Button
+                ref={disclosureRef}
                 type="button"
                 variant="ghost"
                 size="icon"
@@ -78,7 +143,21 @@ export function TechnicalConfigurationBaselineSubgroupSection({
               {subgroupOrdinal}
             </span>
             <div className="min-w-0 pt-1">
-              <h3 className="break-words text-sm font-semibold">{subgroupLabel}</h3>
+              {authoring ? (
+                <Input
+                  ref={subgroupNameRef}
+                  aria-label={`Tên nhóm con ${subgroupOrdinal} của nhóm ${sectionOrdinal}`}
+                  value={subgroup.name}
+                  disabled={disabled}
+                  aria-invalid={Boolean(subgroupError)}
+                  aria-describedby={subgroupErrorId}
+                  onChange={(event) =>
+                    authoring.onSubgroupNameChange(groupKey, subgroup.key, event.target.value)
+                  }
+                />
+              ) : (
+                <h3 className="break-words text-sm font-semibold">{subgroupLabel}</h3>
+              )}
               <div className="mt-2 flex flex-wrap items-center gap-2">
                 <Badge variant="secondary">{subgroup.criteria.length} tiêu chí</Badge>
                 {subgroupError || criterionErrorCount > 0 ? (
@@ -94,18 +173,116 @@ export function TechnicalConfigurationBaselineSubgroupSection({
               ) : null}
             </div>
           </div>
+          {authoring ? (
+            <div className="flex flex-wrap items-center gap-1 sm:justify-end">
+              <Button
+                ref={modeActionRef}
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                aria-label={`${modeActionLabel} cho ${subgroupContext}`}
+                onClick={() =>
+                  authoring.onOwnerModeChange(subgroup.key, mode === "row" ? "bulk" : "row")
+                }
+              >
+                {mode === "row" ? (
+                  <ClipboardPaste className="size-4" aria-hidden="true" />
+                ) : (
+                  <ListChecks className="size-4" aria-hidden="true" />
+                )}
+                {modeActionLabel}
+              </Button>
+              <Button
+                ref={addCriterionRef}
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                aria-label={`Thêm tiêu chí vào ${subgroupContext}`}
+                onClick={() => authoring.onAddCriterion(owner)}
+              >
+                <Plus className="size-4" aria-hidden="true" />
+                Thêm tiêu chí
+              </Button>
+              <IconButton
+                label={`Di chuyển nhóm con ${subgroupOrdinal} của nhóm ${sectionOrdinal} lên`}
+                title="Di chuyển lên"
+                disabled={disabled || subgroupIndex === 0}
+                onClick={() => authoring.onMoveSubgroup(groupKey, subgroupIndex, -1)}
+              >
+                <ArrowUp className="size-4" />
+              </IconButton>
+              <IconButton
+                label={`Di chuyển nhóm con ${subgroupOrdinal} của nhóm ${sectionOrdinal} xuống`}
+                title="Di chuyển xuống"
+                disabled={disabled || subgroupIndex === subgroupCount - 1}
+                onClick={() => authoring.onMoveSubgroup(groupKey, subgroupIndex, 1)}
+              >
+                <ArrowDown className="size-4" />
+              </IconButton>
+              <IconButton
+                label={`Xóa nhóm con ${subgroupOrdinal} của nhóm ${sectionOrdinal}`}
+                title="Xóa nhóm con"
+                disabled={disabled}
+                ariaDisabled={hasPendingBulkInput}
+                ariaDescribedBy={hasPendingBulkInput ? pendingInputDescriptionId : undefined}
+                destructive
+                onClick={() => {
+                  if (!hasPendingBulkInput) authoring.onDeleteSubgroup(groupKey, subgroup.key)
+                }}
+              >
+                <Trash2 className="size-4" />
+              </IconButton>
+            </div>
+          ) : null}
         </div>
 
         <CollapsibleContent id={contentId}>
           <div role="region" aria-label={`Nội dung ${subgroupContext}`} className="pb-4">
-            <TechnicalConfigurationBaselineSubgroupCriteria
-              criteria={subgroup.criteria}
-              sectionOrdinal={sectionOrdinal}
-              subgroupOrdinal={subgroupOrdinal}
-              criterionErrors={criterionErrors}
-              focusCriterionKey={targetCriterionKey}
-              focusCriterionToken={targetCriterionToken}
-            />
+            {authoring && mode === "bulk" && bulkSession ? (
+              <TechnicalConfigurationBulkEntryWorkbench
+                groupName={subgroupLabel}
+                existingCriterionCount={subgroup.criteria.length}
+                session={bulkSession}
+                disabled={disabled}
+                focusInputToken={
+                  focusTarget?.kind === "subgroup-bulk-input" && focusTarget.key === subgroup.key
+                    ? focusTarget.token
+                    : null
+                }
+                onInputChange={(input) => authoring.onBulkInputChange(subgroup.key, input)}
+                onPreview={() => authoring.onBulkPreview(subgroup.key)}
+                onCancel={() => authoring.onBulkCancel(subgroup.key)}
+                onAccept={() => authoring.onBulkAccept(owner)}
+              />
+            ) : (
+              <TechnicalConfigurationBaselineSubgroupCriteria
+                criteria={subgroup.criteria}
+                sectionOrdinal={sectionOrdinal}
+                subgroupOrdinal={subgroupOrdinal}
+                criterionErrors={criterionErrors}
+                focusCriterionKey={targetCriterionKey}
+                focusCriterionToken={targetCriterionToken}
+                authoring={
+                  authoring
+                    ? {
+                        owner,
+                        ownerOptions,
+                        disabled,
+                        onCriterionTextChange: (criterionKey, field, value) =>
+                          authoring.onCriterionTextChange(owner, criterionKey, field, value),
+                        onMoveCriterion: (criterionIndex, offset) =>
+                          authoring.onMoveCriterionWithinOwner(owner, criterionIndex, offset),
+                        onMoveCriterionToOwner: (criterionKey, targetOwner) =>
+                          authoring.onMoveCriterionToOwner(owner, criterionKey, targetOwner),
+                        onDeleteCriterion: (criterionKey) =>
+                          authoring.onDeleteCriterion(owner, criterionKey),
+                      }
+                    : undefined
+                }
+              />
+            )}
           </div>
         </CollapsibleContent>
       </section>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -71,12 +71,19 @@ export function TechnicalConfigurationBaselineTab({
     }
     if (
       Object.keys(summaryValidation.groupErrors).length > 0 ||
+      Object.keys(summaryValidation.subgroupErrors ?? {}).length > 0 ||
       Object.keys(summaryValidation.criterionErrors).length > 0
     ) {
       return "Sửa các lỗi nội dung trước khi khóa phiên bản."
     }
     if (draft.groups.length < 1) return "Cần ít nhất một nhóm trước khi khóa phiên bản."
-    if (!draft.groups.some((group) => group.criteria.length > 0)) {
+    if (
+      !draft.groups.some(
+        (group) =>
+          group.criteria.length > 0 ||
+          group.subgroups.some((subgroup) => subgroup.criteria.length > 0)
+      )
+    ) {
       return "Cần ít nhất một tiêu chí có nội dung trước khi khóa phiên bản."
     }
     return null

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
@@ -57,9 +57,13 @@ export function TechnicalConfigurationBaselineMissingState({
   )
 }
 
+interface TechnicalConfigurationBaselineLockedCriterionProps {
+  criterion: TechnicalConfigurationBaselineCriterionWire
+}
+
 function TechnicalConfigurationBaselineLockedCriterion({
   criterion,
-}: Readonly<{ criterion: TechnicalConfigurationBaselineCriterionWire }>) {
+}: TechnicalConfigurationBaselineLockedCriterionProps): React.JSX.Element {
   return (
     <article className="grid gap-2 py-4 sm:grid-cols-[110px_1fr]">
       <Badge variant="outline" className="w-fit">

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
@@ -1,6 +1,9 @@
 import { AlertCircle, FileLock2, ListPlus, RefreshCw } from "lucide-react"
 
-import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineDraftWire,
+} from "@/app/(app)/technical-configurations/baseline-types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -54,6 +57,24 @@ export function TechnicalConfigurationBaselineMissingState({
   )
 }
 
+function TechnicalConfigurationBaselineLockedCriterion({
+  criterion,
+}: Readonly<{ criterion: TechnicalConfigurationBaselineCriterionWire }>) {
+  return (
+    <article className="grid gap-2 py-4 sm:grid-cols-[110px_1fr]">
+      <Badge variant="outline" className="w-fit">
+        {criterion.criterion_code}
+      </Badge>
+      <div className="min-w-0">
+        {criterion.title ? <h4 className="text-sm font-medium">{criterion.title}</h4> : null}
+        <p className="mt-1 whitespace-pre-wrap break-words text-sm text-foreground">
+          {criterion.requirement_text}
+        </p>
+      </div>
+    </article>
+  )
+}
+
 /** Shows the complete read-only content for a locked baseline version. */
 export function TechnicalConfigurationBaselineLockedState({
   version,
@@ -75,21 +96,34 @@ export function TechnicalConfigurationBaselineLockedState({
           <h3 className="text-sm font-semibold">{group.name}</h3>
           <div className="mt-3 divide-y">
             {group.criteria.map((criterion) => (
-              <article key={criterion.id} className="grid gap-2 py-4 sm:grid-cols-[110px_1fr]">
-                <Badge variant="outline" className="w-fit">
-                  {criterion.criterion_code}
-                </Badge>
-                <div className="min-w-0">
-                  {criterion.title ? (
-                    <h4 className="text-sm font-medium">{criterion.title}</h4>
-                  ) : null}
-                  <p className="mt-1 whitespace-pre-wrap break-words text-sm text-foreground">
-                    {criterion.requirement_text}
-                  </p>
-                </div>
-              </article>
+              <TechnicalConfigurationBaselineLockedCriterion
+                key={criterion.id}
+                criterion={criterion}
+              />
             ))}
           </div>
+          {(group.subgroups ?? []).map((subgroup, subgroupIndex) => (
+            <section
+              key={subgroup.id}
+              aria-label={`Nhóm con ${subgroupIndex + 1}: ${subgroup.name}`}
+              className="border-t py-4"
+            >
+              <div className="flex items-center gap-2">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-md border text-xs font-semibold">
+                  {subgroupIndex + 1}
+                </span>
+                <h4 className="text-sm font-semibold">{subgroup.name}</h4>
+              </div>
+              <div className="mt-2 divide-y">
+                {subgroup.criteria.map((criterion) => (
+                  <TechnicalConfigurationBaselineLockedCriterion
+                    key={criterion.id}
+                    criterion={criterion}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
         </section>
       ))}
     </section>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCriteriaSpreadsheet.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCriteriaSpreadsheet.tsx
@@ -3,13 +3,18 @@
 import * as React from "react"
 import { ArrowDown, ArrowUp, Trash2 } from "lucide-react"
 
-import type { TechnicalConfigurationBaselineEditorGroup } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import type {
+  TechnicalConfigurationBaselineEditorCriterionOwner,
+  TechnicalConfigurationBaselineEditorGroup,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import { formatTechnicalConfigurationBaselineSectionOrdinal } from "@/app/(app)/technical-configurations/technical-configuration-baseline-ordinals"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 
+import { TechnicalConfigurationBaselineCriterionOwnerSelect } from "./TechnicalConfigurationBaselineCriterionOwnerSelect"
 import { TechnicalConfigurationBaselineEditorIconButton as IconButton } from "./TechnicalConfigurationBaselineEditorControls"
+import type { TechnicalConfigurationBaselineCriterionOwnerOption } from "./TechnicalConfigurationBaselineHierarchyAuthoring"
 
 type CriterionTextField = "title" | "requirementText"
 
@@ -24,9 +29,16 @@ type TechnicalConfigurationCriteriaSpreadsheetProps = Readonly<{
   onCriterionTextChange: (criterionKey: string, field: CriterionTextField, value: string) => void
   onMoveCriterion: (criterionIndex: number, offset: -1 | 1) => void
   onDeleteCriterion: (criterionKey: string) => void
+  ownerOptions?: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  onMoveCriterionToOwner?: (
+    criterionKey: string,
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  ) => void
 }>
 
 const GRID_COLUMNS = "grid-cols-[3rem_7rem_minmax(12rem,0.8fr)_minmax(24rem,2fr)_9rem_7rem]"
+const AUTHORING_GRID_COLUMNS =
+  "grid-cols-[3rem_7rem_minmax(12rem,0.8fr)_minmax(24rem,2fr)_12rem_9rem_7rem]"
 
 /** Renders editable criteria for one selected group in a stable spreadsheet grid. */
 export function TechnicalConfigurationCriteriaSpreadsheet({
@@ -40,9 +52,17 @@ export function TechnicalConfigurationCriteriaSpreadsheet({
   onCriterionTextChange,
   onMoveCriterion,
   onDeleteCriterion,
+  ownerOptions,
+  onMoveCriterionToOwner,
 }: TechnicalConfigurationCriteriaSpreadsheetProps) {
   const requirementRefs = React.useRef(new Map<string, HTMLTextAreaElement>())
   const sectionOrdinal = formatTechnicalConfigurationBaselineSectionOrdinal(groupIndex)
+  const currentOwner: TechnicalConfigurationBaselineEditorCriterionOwner = {
+    groupKey: group.key,
+    subgroupKey: null,
+  }
+  const showsOwnerSelect = Boolean(ownerOptions && onMoveCriterionToOwner)
+  const gridColumns = showsOwnerSelect ? AUTHORING_GRID_COLUMNS : GRID_COLUMNS
 
   React.useEffect(() => {
     if (!focusCriterionKey) return
@@ -57,14 +77,15 @@ export function TechnicalConfigurationCriteriaSpreadsheet({
   return (
     <section aria-label={`Danh sách tiêu chí trực tiếp nhóm ${sectionOrdinal}`} className="min-w-0">
       <div className="overflow-x-auto border-y">
-        <div className="min-w-[960px]">
+        <div className={showsOwnerSelect ? "min-w-[1152px]" : "min-w-[960px]"}>
           <div
-            className={`sticky top-0 z-10 grid ${GRID_COLUMNS} border-b bg-muted/95 text-xs font-semibold text-muted-foreground`}
+            className={`sticky top-0 z-10 grid ${gridColumns} border-b bg-muted/95 text-xs font-semibold text-muted-foreground`}
           >
             <span className="px-3 py-2.5 text-center">STT</span>
             <span className="px-3 py-2.5">Mã</span>
             <span className="px-3 py-2.5">Tiêu đề</span>
             <span className="px-3 py-2.5">Nội dung yêu cầu</span>
+            {showsOwnerSelect ? <span className="px-3 py-2.5">Vị trí</span> : null}
             <span className="px-3 py-2.5">Trạng thái</span>
             <span className="px-3 py-2.5 text-center">Thao tác</span>
           </div>
@@ -87,7 +108,7 @@ export function TechnicalConfigurationCriteriaSpreadsheet({
                     key={criterion.key}
                     data-testid={`criterion-row-${criterion.key}`}
                     data-recently-accepted={isRecent ? "true" : undefined}
-                    className={`grid ${GRID_COLUMNS} items-start transition-colors ${
+                    className={`grid ${gridColumns} items-start transition-colors ${
                       isRecent ? "bg-emerald-50/70" : "bg-background"
                     }`}
                   >
@@ -144,6 +165,17 @@ export function TechnicalConfigurationCriteriaSpreadsheet({
                         </p>
                       ) : null}
                     </div>
+                    {ownerOptions && onMoveCriterionToOwner ? (
+                      <div className="px-2 py-2">
+                        <TechnicalConfigurationBaselineCriterionOwnerSelect
+                          label={`Chuyển ${criterionLabel}`}
+                          owner={currentOwner}
+                          options={ownerOptions}
+                          disabled={disabled}
+                          onMove={(owner) => onMoveCriterionToOwner(criterion.key, owner)}
+                        />
+                      </div>
+                    ) : null}
                     <div className="px-3 py-3">
                       {error ? (
                         <Badge variant="destructive">Có lỗi</Badge>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline.ts
@@ -35,6 +35,18 @@ import type {
   TechnicalConfigurationBaselineHierarchyImportPreviewWireResponse,
   TechnicalConfigurationBaselineHierarchyImportRpcArgs,
 } from "../technical-configuration-baseline-hierarchy-import-types"
+import type {
+  TechnicalConfigurationBaselineHierarchyCriteriaReorderRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionCreateRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionMoveRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionWireResponse,
+  TechnicalConfigurationBaselineSubgroupCreateRpcArgs,
+  TechnicalConfigurationBaselineSubgroupDeleteRpcArgs,
+  TechnicalConfigurationBaselineSubgroupsReorderRpcArgs,
+  TechnicalConfigurationBaselineSubgroupUpdateRpcArgs,
+  TechnicalConfigurationBaselineSubgroupWireResponse,
+} from "../technical-configuration-baseline-hierarchy-mutation-types"
+import { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "../technical-configuration-baseline-hierarchy-rpcs"
 
 /** Typed client wrappers for baseline draft and lifecycle RPCs. */
 export const technicalConfigurationBaselineRpc = {
@@ -111,6 +123,48 @@ export const technicalConfigurationBaselineRpc = {
     return callTechnicalConfigurationRpc<unknown>(BASELINE_RPC_FUNCTIONS.reorderCriteria, {
       ...args,
     }).then(decodeTechnicalConfigurationBaselineDraftWireResponse)
+  },
+  createSubgroup(args: TechnicalConfigurationBaselineSubgroupCreateRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineSubgroupWireResponse>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.createSubgroup,
+      { ...args }
+    )
+  },
+  updateSubgroup(args: TechnicalConfigurationBaselineSubgroupUpdateRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineSubgroupWireResponse>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.updateSubgroup,
+      { ...args }
+    )
+  },
+  deleteSubgroup(args: TechnicalConfigurationBaselineSubgroupDeleteRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineDeleteWireResponse>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.deleteSubgroup,
+      { ...args }
+    )
+  },
+  reorderSubgroups(args: TechnicalConfigurationBaselineSubgroupsReorderRpcArgs) {
+    return callTechnicalConfigurationRpc<unknown>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.reorderSubgroups,
+      { ...args }
+    ).then(decodeTechnicalConfigurationBaselineDraftWireResponse)
+  },
+  createHierarchyCriterion(args: TechnicalConfigurationBaselineHierarchyCriterionCreateRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineHierarchyCriterionWireResponse>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.createCriterion,
+      { ...args }
+    )
+  },
+  moveHierarchyCriterion(args: TechnicalConfigurationBaselineHierarchyCriterionMoveRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineHierarchyCriterionWireResponse>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.moveCriterion,
+      { ...args }
+    )
+  },
+  reorderHierarchyCriteria(args: TechnicalConfigurationBaselineHierarchyCriteriaReorderRpcArgs) {
+    return callTechnicalConfigurationRpc<unknown>(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.reorderCriteria,
+      { ...args }
+    ).then(decodeTechnicalConfigurationBaselineDraftWireResponse)
   },
   previewBulk(args: TechnicalConfigurationBaselineBulkPreviewRpcArgs) {
     return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineBulkPreviewWireResponse>(

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions.ts
@@ -11,14 +11,14 @@ export interface TechnicalConfigurationBulkEntrySession {
 }
 
 export interface TechnicalConfigurationBulkEntrySessionsApi {
-  readonly getSession: (groupKey: string) => TechnicalConfigurationBulkEntrySession
-  readonly setInput: (groupKey: string, input: string) => void
+  readonly getSession: (ownerKey: string) => TechnicalConfigurationBulkEntrySession
+  readonly setInput: (ownerKey: string, input: string) => void
   readonly setPreview: (
-    groupKey: string,
+    ownerKey: string,
     preview: TechnicalConfigurationBulkEntryPreview | null
   ) => void
-  readonly clearSession: (groupKey: string) => void
-  readonly syncGroupKeys: (groupKeys: readonly string[]) => void
+  readonly clearSession: (ownerKey: string) => void
+  readonly syncOwnerKeys: (ownerKeys: readonly string[]) => void
   readonly setRecentlyAccepted: (criterionKeys: readonly string[]) => void
   readonly clearRecentHighlights: () => void
   readonly clearAll: () => void
@@ -31,9 +31,9 @@ const EMPTY_SESSION: TechnicalConfigurationBulkEntrySession = Object.freeze({
   preview: null,
 })
 
-/** Manages transient bulk-entry buffers and accepted-row highlights per group. */
+/** Manages transient bulk-entry buffers and accepted-row highlights per criterion owner. */
 export function useTechnicalConfigurationBulkEntrySessions(): TechnicalConfigurationBulkEntrySessionsApi {
-  const [sessionsByGroup, setSessionsByGroup] = React.useState<
+  const [sessionsByOwner, setSessionsByOwner] = React.useState<
     Record<string, TechnicalConfigurationBulkEntrySession>
   >({})
   const [recentlyAcceptedCriterionKeys, setRecentlyAcceptedCriterionKeys] = React.useState<
@@ -41,23 +41,23 @@ export function useTechnicalConfigurationBulkEntrySessions(): TechnicalConfigura
   >(() => new Set())
 
   const getSession = React.useCallback(
-    (groupKey: string) => sessionsByGroup[groupKey] ?? EMPTY_SESSION,
-    [sessionsByGroup]
+    (ownerKey: string) => sessionsByOwner[ownerKey] ?? EMPTY_SESSION,
+    [sessionsByOwner]
   )
 
-  const setInput = React.useCallback((groupKey: string, input: string) => {
-    setSessionsByGroup((current) => ({
+  const setInput = React.useCallback((ownerKey: string, input: string) => {
+    setSessionsByOwner((current) => ({
       ...current,
-      [groupKey]: { input, preview: null },
+      [ownerKey]: { input, preview: null },
     }))
   }, [])
 
   const setPreview = React.useCallback(
-    (groupKey: string, preview: TechnicalConfigurationBulkEntryPreview | null) => {
-      setSessionsByGroup((current) => ({
+    (ownerKey: string, preview: TechnicalConfigurationBulkEntryPreview | null) => {
+      setSessionsByOwner((current) => ({
         ...current,
-        [groupKey]: {
-          input: current[groupKey]?.input ?? "",
+        [ownerKey]: {
+          input: current[ownerKey]?.input ?? "",
           preview,
         },
       }))
@@ -65,20 +65,20 @@ export function useTechnicalConfigurationBulkEntrySessions(): TechnicalConfigura
     []
   )
 
-  const clearSession = React.useCallback((groupKey: string) => {
-    setSessionsByGroup((current) => {
-      if (!(groupKey in current)) return current
+  const clearSession = React.useCallback((ownerKey: string) => {
+    setSessionsByOwner((current) => {
+      if (!(ownerKey in current)) return current
       const next = { ...current }
-      delete next[groupKey]
+      delete next[ownerKey]
       return next
     })
   }, [])
 
-  const syncGroupKeys = React.useCallback((groupKeys: readonly string[]) => {
-    const allowedKeys = new Set(groupKeys)
-    setSessionsByGroup((current) => {
+  const syncOwnerKeys = React.useCallback((ownerKeys: readonly string[]) => {
+    const allowedKeys = new Set(ownerKeys)
+    setSessionsByOwner((current) => {
       const next = Object.fromEntries(
-        Object.entries(current).filter(([groupKey]) => allowedKeys.has(groupKey))
+        Object.entries(current).filter(([ownerKey]) => allowedKeys.has(ownerKey))
       )
       return Object.keys(next).length === Object.keys(current).length ? current : next
     })
@@ -93,16 +93,16 @@ export function useTechnicalConfigurationBulkEntrySessions(): TechnicalConfigura
   }, [])
 
   const clearAll = React.useCallback(() => {
-    setSessionsByGroup({})
+    setSessionsByOwner({})
     setRecentlyAcceptedCriterionKeys(new Set())
   }, [])
 
   const hasPendingInput = React.useMemo(
     () =>
-      Object.values(sessionsByGroup).some((session) =>
+      Object.values(sessionsByOwner).some((session) =>
         hasTechnicalConfigurationBulkEntryInput(session.input)
       ),
-    [sessionsByGroup]
+    [sessionsByOwner]
   )
 
   return {
@@ -110,7 +110,7 @@ export function useTechnicalConfigurationBulkEntrySessions(): TechnicalConfigura
     setInput,
     setPreview,
     clearSession,
-    syncGroupKeys,
+    syncOwnerKeys,
     setRecentlyAccepted,
     clearRecentHighlights,
     clearAll,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationHierarchyAuthoring.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationHierarchyAuthoring.ts
@@ -1,4 +1,7 @@
-import type { TechnicalConfigurationBaselineHierarchyAuthoring } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyAuthoring"
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerKey,
+  type TechnicalConfigurationBaselineHierarchyAuthoring,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyAuthoring"
 import type {
   TechnicalConfigurationEntryMode,
   TechnicalConfigurationFocusTarget,
@@ -40,10 +43,6 @@ type UseTechnicalConfigurationHierarchyAuthoringOptions = Readonly<{
   transitionView: (transition: ViewTransition) => void
   nextFocusToken: () => number
 }>
-
-function ownerKey(owner: TechnicalConfigurationBaselineEditorCriterionOwner): string {
-  return owner.subgroupKey ?? owner.groupKey
-}
 
 /** Owns subgroup CRUD, criterion ownership, and subgroup-scoped entry transitions. */
 export function useTechnicalConfigurationHierarchyAuthoring({
@@ -98,7 +97,7 @@ export function useTechnicalConfigurationHierarchyAuthoring({
     const criterion = getTechnicalConfigurationBaselineEditorOwnerCriteria(nextDraft, owner).at(-1)
     updateDraft(nextDraft)
     transitionView({
-      activeValue: ownerKey(owner),
+      activeValue: getTechnicalConfigurationBaselineCriterionOwnerKey(owner),
       entryMode: "row",
       focusTarget: criterion
         ? { kind: "criterion", key: criterion.key, token: nextFocusToken() }
@@ -123,7 +122,7 @@ export function useTechnicalConfigurationHierarchyAuthoring({
     updateDraft(nextDraft)
     bulkSessions.clearRecentHighlights()
     transitionView({
-      activeValue: ownerKey(owner),
+      activeValue: getTechnicalConfigurationBaselineCriterionOwnerKey(owner),
       entryMode: "row",
       focusTarget: nextCriterion
         ? { kind: "criterion", key: nextCriterion.key, token: nextFocusToken() }
@@ -141,23 +140,34 @@ export function useTechnicalConfigurationHierarchyAuthoring({
     const criteria = getTechnicalConfigurationBaselineEditorOwnerCriteria(draft, owner)
     const targetCriterion =
       criteria.find((criterion) => validation.criterionErrors[criterion.key]) ?? criteria[0]
+    let focusTarget: TechnicalConfigurationFocusTarget
+    if (mode === "bulk") {
+      focusTarget = {
+        kind: owner.subgroupKey ? "subgroup-bulk-input" : "bulk-input",
+        key: nextOwnerKey,
+        token: nextFocusToken(),
+      }
+    } else if (targetCriterion) {
+      focusTarget = { kind: "criterion", key: targetCriterion.key, token: nextFocusToken() }
+    } else if (owner.subgroupKey) {
+      focusTarget = {
+        kind: "add-subgroup-criterion",
+        key: nextOwnerKey,
+        token: nextFocusToken(),
+      }
+    } else {
+      focusTarget = { kind: "add-criterion", key: owner.groupKey, token: nextFocusToken() }
+    }
     transitionView({
       activeValue: nextOwnerKey,
       entryMode: mode,
-      focusTarget:
-        mode === "bulk"
-          ? { kind: "subgroup-bulk-input", key: nextOwnerKey, token: nextFocusToken() }
-          : targetCriterion
-            ? { kind: "criterion", key: targetCriterion.key, token: nextFocusToken() }
-            : owner.subgroupKey
-              ? { kind: "add-subgroup-criterion", key: nextOwnerKey, token: nextFocusToken() }
-              : { kind: "add-criterion", key: owner.groupKey, token: nextFocusToken() },
+      focusTarget,
     })
   }
 
   const onBulkAccept = (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => {
     if (!draft) return
-    const key = ownerKey(owner)
+    const key = getTechnicalConfigurationBaselineCriterionOwnerKey(owner)
     const session = bulkSessions.getSession(key)
     if (!session.preview?.canAccept) return
     const previousKeys = new Set(
@@ -182,7 +192,11 @@ export function useTechnicalConfigurationHierarchyAuthoring({
       entryMode: "row",
       focusTarget: acceptedCriteria[0]
         ? { kind: "criterion", key: acceptedCriteria[0].key, token: nextFocusToken() }
-        : { kind: "subgroup-mode-action", key, token: nextFocusToken() },
+        : {
+            kind: owner.subgroupKey ? "subgroup-mode-action" : "group-mode-action",
+            key,
+            token: nextFocusToken(),
+          },
     })
   }
 
@@ -239,7 +253,7 @@ export function useTechnicalConfigurationHierarchyAuthoring({
         )
       )
       transitionView({
-        activeValue: ownerKey(targetOwner),
+        activeValue: getTechnicalConfigurationBaselineCriterionOwnerKey(targetOwner),
         entryMode: "row",
         focusTarget: { kind: "criterion", key: criterionKey, token: nextFocusToken() },
       })
@@ -253,10 +267,15 @@ export function useTechnicalConfigurationHierarchyAuthoring({
     },
     onBulkCancel: (key) => {
       bulkSessions.clearSession(key)
+      const owner = findOwner(draft, key)
       transitionView({
         activeValue: key,
         entryMode: "row",
-        focusTarget: { kind: "subgroup-mode-action", key, token: nextFocusToken() },
+        focusTarget: {
+          kind: owner?.subgroupKey ? "subgroup-mode-action" : "group-mode-action",
+          key,
+          token: nextFocusToken(),
+        },
       })
     },
     onBulkAccept,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationHierarchyAuthoring.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationHierarchyAuthoring.ts
@@ -1,0 +1,278 @@
+import type { TechnicalConfigurationBaselineHierarchyAuthoring } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyAuthoring"
+import type {
+  TechnicalConfigurationEntryMode,
+  TechnicalConfigurationFocusTarget,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
+import type { TechnicalConfigurationBulkEntrySessionsApi } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import {
+  appendTechnicalConfigurationBaselineEditorCriteriaToOwner,
+  appendTechnicalConfigurationBaselineEditorCriterionToOwner,
+  appendTechnicalConfigurationBaselineEditorSubgroup,
+  getTechnicalConfigurationBaselineEditorOwnerCriteria,
+  moveTechnicalConfigurationBaselineEditorCriterionToOwner,
+  moveTechnicalConfigurationBaselineEditorCriterionWithinOwner,
+  moveTechnicalConfigurationBaselineEditorSubgroup,
+  removeTechnicalConfigurationBaselineEditorCriterionFromOwner,
+  removeTechnicalConfigurationBaselineEditorSubgroup,
+  setTechnicalConfigurationBaselineEditorCriterionTextInOwner,
+  setTechnicalConfigurationBaselineEditorSubgroupName,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import type {
+  TechnicalConfigurationBaselineEditorCriterionOwner,
+  TechnicalConfigurationBaselineEditorDraft,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+import { parseTechnicalConfigurationBulkEntry } from "@/app/(app)/technical-configurations/bulk-entry-utils"
+
+type ViewTransition = Readonly<{
+  activeValue?: string
+  entryMode?: TechnicalConfigurationEntryMode
+  focusTarget?: TechnicalConfigurationFocusTarget
+}>
+
+type UseTechnicalConfigurationHierarchyAuthoringOptions = Readonly<{
+  draft: TechnicalConfigurationBaselineEditorDraft | null
+  validation: TechnicalConfigurationBaselineEditorValidation
+  activeValue: string
+  entryMode: TechnicalConfigurationEntryMode
+  bulkSessions: TechnicalConfigurationBulkEntrySessionsApi
+  updateDraft: (draft: TechnicalConfigurationBaselineEditorDraft) => void
+  transitionView: (transition: ViewTransition) => void
+  nextFocusToken: () => number
+}>
+
+function ownerKey(owner: TechnicalConfigurationBaselineEditorCriterionOwner): string {
+  return owner.subgroupKey ?? owner.groupKey
+}
+
+/** Owns subgroup CRUD, criterion ownership, and subgroup-scoped entry transitions. */
+export function useTechnicalConfigurationHierarchyAuthoring({
+  draft,
+  validation,
+  activeValue,
+  entryMode,
+  bulkSessions,
+  updateDraft,
+  transitionView,
+  nextFocusToken,
+}: UseTechnicalConfigurationHierarchyAuthoringOptions): TechnicalConfigurationBaselineHierarchyAuthoring {
+  const onAddSubgroup = (groupKey: string) => {
+    if (!draft) return
+    const nextDraft = appendTechnicalConfigurationBaselineEditorSubgroup(draft, groupKey)
+    const subgroup = nextDraft.groups.find((group) => group.key === groupKey)?.subgroups.at(-1)
+    updateDraft(nextDraft)
+    if (!subgroup) return
+    transitionView({
+      activeValue: subgroup.key,
+      entryMode: "row",
+      focusTarget: { kind: "subgroup-name", key: subgroup.key, token: nextFocusToken() },
+    })
+  }
+
+  const onDeleteSubgroup = (groupKey: string, subgroupKey: string) => {
+    if (!draft) return
+    const group = draft.groups.find((item) => item.key === groupKey)
+    const subgroupIndex = group?.subgroups.findIndex((item) => item.key === subgroupKey) ?? -1
+    const nextDraft = removeTechnicalConfigurationBaselineEditorSubgroup(
+      draft,
+      groupKey,
+      subgroupKey
+    )
+    const nextGroup = nextDraft.groups.find((item) => item.key === groupKey)
+    const nextSubgroup =
+      nextGroup?.subgroups[Math.min(subgroupIndex, nextGroup.subgroups.length - 1)]
+    updateDraft(nextDraft)
+    bulkSessions.clearSession(subgroupKey)
+    transitionView({
+      activeValue: nextSubgroup?.key ?? groupKey,
+      entryMode: "row",
+      focusTarget: nextSubgroup
+        ? { kind: "subgroup-disclosure", key: nextSubgroup.key, token: nextFocusToken() }
+        : { kind: "add-subgroup", key: groupKey, token: nextFocusToken() },
+    })
+  }
+
+  const onAddCriterion = (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => {
+    if (!draft) return
+    const nextDraft = appendTechnicalConfigurationBaselineEditorCriterionToOwner(draft, owner)
+    const criterion = getTechnicalConfigurationBaselineEditorOwnerCriteria(nextDraft, owner).at(-1)
+    updateDraft(nextDraft)
+    transitionView({
+      activeValue: ownerKey(owner),
+      entryMode: "row",
+      focusTarget: criterion
+        ? { kind: "criterion", key: criterion.key, token: nextFocusToken() }
+        : null,
+    })
+  }
+
+  const onDeleteCriterion = (
+    owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+    criterionKey: string
+  ) => {
+    if (!draft) return
+    const criteria = getTechnicalConfigurationBaselineEditorOwnerCriteria(draft, owner)
+    const criterionIndex = criteria.findIndex((criterion) => criterion.key === criterionKey)
+    const nextDraft = removeTechnicalConfigurationBaselineEditorCriterionFromOwner(
+      draft,
+      owner,
+      criterionKey
+    )
+    const nextCriteria = getTechnicalConfigurationBaselineEditorOwnerCriteria(nextDraft, owner)
+    const nextCriterion = nextCriteria[Math.min(criterionIndex, nextCriteria.length - 1)]
+    updateDraft(nextDraft)
+    bulkSessions.clearRecentHighlights()
+    transitionView({
+      activeValue: ownerKey(owner),
+      entryMode: "row",
+      focusTarget: nextCriterion
+        ? { kind: "criterion", key: nextCriterion.key, token: nextFocusToken() }
+        : owner.subgroupKey
+          ? { kind: "add-subgroup-criterion", key: owner.subgroupKey, token: nextFocusToken() }
+          : { kind: "add-criterion", key: owner.groupKey, token: nextFocusToken() },
+    })
+  }
+
+  const onOwnerModeChange = (nextOwnerKey: string, mode: TechnicalConfigurationEntryMode) => {
+    if (!draft) return
+    const owner = findOwner(draft, nextOwnerKey)
+    if (!owner) return
+    if (nextOwnerKey !== activeValue || mode !== entryMode) bulkSessions.clearRecentHighlights()
+    const criteria = getTechnicalConfigurationBaselineEditorOwnerCriteria(draft, owner)
+    const targetCriterion =
+      criteria.find((criterion) => validation.criterionErrors[criterion.key]) ?? criteria[0]
+    transitionView({
+      activeValue: nextOwnerKey,
+      entryMode: mode,
+      focusTarget:
+        mode === "bulk"
+          ? { kind: "subgroup-bulk-input", key: nextOwnerKey, token: nextFocusToken() }
+          : targetCriterion
+            ? { kind: "criterion", key: targetCriterion.key, token: nextFocusToken() }
+            : owner.subgroupKey
+              ? { kind: "add-subgroup-criterion", key: nextOwnerKey, token: nextFocusToken() }
+              : { kind: "add-criterion", key: owner.groupKey, token: nextFocusToken() },
+    })
+  }
+
+  const onBulkAccept = (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => {
+    if (!draft) return
+    const key = ownerKey(owner)
+    const session = bulkSessions.getSession(key)
+    if (!session.preview?.canAccept) return
+    const previousKeys = new Set(
+      getTechnicalConfigurationBaselineEditorOwnerCriteria(draft, owner).map(
+        (criterion) => criterion.key
+      )
+    )
+    const nextDraft = appendTechnicalConfigurationBaselineEditorCriteriaToOwner(
+      draft,
+      owner,
+      session.preview.rows.map((row) => row.requirementText)
+    )
+    const acceptedCriteria = getTechnicalConfigurationBaselineEditorOwnerCriteria(
+      nextDraft,
+      owner
+    ).filter((criterion) => !previousKeys.has(criterion.key))
+    updateDraft(nextDraft)
+    bulkSessions.setRecentlyAccepted(acceptedCriteria.map((criterion) => criterion.key))
+    bulkSessions.clearSession(key)
+    transitionView({
+      activeValue: key,
+      entryMode: "row",
+      focusTarget: acceptedCriteria[0]
+        ? { kind: "criterion", key: acceptedCriteria[0].key, token: nextFocusToken() }
+        : { kind: "subgroup-mode-action", key, token: nextFocusToken() },
+    })
+  }
+
+  return {
+    activeOwnerKey: activeValue,
+    entryMode,
+    getBulkSession: bulkSessions.getSession,
+    onOwnerModeChange,
+    onAddSubgroup,
+    onSubgroupNameChange: (groupKey, subgroupKey, name) => {
+      if (draft)
+        updateDraft(
+          setTechnicalConfigurationBaselineEditorSubgroupName(draft, groupKey, subgroupKey, name)
+        )
+    },
+    onMoveSubgroup: (groupKey, subgroupIndex, offset) => {
+      if (draft)
+        updateDraft(
+          moveTechnicalConfigurationBaselineEditorSubgroup(draft, groupKey, subgroupIndex, offset)
+        )
+    },
+    onDeleteSubgroup,
+    onCriterionTextChange: (owner, criterionKey, field, value) => {
+      if (draft)
+        updateDraft(
+          setTechnicalConfigurationBaselineEditorCriterionTextInOwner(
+            draft,
+            owner,
+            criterionKey,
+            field,
+            value
+          )
+        )
+    },
+    onMoveCriterionWithinOwner: (owner, criterionIndex, offset) => {
+      if (draft)
+        updateDraft(
+          moveTechnicalConfigurationBaselineEditorCriterionWithinOwner(
+            draft,
+            owner,
+            criterionIndex,
+            offset
+          )
+        )
+    },
+    onMoveCriterionToOwner: (sourceOwner, criterionKey, targetOwner) => {
+      if (!draft) return
+      updateDraft(
+        moveTechnicalConfigurationBaselineEditorCriterionToOwner(
+          draft,
+          sourceOwner,
+          criterionKey,
+          targetOwner
+        )
+      )
+      transitionView({
+        activeValue: ownerKey(targetOwner),
+        entryMode: "row",
+        focusTarget: { kind: "criterion", key: criterionKey, token: nextFocusToken() },
+      })
+    },
+    onDeleteCriterion,
+    onAddCriterion,
+    onBulkInputChange: bulkSessions.setInput,
+    onBulkPreview: (key) => {
+      const session = bulkSessions.getSession(key)
+      bulkSessions.setPreview(key, parseTechnicalConfigurationBulkEntry(session.input))
+    },
+    onBulkCancel: (key) => {
+      bulkSessions.clearSession(key)
+      transitionView({
+        activeValue: key,
+        entryMode: "row",
+        focusTarget: { kind: "subgroup-mode-action", key, token: nextFocusToken() },
+      })
+    },
+    onBulkAccept,
+  }
+}
+
+function findOwner(
+  draft: TechnicalConfigurationBaselineEditorDraft | null,
+  key: string
+): TechnicalConfigurationBaselineEditorCriterionOwner | null {
+  if (!draft) return null
+  for (const group of draft.groups) {
+    if (group.key === key) return { groupKey: group.key, subgroupKey: null }
+    if (group.subgroups.some((subgroup) => subgroup.key === key)) {
+      return { groupKey: group.key, subgroupKey: key }
+    }
+  }
+  return null
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor.ts
@@ -20,6 +20,7 @@ import type {
   TechnicalConfigurationFocusTarget,
 } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEditor"
 import type { useTechnicalConfigurationBulkEntrySessions } from "./useTechnicalConfigurationBulkEntrySessions"
+import { useTechnicalConfigurationHierarchyAuthoring } from "./useTechnicalConfigurationHierarchyAuthoring"
 
 type BulkSessions = ReturnType<typeof useTechnicalConfigurationBulkEntrySessions>
 
@@ -50,30 +51,34 @@ export function useTechnicalConfigurationInlineEditor({
     entryMode: "row",
     focusTarget: null,
   })
-  const previousGroupKeysRef = React.useRef<readonly string[]>([])
+  const previousOwnerKeysRef = React.useRef<readonly string[]>([])
   const focusTokenRef = React.useRef(0)
   const { activeValue, entryMode, focusTarget } = viewState
 
-  const nextFocusToken = () => {
+  const nextFocusToken = React.useCallback(() => {
     focusTokenRef.current += 1
     return focusTokenRef.current
-  }
+  }, [])
 
   React.useEffect(() => {
-    const groupKeys = draft?.groups.map((group) => group.key) ?? []
-    const previousGroupKeys = previousGroupKeysRef.current
-    previousGroupKeysRef.current = groupKeys
-    bulkSessions.syncGroupKeys(groupKeys)
+    const ownerKeys =
+      draft?.groups.flatMap((group) => [
+        group.key,
+        ...(group.subgroups ?? []).map((subgroup) => subgroup.key),
+      ]) ?? []
+    const previousOwnerKeys = previousOwnerKeysRef.current
+    previousOwnerKeysRef.current = ownerKeys
+    bulkSessions.syncOwnerKeys(ownerKeys)
     setViewState((current) => {
-      if (groupKeys.includes(current.activeValue)) return current
-      const previousIndex = previousGroupKeys.indexOf(current.activeValue)
+      if (ownerKeys.includes(current.activeValue)) return current
+      const previousIndex = previousOwnerKeys.indexOf(current.activeValue)
       return {
         ...current,
-        activeValue: groupKeys[previousIndex] ?? groupKeys[0] ?? "",
+        activeValue: ownerKeys[previousIndex] ?? ownerKeys[0] ?? "",
         focusTarget: current.activeValue ? null : current.focusTarget,
       }
     })
-  }, [draft?.groups, bulkSessions.syncGroupKeys])
+  }, [draft?.groups, bulkSessions.syncOwnerKeys])
 
   React.useEffect(() => {
     if (saveStatus === "saved") bulkSessions.clearRecentHighlights()
@@ -85,6 +90,22 @@ export function useTechnicalConfigurationInlineEditor({
     },
     [onEditorChange]
   )
+  const transitionView = React.useCallback(
+    (transition: Partial<TechnicalConfigurationEditorViewState>) => {
+      setViewState((current) => ({ ...current, ...transition }))
+    },
+    []
+  )
+  const hierarchyAuthoring = useTechnicalConfigurationHierarchyAuthoring({
+    draft,
+    validation,
+    activeValue,
+    entryMode,
+    bulkSessions,
+    updateDraft,
+    transitionView,
+    nextFocusToken,
+  })
 
   const addGroup = () => {
     if (!draft) return
@@ -218,6 +239,7 @@ export function useTechnicalConfigurationInlineEditor({
     activeValue,
     entryMode,
     focusTarget,
+    hierarchyAuthoring,
     bulkSession: bulkSessions.getSession(activeValue),
     addGroup,
     deleteGroup,

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-editor-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-editor-state.ts
@@ -4,6 +4,7 @@ import {
   createTechnicalConfigurationBaselineEditorKey,
   moveTechnicalConfigurationBaselineEditorItem,
 } from "./technical-configuration-baseline-editor-state"
+import { normalizeTechnicalConfigurationBulkEntryText } from "./bulk-entry-utils"
 import type {
   TechnicalConfigurationBaselineEditorCriterion,
   TechnicalConfigurationBaselineEditorDraft,
@@ -43,6 +44,24 @@ export function appendTechnicalConfigurationBaselineEditorSubgroup(
   }))
 }
 
+/** Replaces one subgroup name without mutating the editor tree. */
+export function setTechnicalConfigurationBaselineEditorSubgroupName(
+  draft: TechnicalConfigurationBaselineEditorDraft,
+  groupKey: string,
+  subgroupKey: string,
+  name: string
+): TechnicalConfigurationBaselineEditorDraft {
+  return updateGroup(draft, groupKey, (group) => {
+    const currentSubgroups = group.subgroups ?? []
+    const subgroupIndex = currentSubgroups.findIndex((subgroup) => subgroup.key === subgroupKey)
+    if (subgroupIndex < 0) return group
+
+    const subgroups = [...currentSubgroups]
+    subgroups[subgroupIndex] = { ...subgroups[subgroupIndex], name }
+    return { ...group, subgroups }
+  })
+}
+
 /** Appends one criterion to either a direct section owner or a subgroup owner. */
 export function appendTechnicalConfigurationBaselineEditorCriterionToOwner(
   draft: TechnicalConfigurationBaselineEditorDraft,
@@ -50,6 +69,44 @@ export function appendTechnicalConfigurationBaselineEditorCriterionToOwner(
   criterion = createTechnicalConfigurationBaselineEditorCriterion()
 ): TechnicalConfigurationBaselineEditorDraft {
   return updateOwnerCriteria(draft, owner, (criteria) => [...criteria, criterion])
+}
+
+/** Appends normalized unsaved criteria to a direct or subgroup owner. */
+export function appendTechnicalConfigurationBaselineEditorCriteriaToOwner(
+  draft: TechnicalConfigurationBaselineEditorDraft,
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+  requirementTexts: readonly string[]
+): TechnicalConfigurationBaselineEditorDraft {
+  return updateOwnerCriteria(draft, owner, (criteria) => [
+    ...criteria,
+    ...requirementTexts.map((requirementText) => ({
+      ...createTechnicalConfigurationBaselineEditorCriterion(),
+      requirementText: normalizeTechnicalConfigurationBulkEntryText(requirementText),
+    })),
+  ])
+}
+
+/** Replaces one criterion field inside a direct or subgroup owner. */
+export function setTechnicalConfigurationBaselineEditorCriterionTextInOwner(
+  draft: TechnicalConfigurationBaselineEditorDraft,
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner,
+  criterionKey: string,
+  field: "title" | "requirementText",
+  value: string
+): TechnicalConfigurationBaselineEditorDraft {
+  return updateOwnerCriteria(draft, owner, (criteria) =>
+    criteria.map((criterion) =>
+      criterion.key === criterionKey ? { ...criterion, [field]: value } : criterion
+    )
+  )
+}
+
+/** Reads the current criteria for a direct or subgroup owner. */
+export function getTechnicalConfigurationBaselineEditorOwnerCriteria(
+  draft: TechnicalConfigurationBaselineEditorDraft,
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+): readonly TechnicalConfigurationBaselineEditorCriterion[] {
+  return getOwnerCriteria(draft, owner) ?? []
 }
 
 /** Moves one section by a single stable position. */

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-mutation-types.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-mutation-types.ts
@@ -1,0 +1,72 @@
+import type {
+  TechnicalConfigurationBaselineCriterionMutationWire,
+  TechnicalConfigurationBaselineDeleteWireResponse,
+  TechnicalConfigurationBaselineDraftWireResponse,
+  TechnicalConfigurationBaselineSubgroupWire,
+} from "./baseline-types"
+
+export interface TechnicalConfigurationBaselineSubgroupMutationWire extends Omit<
+  TechnicalConfigurationBaselineSubgroupWire,
+  "criteria"
+> {
+  revision: number
+}
+
+export interface TechnicalConfigurationBaselineSubgroupWireResponse {
+  data: TechnicalConfigurationBaselineSubgroupMutationWire
+}
+
+export interface TechnicalConfigurationBaselineSubgroupCreateRpcArgs {
+  p_group_id: string
+  p_name: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineSubgroupUpdateRpcArgs {
+  p_subgroup_id: string
+  p_name: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineSubgroupDeleteRpcArgs {
+  p_subgroup_id: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineSubgroupsReorderRpcArgs {
+  p_group_id: string
+  p_subgroup_ids: string[]
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineHierarchyCriterionCreateRpcArgs {
+  p_group_id: string
+  p_subgroup_id: string | null
+  p_title: string | null
+  p_requirement_text: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineHierarchyCriterionMoveRpcArgs {
+  p_criterion_id: string
+  p_target_group_id: string
+  p_target_subgroup_id: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineHierarchyCriteriaReorderRpcArgs {
+  p_group_id: string
+  p_subgroup_id: string | null
+  p_criterion_ids: string[]
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineHierarchyCriterionWireResponse {
+  data: TechnicalConfigurationBaselineCriterionMutationWire
+}
+
+export type TechnicalConfigurationBaselineHierarchyDeleteWireResponse =
+  TechnicalConfigurationBaselineDeleteWireResponse
+
+export type TechnicalConfigurationBaselineHierarchyReorderWireResponse =
+  TechnicalConfigurationBaselineDraftWireResponse

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs.ts
@@ -1,0 +1,10 @@
+/** Dormant P1E mutation names. Do not add these to the production proxy allowlist before P6A. */
+export const TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS = {
+  createSubgroup: "technical_configuration_baseline_subgroup_create",
+  updateSubgroup: "technical_configuration_baseline_subgroup_update",
+  deleteSubgroup: "technical_configuration_baseline_subgroup_delete",
+  reorderSubgroups: "technical_configuration_baseline_subgroups_reorder",
+  createCriterion: "technical_configuration_baseline_hierarchy_criterion_create",
+  moveCriterion: "technical_configuration_baseline_hierarchy_criterion_move",
+  reorderCriteria: "technical_configuration_baseline_hierarchy_criteria_reorder",
+} as const

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-steps.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-steps.ts
@@ -1,0 +1,300 @@
+/* eslint-disable react-doctor/async-await-in-loop -- Revision-chained mutations must run sequentially. */
+
+import type {
+  TechnicalConfigurationBaselineEditorProgress,
+  TechnicalConfigurationBaselineEditorRpc,
+} from "./technical-configuration-baseline-save"
+import {
+  createNewGroups,
+  deleteRemovedGroups,
+  reorderGroups,
+  type TechnicalConfigurationBaselineRunSaveStep,
+  updateExistingGroups,
+} from "./technical-configuration-baseline-save-steps"
+import { toTechnicalConfigurationBaselineWireCriterion } from "./technical-configuration-baseline-save-mappers"
+import {
+  adoptSnapshot,
+  appendWireCriterion,
+  applyCriterionResponse,
+  findWireCriterionLocation,
+  findWireGroup,
+  findWireSubgroup,
+  getEditorCriterionLocations,
+  getPersistedIds,
+  getWireCriterionLocations,
+  removeWireCriterion,
+  replaceWireCriterion,
+  replaceWireSubgroup,
+  sameCriterionOwner,
+  sameOrder,
+  toWireSubgroup,
+  updateNextCriterionNumber,
+  updateRevision,
+  type HierarchyEditorCriterionLocation,
+  type HierarchyEditorGroup,
+  type HierarchyEditorSubgroup,
+} from "./technical-configuration-baseline-hierarchy-save-support"
+
+/** Runs the dormant P1E hierarchy mutation sequence with resumable progress. */
+export async function runTechnicalConfigurationBaselineHierarchySaveSteps(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  await createNewGroups(progress, rpc, run)
+  await updateExistingGroups(progress, rpc, run)
+  await createAndUpdateSubgroups(progress, rpc, run)
+  await createUpdateAndMoveCriteria(progress, rpc, run)
+  await deleteRemovedCriteria(progress, rpc, run)
+  await deleteRemovedSubgroups(progress, rpc, run)
+  await deleteRemovedGroups(progress, rpc, run)
+  await reorderGroups(progress, rpc, run)
+  await reorderSubgroups(progress, rpc, run)
+  await reorderCriterionOwners(progress, rpc, run)
+}
+
+async function createAndUpdateSubgroups(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  for (const group of progress.editorDraft.groups) {
+    if (!group.id) continue
+    for (const subgroup of group.subgroups) {
+      if (!subgroup.id) {
+        await run(
+          () =>
+            rpc.createSubgroup({
+              p_group_id: group.id as string,
+              p_name: subgroup.name,
+              p_expected_revision: progress.baseDraft.revision,
+            }),
+          (response) => {
+            subgroup.id = response.data.id
+            subgroup.name = response.data.name
+            findWireGroup(progress, group.id as string).subgroups = [
+              ...(findWireGroup(progress, group.id as string).subgroups ?? []),
+              toWireSubgroup(response.data),
+            ]
+            updateRevision(progress, response.data.revision)
+          }
+        )
+        continue
+      }
+
+      const wireSubgroup = findWireSubgroup(progress, subgroup.id)
+      if (wireSubgroup.name === subgroup.name) continue
+      await run(
+        () =>
+          rpc.updateSubgroup({
+            p_subgroup_id: subgroup.id as string,
+            p_name: subgroup.name,
+            p_expected_revision: progress.baseDraft.revision,
+          }),
+        (response) => {
+          replaceWireSubgroup(progress, response.data)
+          subgroup.name = response.data.name
+          updateRevision(progress, response.data.revision)
+        }
+      )
+    }
+  }
+}
+
+async function createUpdateAndMoveCriteria(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  for (const location of getEditorCriterionLocations(progress)) {
+    const editorCriterion = location.criterion
+    if (!editorCriterion.id) {
+      await createCriterion(location, progress, rpc, run)
+      continue
+    }
+
+    const wireLocation = findWireCriterionLocation(progress, editorCriterion.id)
+    if (
+      (wireLocation.criterion.title ?? "") !== editorCriterion.title ||
+      wireLocation.criterion.requirement_text !== editorCriterion.requirementText
+    ) {
+      await run(
+        () =>
+          rpc.updateCriterion({
+            p_criterion_id: editorCriterion.id as string,
+            p_title: editorCriterion.title.trim() || null,
+            p_requirement_text: editorCriterion.requirementText,
+            p_expected_revision: progress.baseDraft.revision,
+          }),
+        (response) => {
+          replaceWireCriterion(progress, response.data)
+          applyCriterionResponse(editorCriterion, response.data)
+          updateRevision(progress, response.data.revision)
+        }
+      )
+    }
+
+    const currentLocation = findWireCriterionLocation(progress, editorCriterion.id as string)
+    if (sameCriterionOwner(currentLocation, location)) continue
+    await run(
+      () =>
+        rpc.moveHierarchyCriterion({
+          p_criterion_id: editorCriterion.id as string,
+          p_target_group_id: location.group.id as string,
+          p_target_subgroup_id: location.subgroup?.id ?? null,
+          p_expected_revision: progress.baseDraft.revision,
+        }),
+      (response) => {
+        removeWireCriterion(progress, response.data.id)
+        appendWireCriterion(progress, toTechnicalConfigurationBaselineWireCriterion(response.data))
+        applyCriterionResponse(editorCriterion, response.data)
+        updateRevision(progress, response.data.revision)
+      }
+    )
+  }
+}
+
+async function createCriterion(
+  location: HierarchyEditorCriterionLocation,
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  await run(
+    () =>
+      rpc.createHierarchyCriterion({
+        p_group_id: location.group.id as string,
+        p_subgroup_id: location.subgroup?.id ?? null,
+        p_title: location.criterion.title.trim() || null,
+        p_requirement_text: location.criterion.requirementText,
+        p_expected_revision: progress.baseDraft.revision,
+      }),
+    (response) => {
+      applyCriterionResponse(location.criterion, response.data)
+      appendWireCriterion(progress, toTechnicalConfigurationBaselineWireCriterion(response.data))
+      updateNextCriterionNumber(progress, response.data.criterion_code)
+      updateRevision(progress, response.data.revision)
+    }
+  )
+}
+
+async function deleteRemovedCriteria(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  const editorIds = new Set(
+    getEditorCriterionLocations(progress)
+      .map(({ criterion }) => criterion.id)
+      .filter((id): id is string => id !== null)
+  )
+  for (const location of getWireCriterionLocations(progress)) {
+    const criterionId = location.criterion.id
+    if (editorIds.has(criterionId)) continue
+    await run(
+      () =>
+        rpc.deleteCriterion({
+          p_criterion_id: criterionId,
+          p_expected_revision: progress.baseDraft.revision,
+        }),
+      (response) => {
+        removeWireCriterion(progress, criterionId)
+        updateRevision(progress, response.data.revision)
+      }
+    )
+  }
+}
+
+async function deleteRemovedSubgroups(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  const editorIds = new Set(
+    progress.editorDraft.groups.flatMap((group) =>
+      group.subgroups.map((subgroup) => subgroup.id).filter((id): id is string => id !== null)
+    )
+  )
+  for (const group of progress.baseDraft.groups) {
+    for (const subgroup of [...(group.subgroups ?? [])]) {
+      if (editorIds.has(subgroup.id)) continue
+      await run(
+        () =>
+          rpc.deleteSubgroup({
+            p_subgroup_id: subgroup.id,
+            p_expected_revision: progress.baseDraft.revision,
+          }),
+        (response) => {
+          group.subgroups = (group.subgroups ?? []).filter((item) => item.id !== subgroup.id)
+          updateRevision(progress, response.data.revision)
+        }
+      )
+    }
+  }
+}
+
+async function reorderSubgroups(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  for (const group of progress.editorDraft.groups) {
+    if (!group.id) continue
+    const editorIds = getPersistedIds(group.subgroups)
+    const wireIds = (findWireGroup(progress, group.id).subgroups ?? []).map(
+      (subgroup) => subgroup.id
+    )
+    if (sameOrder(editorIds, wireIds)) continue
+    await run(
+      () =>
+        rpc.reorderSubgroups({
+          p_group_id: group.id as string,
+          p_subgroup_ids: editorIds,
+          p_expected_revision: progress.baseDraft.revision,
+        }),
+      (response) => adoptSnapshot(progress, response.data)
+    )
+  }
+}
+
+async function reorderCriterionOwners(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  for (const group of progress.editorDraft.groups) {
+    if (!group.id) continue
+    await reorderCriterionOwner(group, null, progress, rpc, run)
+    for (const subgroup of group.subgroups) {
+      if (subgroup.id) await reorderCriterionOwner(group, subgroup, progress, rpc, run)
+    }
+  }
+}
+
+async function reorderCriterionOwner(
+  group: HierarchyEditorGroup,
+  subgroup: HierarchyEditorSubgroup | null,
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  rpc: TechnicalConfigurationBaselineEditorRpc,
+  run: TechnicalConfigurationBaselineRunSaveStep
+): Promise<void> {
+  const editorCriteria = subgroup?.criteria ?? group.criteria
+  const editorIds = getPersistedIds(editorCriteria)
+  const wireGroup = findWireGroup(progress, group.id as string)
+  const wireCriteria = subgroup
+    ? ((wireGroup.subgroups ?? []).find((item) => item.id === subgroup.id)?.criteria ?? [])
+    : wireGroup.criteria
+  const wireIds = wireCriteria.map((criterion) => criterion.id)
+  if (sameOrder(editorIds, wireIds)) return
+
+  await run(
+    () =>
+      rpc.reorderHierarchyCriteria({
+        p_group_id: group.id as string,
+        p_subgroup_id: subgroup?.id ?? null,
+        p_criterion_ids: editorIds,
+        p_expected_revision: progress.baseDraft.revision,
+      }),
+    (response) => adoptSnapshot(progress, response.data)
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-steps.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-steps.ts
@@ -1,4 +1,7 @@
-/* eslint-disable react-doctor/async-await-in-loop -- Revision-chained mutations must run sequentially. */
+/*
+ * Revision-chained mutations must run sequentially because each RPC consumes
+ * the revision returned by the previous mutation.
+ */
 
 import type {
   TechnicalConfigurationBaselineEditorProgress,
@@ -26,14 +29,16 @@ import {
   replaceWireCriterion,
   replaceWireSubgroup,
   sameCriterionOwner,
-  sameOrder,
   toWireSubgroup,
-  updateNextCriterionNumber,
-  updateRevision,
   type HierarchyEditorCriterionLocation,
   type HierarchyEditorGroup,
   type HierarchyEditorSubgroup,
 } from "./technical-configuration-baseline-hierarchy-save-support"
+import {
+  sameOrder,
+  updateNextCriterionNumber,
+  updateRevision,
+} from "./technical-configuration-baseline-save-support"
 
 /** Runs the dormant P1E hierarchy mutation sequence with resumable progress. */
 export async function runTechnicalConfigurationBaselineHierarchySaveSteps(

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-support.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-support.ts
@@ -1,0 +1,223 @@
+import type {
+  TechnicalConfigurationBaselineCriterionMutationWire,
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+  TechnicalConfigurationBaselineSubgroupWire,
+} from "./baseline-types"
+import { cloneTechnicalConfigurationBaselineDraft } from "./technical-configuration-baseline-editor-state"
+import type { TechnicalConfigurationBaselineEditorProgress } from "./technical-configuration-baseline-save"
+import { toTechnicalConfigurationBaselineWireCriterion } from "./technical-configuration-baseline-save-mappers"
+
+export type HierarchyEditorGroup =
+  TechnicalConfigurationBaselineEditorProgress["editorDraft"]["groups"][number]
+export type HierarchyEditorSubgroup = HierarchyEditorGroup["subgroups"][number]
+export type HierarchyEditorCriterion = HierarchyEditorGroup["criteria"][number]
+
+export type HierarchyEditorCriterionLocation = Readonly<{
+  criterion: HierarchyEditorCriterion
+  group: HierarchyEditorGroup
+  subgroup: HierarchyEditorSubgroup | null
+}>
+
+type WireCriterionLocation = Readonly<{
+  criterion: TechnicalConfigurationBaselineCriterionWire
+  group: TechnicalConfigurationBaselineGroupWire
+  subgroup: TechnicalConfigurationBaselineSubgroupWire | null
+}>
+
+/** Maps each editor criterion to its current group and optional subgroup owner. */
+export function getEditorCriterionLocations(
+  progress: TechnicalConfigurationBaselineEditorProgress
+): HierarchyEditorCriterionLocation[] {
+  return progress.editorDraft.groups.flatMap((group) => [
+    ...group.criteria.map((criterion) => ({ criterion, group, subgroup: null })),
+    ...group.subgroups.flatMap((subgroup) =>
+      subgroup.criteria.map((criterion) => ({ criterion, group, subgroup }))
+    ),
+  ])
+}
+
+/** Maps each persisted criterion to its current group and optional subgroup owner. */
+export function getWireCriterionLocations(
+  progress: TechnicalConfigurationBaselineEditorProgress
+): WireCriterionLocation[] {
+  return progress.baseDraft.groups.flatMap((group) => [
+    ...group.criteria.map((criterion) => ({ criterion, group, subgroup: null })),
+    ...(group.subgroups ?? []).flatMap((subgroup) =>
+      subgroup.criteria.map((criterion) => ({ criterion, group, subgroup }))
+    ),
+  ])
+}
+
+/** Finds a persisted group by ID in the mutable save snapshot. */
+export function findWireGroup(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  groupId: string
+): TechnicalConfigurationBaselineGroupWire {
+  const group = progress.baseDraft.groups.find((item) => item.id === groupId)
+  if (!group) throw new Error(`Missing baseline group ${groupId}`)
+  return group
+}
+
+/** Finds a persisted subgroup by ID in the mutable save snapshot. */
+export function findWireSubgroup(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  subgroupId: string
+): TechnicalConfigurationBaselineSubgroupWire {
+  for (const group of progress.baseDraft.groups) {
+    const subgroup = (group.subgroups ?? []).find((item) => item.id === subgroupId)
+    if (subgroup) return subgroup
+  }
+  throw new Error(`Missing baseline subgroup ${subgroupId}`)
+}
+
+/** Finds a persisted criterion and its owner location by criterion ID. */
+export function findWireCriterionLocation(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  criterionId: string
+): WireCriterionLocation {
+  const location = getWireCriterionLocations(progress).find(
+    ({ criterion }) => criterion.id === criterionId
+  )
+  if (!location) throw new Error(`Missing baseline criterion ${criterionId}`)
+  return location
+}
+
+/** Replaces one subgroup in the mutable save snapshot. */
+export function replaceWireSubgroup(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  response: Omit<TechnicalConfigurationBaselineSubgroupWire, "criteria"> & { revision: number }
+): void {
+  for (const group of progress.baseDraft.groups) {
+    group.subgroups = (group.subgroups ?? []).map((subgroup) =>
+      subgroup.id === response.id
+        ? { ...toWireSubgroup(response), criteria: subgroup.criteria }
+        : subgroup
+    )
+  }
+}
+
+/** Replaces one criterion while preserving its current owner location. */
+export function replaceWireCriterion(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  response: TechnicalConfigurationBaselineCriterionMutationWire
+): void {
+  const criterion = toTechnicalConfigurationBaselineWireCriterion(response)
+  for (const group of progress.baseDraft.groups) {
+    group.criteria = group.criteria.map((item) => (item.id === criterion.id ? criterion : item))
+    for (const subgroup of group.subgroups ?? []) {
+      subgroup.criteria = subgroup.criteria.map((item) =>
+        item.id === criterion.id ? criterion : item
+      )
+    }
+  }
+}
+
+/** Removes a criterion from its current owner and returns the updated snapshot. */
+export function removeWireCriterion(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  criterionId: string
+): void {
+  for (const group of progress.baseDraft.groups) {
+    group.criteria = group.criteria.filter((criterion) => criterion.id !== criterionId)
+    for (const subgroup of group.subgroups ?? []) {
+      subgroup.criteria = subgroup.criteria.filter((criterion) => criterion.id !== criterionId)
+    }
+  }
+}
+
+/** Appends a criterion to a direct group or subgroup owner. */
+export function appendWireCriterion(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  criterion: TechnicalConfigurationBaselineCriterionWire
+): void {
+  const group = findWireGroup(progress, criterion.group_id)
+  if (criterion.subgroup_id) {
+    const subgroup = (group.subgroups ?? []).find((item) => item.id === criterion.subgroup_id)
+    if (!subgroup) throw new Error(`Missing baseline subgroup ${criterion.subgroup_id}`)
+    subgroup.criteria.push(criterion)
+    return
+  }
+  group.criteria.push(criterion)
+}
+
+/** Applies a criterion mutation response and advances the chained revision. */
+export function applyCriterionResponse(
+  criterion: HierarchyEditorCriterion,
+  response: TechnicalConfigurationBaselineCriterionMutationWire
+): void {
+  criterion.id = response.id
+  criterion.criterionCode = response.criterion_code
+  criterion.title = response.title ?? ""
+  criterion.requirementText = response.requirement_text
+}
+
+/** Reports whether two criterion owner locations identify the same container. */
+export function sameCriterionOwner(
+  wire: WireCriterionLocation,
+  editor: HierarchyEditorCriterionLocation
+): boolean {
+  return (
+    wire.group.id === editor.group.id &&
+    (wire.subgroup?.id ?? null) === (editor.subgroup?.id ?? null)
+  )
+}
+
+/** Converts an editor subgroup into the persisted hierarchy wire shape. */
+export function toWireSubgroup(
+  response: Omit<TechnicalConfigurationBaselineSubgroupWire, "criteria"> & { revision: number }
+): TechnicalConfigurationBaselineSubgroupWire {
+  const { revision: _revision, ...subgroup } = response
+  return { ...subgroup, criteria: [] }
+}
+
+/** Replaces the save runner snapshot with a server-returned hierarchy snapshot. */
+export function adoptSnapshot(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  snapshot: TechnicalConfigurationBaselineEditorProgress["baseDraft"]
+): void {
+  progress.baseDraft = cloneTechnicalConfigurationBaselineDraft(snapshot)
+  updateRevision(progress, snapshot.revision)
+}
+
+/** Updates only the revision carried by the mutable save snapshot. */
+export function updateRevision(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  revision: number
+): void {
+  progress.baseDraft.revision = revision
+  progress.editorDraft.revision = revision
+}
+
+/** Updates the next criterion sequence number in the mutable save snapshot. */
+export function updateNextCriterionNumber(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  criterionCode: string
+): void {
+  const sequence = Number.parseInt(criterionCode.replace(/^TC-/, ""), 10)
+  if (Number.isFinite(sequence)) {
+    progress.baseDraft.next_criterion_number = Math.max(
+      progress.baseDraft.next_criterion_number,
+      sequence + 1
+    )
+  }
+}
+
+/** Compares two ID sequences without reordering either input. */
+export function sameOrder(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((item, index) => item === right[index])
+}
+
+/** Narrows nullable persisted IDs to strings. */
+export function isString(value: string | null): value is string {
+  return value !== null
+}
+
+/** Collects non-null persisted IDs while preserving item order. */
+export function getPersistedIds(items: readonly { id: string | null }[]): string[] {
+  const ids: string[] = []
+  for (const { id } of items) {
+    if (isString(id)) ids.push(id)
+  }
+  return ids
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-support.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-save-support.ts
@@ -7,6 +7,7 @@ import type {
 import { cloneTechnicalConfigurationBaselineDraft } from "./technical-configuration-baseline-editor-state"
 import type { TechnicalConfigurationBaselineEditorProgress } from "./technical-configuration-baseline-save"
 import { toTechnicalConfigurationBaselineWireCriterion } from "./technical-configuration-baseline-save-mappers"
+import { updateRevision } from "./technical-configuration-baseline-save-support"
 
 export type HierarchyEditorGroup =
   TechnicalConfigurationBaselineEditorProgress["editorDraft"]["groups"][number]
@@ -178,34 +179,6 @@ export function adoptSnapshot(
 ): void {
   progress.baseDraft = cloneTechnicalConfigurationBaselineDraft(snapshot)
   updateRevision(progress, snapshot.revision)
-}
-
-/** Updates only the revision carried by the mutable save snapshot. */
-export function updateRevision(
-  progress: TechnicalConfigurationBaselineEditorProgress,
-  revision: number
-): void {
-  progress.baseDraft.revision = revision
-  progress.editorDraft.revision = revision
-}
-
-/** Updates the next criterion sequence number in the mutable save snapshot. */
-export function updateNextCriterionNumber(
-  progress: TechnicalConfigurationBaselineEditorProgress,
-  criterionCode: string
-): void {
-  const sequence = Number.parseInt(criterionCode.replace(/^TC-/, ""), 10)
-  if (Number.isFinite(sequence)) {
-    progress.baseDraft.next_criterion_number = Math.max(
-      progress.baseDraft.next_criterion_number,
-      sequence + 1
-    )
-  }
-}
-
-/** Compares two ID sequences without reordering either input. */
-export function sameOrder(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((item, index) => item === right[index])
 }
 
 /** Narrows nullable persisted IDs to strings. */

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-save-steps.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-save-steps.ts
@@ -14,6 +14,11 @@ import {
   toTechnicalConfigurationBaselineWireCriterion,
   toTechnicalConfigurationBaselineWireGroup,
 } from "./technical-configuration-baseline-save-mappers"
+import {
+  sameOrder,
+  updateNextCriterionNumber,
+  updateRevision,
+} from "./technical-configuration-baseline-save-support"
 
 export type TechnicalConfigurationBaselineRunSaveStep = <T>(
   request: () => Promise<T>,
@@ -181,7 +186,7 @@ async function createNewCriteria(
         findWireGroup(progress.baseDraft, group.id as string).criteria.push(
           toTechnicalConfigurationBaselineWireCriterion(response.data)
         )
-        updateNextCriterionNumber(progress.baseDraft, response.data.criterion_code)
+        updateNextCriterionNumber(progress, response.data.criterion_code)
         updateRevision(progress, response.data.revision)
       }
     )
@@ -279,14 +284,6 @@ async function reorderCriteria(
   }
 }
 
-function updateRevision(
-  progress: TechnicalConfigurationBaselineEditorProgress,
-  revision: number
-): void {
-  progress.baseDraft.revision = revision
-  progress.editorDraft.revision = revision
-}
-
 function findWireGroup(
   draft: TechnicalConfigurationBaselineDraftWire,
   groupId: string
@@ -331,18 +328,4 @@ function replaceWireCriterion(
       item.id === criterion.id ? toTechnicalConfigurationBaselineWireCriterion(criterion) : item
     )
   }
-}
-
-function updateNextCriterionNumber(
-  draft: TechnicalConfigurationBaselineDraftWire,
-  criterionCode: string
-): void {
-  const sequence = Number.parseInt(criterionCode.replace(/^TC-/, ""), 10)
-  if (Number.isFinite(sequence)) {
-    draft.next_criterion_number = Math.max(draft.next_criterion_number, sequence + 1)
-  }
-}
-
-function sameOrder(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((item, index) => item === right[index])
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-save-steps.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-save-steps.ts
@@ -15,14 +15,17 @@ import {
   toTechnicalConfigurationBaselineWireGroup,
 } from "./technical-configuration-baseline-save-mappers"
 
-type RunStep = <T>(request: () => Promise<T>, apply: (response: T) => void) => Promise<void>
+export type TechnicalConfigurationBaselineRunSaveStep = <T>(
+  request: () => Promise<T>,
+  apply: (response: T) => void
+) => Promise<void>
 type EditorGroup = TechnicalConfigurationBaselineEditorProgress["editorDraft"]["groups"][number]
 
 /** Runs ordered P2 mutations while applying each successful revision to resumable progress. */
 export async function runTechnicalConfigurationBaselineSaveSteps(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   await deleteRemovedGroups(progress, rpc, run)
   await deleteRemovedCriteria(progress, rpc, run)
@@ -33,10 +36,11 @@ export async function runTechnicalConfigurationBaselineSaveSteps(
   await reorderCriteria(progress, rpc, run)
 }
 
-async function deleteRemovedGroups(
+/** Deletes persisted groups omitted from the editor draft. */
+export async function deleteRemovedGroups(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of [...progress.baseDraft.groups]) {
     if (progress.editorDraft.groups.some((item) => item.id === group.id)) continue
@@ -60,7 +64,7 @@ async function deleteRemovedGroups(
 async function deleteRemovedCriteria(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of [...progress.baseDraft.groups]) {
     const editorGroup = progress.editorDraft.groups.find((item) => item.id === group.id)
@@ -87,10 +91,11 @@ async function deleteRemovedCriteria(
   }
 }
 
-async function createNewGroups(
+/** Creates draft groups and adopts their server-assigned identities. */
+export async function createNewGroups(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of progress.editorDraft.groups) {
     if (group.id) continue
@@ -112,10 +117,11 @@ async function createNewGroups(
   }
 }
 
-async function updateExistingGroups(
+/** Persists edits to groups that already exist on the server. */
+export async function updateExistingGroups(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of progress.editorDraft.groups) {
     if (!group.id) continue
@@ -141,7 +147,7 @@ async function updateExistingGroups(
 async function createAndUpdateCriteria(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of progress.editorDraft.groups) {
     if (!group.id) continue
@@ -154,7 +160,7 @@ async function createNewCriteria(
   group: EditorGroup,
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const criterion of group.criteria) {
     if (criterion.id) continue
@@ -186,7 +192,7 @@ async function updateExistingCriteria(
   group: EditorGroup,
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const criterion of group.criteria) {
     if (!criterion.id) continue
@@ -216,10 +222,11 @@ async function updateExistingCriteria(
   }
 }
 
-async function reorderGroups(
+/** Persists group ordering when the draft differs from the server snapshot. */
+export async function reorderGroups(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   const editorGroupIds = progress.editorDraft.groups.map((group) => group.id as string)
   if (
@@ -247,7 +254,7 @@ async function reorderGroups(
 async function reorderCriteria(
   progress: TechnicalConfigurationBaselineEditorProgress,
   rpc: TechnicalConfigurationBaselineEditorRpc,
-  run: RunStep
+  run: TechnicalConfigurationBaselineRunSaveStep
 ): Promise<void> {
   for (const group of progress.editorDraft.groups) {
     const groupId = group.id as string

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-save-support.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-save-support.ts
@@ -1,0 +1,29 @@
+import type { TechnicalConfigurationBaselineEditorProgress } from "./technical-configuration-baseline-save"
+
+/** Updates the persisted and editor revisions carried by resumable save progress. */
+export function updateRevision(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  revision: number
+): void {
+  progress.baseDraft.revision = revision
+  progress.editorDraft.revision = revision
+}
+
+/** Advances the next criterion sequence number from a persisted criterion code. */
+export function updateNextCriterionNumber(
+  progress: TechnicalConfigurationBaselineEditorProgress,
+  criterionCode: string
+): void {
+  const sequence = Number.parseInt(criterionCode.replace(/^TC-/, ""), 10)
+  if (Number.isFinite(sequence)) {
+    progress.baseDraft.next_criterion_number = Math.max(
+      progress.baseDraft.next_criterion_number,
+      sequence + 1
+    )
+  }
+}
+
+/** Compares two ID sequences without reordering either input. */
+export function sameOrder(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((item, index) => item === right[index])
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-save.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-save.ts
@@ -18,6 +18,25 @@ import {
   cloneTechnicalConfigurationBaselineEditorDraft,
   validateTechnicalConfigurationBaselineEditorDraft,
 } from "./technical-configuration-baseline-editor-state"
+import type {
+  TechnicalConfigurationBaselineHierarchyCriteriaReorderRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionCreateRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionMoveRpcArgs,
+  TechnicalConfigurationBaselineHierarchyCriterionWireResponse,
+  TechnicalConfigurationBaselineHierarchyDeleteWireResponse,
+  TechnicalConfigurationBaselineHierarchyReorderWireResponse,
+  TechnicalConfigurationBaselineSubgroupCreateRpcArgs,
+  TechnicalConfigurationBaselineSubgroupDeleteRpcArgs,
+  TechnicalConfigurationBaselineSubgroupsReorderRpcArgs,
+  TechnicalConfigurationBaselineSubgroupUpdateRpcArgs,
+  TechnicalConfigurationBaselineSubgroupWireResponse,
+} from "./technical-configuration-baseline-hierarchy-mutation-types"
+import { runTechnicalConfigurationBaselineHierarchySaveSteps } from "./technical-configuration-baseline-hierarchy-save-steps"
+import {
+  getEditorCriterionLocations,
+  getWireCriterionLocations,
+  sameCriterionOwner,
+} from "./technical-configuration-baseline-hierarchy-save-support"
 import { runTechnicalConfigurationBaselineSaveSteps } from "./technical-configuration-baseline-save-steps"
 import type {
   TechnicalConfigurationBaselineEditorDraft,
@@ -55,6 +74,27 @@ export interface TechnicalConfigurationBaselineEditorRpc {
   reorderCriteria(
     args: TechnicalConfigurationBaselineCriteriaReorderRpcArgs
   ): Promise<TechnicalConfigurationBaselineDraftWireResponse>
+  createSubgroup(
+    args: TechnicalConfigurationBaselineSubgroupCreateRpcArgs
+  ): Promise<TechnicalConfigurationBaselineSubgroupWireResponse>
+  updateSubgroup(
+    args: TechnicalConfigurationBaselineSubgroupUpdateRpcArgs
+  ): Promise<TechnicalConfigurationBaselineSubgroupWireResponse>
+  deleteSubgroup(
+    args: TechnicalConfigurationBaselineSubgroupDeleteRpcArgs
+  ): Promise<TechnicalConfigurationBaselineHierarchyDeleteWireResponse>
+  reorderSubgroups(
+    args: TechnicalConfigurationBaselineSubgroupsReorderRpcArgs
+  ): Promise<TechnicalConfigurationBaselineHierarchyReorderWireResponse>
+  createHierarchyCriterion(
+    args: TechnicalConfigurationBaselineHierarchyCriterionCreateRpcArgs
+  ): Promise<TechnicalConfigurationBaselineHierarchyCriterionWireResponse>
+  moveHierarchyCriterion(
+    args: TechnicalConfigurationBaselineHierarchyCriterionMoveRpcArgs
+  ): Promise<TechnicalConfigurationBaselineHierarchyCriterionWireResponse>
+  reorderHierarchyCriteria(
+    args: TechnicalConfigurationBaselineHierarchyCriteriaReorderRpcArgs
+  ): Promise<TechnicalConfigurationBaselineHierarchyReorderWireResponse>
 }
 
 /** Carries resumable local and server progress after a multi-RPC explicit save fails. */
@@ -96,6 +136,7 @@ export async function saveTechnicalConfigurationBaselineEditorDraft({
   const validation = validateTechnicalConfigurationBaselineEditorDraft(editorDraft)
   if (
     Object.keys(validation.groupErrors).length ||
+    Object.keys(validation.subgroupErrors ?? {}).length ||
     Object.keys(validation.criterionErrors).length
   ) {
     throw new BaselineEditorValidationFailure(validation)
@@ -110,10 +151,31 @@ export async function saveTechnicalConfigurationBaselineEditorDraft({
     }
   }
 
-  await runTechnicalConfigurationBaselineSaveSteps(progress, rpc, run)
+  const hasHierarchy =
+    progress.baseDraft.groups.some((group) => (group.subgroups?.length ?? 0) > 0) ||
+    progress.editorDraft.groups.some((group) => group.subgroups.length > 0) ||
+    hasCriterionOwnerChanges(progress)
+
+  if (hasHierarchy) {
+    await runTechnicalConfigurationBaselineHierarchySaveSteps(progress, rpc, run)
+  } else {
+    await runTechnicalConfigurationBaselineSaveSteps(progress, rpc, run)
+  }
 
   progress.editorDraft.revision = progress.baseDraft.revision
   return cloneProgress(progress)
+}
+
+function hasCriterionOwnerChanges(progress: TechnicalConfigurationBaselineEditorProgress): boolean {
+  const wireLocations = new Map(
+    getWireCriterionLocations(progress).map((location) => [location.criterion.id, location])
+  )
+
+  return getEditorCriterionLocations(progress).some((editorLocation) => {
+    if (!editorLocation.criterion.id) return false
+    const wireLocation = wireLocations.get(editorLocation.criterion.id)
+    return wireLocation ? !sameCriterionOwner(wireLocation, editorLocation) : false
+  })
 }
 
 function cloneProgress(

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from "vitest"
 
 vi.mock("server-only", () => ({}))
 
-import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "@/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs"
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import {
@@ -121,6 +122,13 @@ describe("technical configuration baseline RPC whitelist", () => {
 
     expect(response.status).toBe(411)
     await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
+
+  it("keeps P1E hierarchy authoring mutations dormant until P6A", () => {
+    for (const fn of Object.values(TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS)) {
+      expect(ALLOWED_FUNCTIONS.has(fn)).toBe(false)
+      expect(SERVICE_ROLE_RPC_FUNCTIONS.has(fn)).toBe(false)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- implement P4C subgroup create, rename, delete, and reorder plus criterion moves across direct and subgroup owners
- add owner-scoped direct/subgroup entry, ordinal normalization, and revision-chained resumable hierarchy saves
- preserve dirty navigation, conflict, lock, reload, focus, scrolling, pending-buffer, validation, responsive, and P4B behavior
- keep hierarchy authoring controls hidden on the production baseline screen until P6A

## Scope
- reuses deployed mutation paths only
- no migration, RPC, backend mutation, generated DB type, or live DB write
- closes #889

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P4C tests: 36/36
- technical-configuration suite: 787/787
- RPC whitelist: 71/71
- React Doctor: 35 files, score 90, no issues
- `openspec validate revise-technical-configuration-baseline-hierarchy --strict`
- `mix-gpt-5.6-sol` xhigh review: Zero findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P4C hierarchy authoring to the technical configuration baseline: create/rename/delete/reorder subgroups, move and reorder criteria across direct and subgroup owners, owner‑scoped entry, and a resumable save flow. Controls are hidden on the production baseline screen and P1E mutations remain dormant until P6A. Closes #889.

- **New Features**
  - Subgroup controls: create, rename, delete, and reorder; criterion move/reorder across direct/subgroup owners with an owner picker.
  - Entry: direct and subgroup‑scoped single row and bulk entry; bulk sessions now owner‑scoped; ordinals normalize after structural edits.
  - Save: revision‑chained hierarchy save that maps returned IDs and resumes after partial failures; wired to dormant P1E functions via `TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS`.
  - UX/parity: keeps explicit Save, dirty‑nav, conflict/lock handling, reload, focus/scrolling, validation, responsiveness, and P4B presentation; baseline tab validation now includes subgroup errors and counts subgroup criteria.
  - Safety: no migrations or new live writes; production RPC allowlist unchanged and tests ensure hierarchy mutations stay inactive; controls are unmounted in prod until P6A.

- **Bug Fixes**
  - Tightened lock prerequisites to require at least one criterion in either a group or subgroup and fixed bulk‑entry session syncing by owner key.

<sup>Written for commit 05ef7b51cab0650c706d52e7695836c355ca4829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional hierarchy authoring for technical-configuration baselines, including subgroup creation, renaming, reordering, deletion, and criterion movement.
  * Added editable subgroup criteria with direct and bulk-entry workflows.
  * Added owner selection, responsive controls, and improved focus behavior.
  * Added sequential saving with retry and conflict recovery.

* **Bug Fixes**
  * Improved locking validation for nested criteria and pending subgroup input.

* **Tests**
  * Expanded coverage for hierarchy editing, saving, locking, conflicts, accessibility, focus, and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->