### PR TITLE
feat(technical-config): add P5A aggregate status model

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p5a-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p5a-tdd-plan.md
@@ -1,0 +1,159 @@
+# P5A TDD Plan - Aggregate Status Model
+
+Issue: #890
+
+Branch: `feat/issue-890-p5a-aggregate-status-model`
+
+Base: clean `main` at merge commit `a0d85678`
+
+## Scope
+
+Implement P5A.1-P5A.3 as a pure TypeScript domain model with focused Vitest
+coverage. This phase does not wire the model into production UI, hooks, RPCs,
+migrations, or live Supabase state.
+
+## Assumptions
+
+- The canonical leaf status contract is
+  `TechnicalConfigurationDerivedStatus` from
+  `src/lib/technical-configuration-evaluation.ts`.
+- The canonical failing leaf value is `fails`; the OpenSpec prose word
+  `failed` describes that existing domain value.
+- Missing entries in the leaf status map are treated as `not_evaluated`.
+- A subgroup aggregates only its direct leaf criterion IDs.
+- A section aggregates its direct leaf criterion IDs plus every leaf criterion
+  ID declared by its subgroups.
+- Duplicate criterion IDs are counted once per aggregate and once in the
+  hierarchy-wide leaf universe.
+- Structural IDs are metadata only. They never enter the leaf universe,
+  descendant counts, progress denominators, filter totals, ranking inputs, or
+  score inputs.
+
+## Model Contract
+
+Add `src/lib/technical-configuration-hierarchy-aggregate-status.ts` with:
+
+- stable aggregate states and Vietnamese labels:
+  `no_criteria`, `failed`, `in_progress`, `needs_clarification`,
+  `not_applicable`, and `passed`;
+- exact counts for every canonical derived leaf status;
+- minimal section/subgroup hierarchy input types containing structural IDs and
+  leaf criterion IDs only;
+- one builder that returns:
+  - the hierarchy-wide unique leaf criterion IDs;
+  - the hierarchy-wide leaf status projection and exact status counts;
+  - subgroup rollups;
+  - section rollups;
+  - each rollup's unique descendant IDs, descendant count, exact status counts,
+    and aggregate status.
+
+Do not change `deriveTechnicalConfigurationEvaluationStatus` or existing
+production consumers in P5A.
+
+## File Map
+
+Create:
+
+- `src/lib/technical-configuration-hierarchy-aggregate-status.ts`
+  - owns aggregate precedence, unique-ID collection, exact counts, and rollups.
+- `src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts`
+  - owns exhaustive precedence and owner rollup behavior.
+- `src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts`
+  - owns hierarchy-wide deduplication, empty structural rows, snapshot
+    independence, and P5A.3 denominator/filter/ranking/score invariants.
+
+Update after GREEN:
+
+- `openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md`
+  - mark P5A.1-P5A.3 complete only after all required verification passes.
+
+No other production source file is in scope.
+
+## TDD Sequence
+
+### RED 1 - Aggregate Precedence And Counts
+
+1. Add a focused test suite that imports the planned model API.
+2. Cover:
+   - zero descendants;
+   - fail-fast `fails`, including a simultaneous `not_evaluated` leaf;
+   - incomplete `not_evaluated` before review-required statuses;
+   - `unclear` and `insufficient_evidence` review-required cases;
+   - all `not_applicable`;
+   - passing `meets`/`exceeds` combinations;
+   - exact count for every canonical derived status;
+   - supplementary `exceeds` count without a separate aggregate state.
+3. Run the focused suite and confirm RED because the model module does not yet
+   exist.
+
+### RED 2 - Hierarchy Rollups And Structural Invariants
+
+1. Add subgroup and section cases with:
+   - direct section criteria;
+   - subgroup criteria;
+   - multiple subgroups;
+   - duplicate leaf IDs inside and across structural nodes;
+   - missing leaf statuses.
+2. Assert subgroup rollups use direct subgroup leaves only.
+3. Assert section rollups use the unique union of direct and subgroup leaves.
+4. Assert hierarchy-wide leaf IDs remain unique and structural IDs are absent.
+5. Compare flat and nested hierarchies through the returned leaf projection:
+   - progress denominator uses the leaf projection length;
+   - filter totals use every canonical status count;
+   - ranking inputs preserve the unique criterion universe and map the
+     failed/insufficient/exceeds fields available from derived statuses;
+   - ranking completeness remains owned by consumers with the raw
+     technical/evidence axes and is not inferred from `not_evaluated`;
+   - score inputs remain the same ordered leaf-status set without inventing a
+     numeric or weighted score.
+
+### GREEN - Minimal Model
+
+1. Add the stable aggregate status values, labels, types, and empty count
+   factory.
+2. Normalize leaf IDs with `Set` while preserving first-seen canonical order.
+3. Resolve missing status entries as `not_evaluated`.
+4. Count each unique descendant exactly once.
+5. Apply precedence in this order:
+   - `no_criteria`;
+   - `failed`;
+   - `in_progress`;
+   - `needs_clarification`;
+   - `not_applicable`;
+   - `passed`.
+6. Build subgroup and section rollups without mutating input.
+7. Return the unique hierarchy leaf universe and canonical status projection
+   separately from structural rollups.
+8. Run the focused suite to GREEN.
+
+### REFACTOR
+
+1. Keep helpers private unless a testable public contract is required.
+2. Keep the model independent of React, RPC, wire-decoder, and database types.
+3. Keep source and test files below repository size thresholds.
+4. Run Prettier and simplify names only after behavior is green.
+
+## Verification
+
+Run through one context-mode batch where practical:
+
+1. `node scripts/npm-run.js run format:check`
+2. `node scripts/npm-run.js run verify:no-explicit-any`
+3. `node scripts/npm-run.js run verify:dedupe`
+4. `node scripts/npm-run.js run typecheck`
+5. `node scripts/npm-run.js exec vitest run src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts`
+6. `node scripts/npm-run.js run react-doctor`
+7. `openspec validate revise-technical-configuration-baseline-hierarchy --strict`
+
+Then run change-aware review:
+
+- Code Review Graph `detect_changes_tool` with minimal output;
+- GitNexus `detect_changes` and focused impact/context for risky symbols;
+- xhigh independent code review, fixing findings and repeating review until
+  zero findings.
+
+## Completion Boundary
+
+Stop before landing. Report issue, branch, changed files, RED/GREEN evidence,
+gate results, strict OpenSpec result, and xhigh review result. Do not merge,
+push, or close issue #890 until the user approves landing.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -275,11 +275,11 @@ Depends on: the parent change's canonical derived criterion status contract.
 
 Deploy boundary: pure model and tests only; no production surface changes.
 
-- [ ] P5A.1 Write exhaustive tests for fail-fast `failed`, incomplete
+- [x] P5A.1 Write exhaustive tests for fail-fast `failed`, incomplete
       `not_evaluated`, review-required statuses, zero descendants, all-not-applicable,
       pass, and exact descendant counts.
-- [ ] P5A.2 Implement subgroup and section rollups over unique leaf criterion IDs.
-- [ ] P5A.3 Prove structural rows never change progress denominators, filter totals,
+- [x] P5A.2 Implement subgroup and section rollups over unique leaf criterion IDs.
+- [x] P5A.3 Prove structural rows never change progress denominators, filter totals,
       ranking inputs, or score.
 
 ## Phase P5B - Comparison Hierarchy

--- a/src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts
+++ b/src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS,
+  TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_VALUES,
+  buildTechnicalConfigurationHierarchyAggregateStatus,
+  type TechnicalConfigurationAggregateStatus,
+} from "@/lib/technical-configuration-hierarchy-aggregate-status"
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+
+const ALL_STATUS_COUNTS = {
+  not_evaluated: 0,
+  not_applicable: 0,
+  fails: 0,
+  unclear: 0,
+  insufficient_evidence: 0,
+  exceeds: 0,
+  meets: 0,
+} as const
+
+const SINGLE_STATUS_EXPECTED_AGGREGATE = {
+  not_evaluated: "in_progress",
+  not_applicable: "not_applicable",
+  fails: "failed",
+  unclear: "needs_clarification",
+  insufficient_evidence: "needs_clarification",
+  exceeds: "passed",
+  meets: "passed",
+} as const satisfies Record<
+  TechnicalConfigurationDerivedStatus,
+  TechnicalConfigurationAggregateStatus
+>
+
+function buildSingleSectionModel(statuses: readonly TechnicalConfigurationDerivedStatus[]) {
+  const criterionIds = statuses.map((_, index) => `criterion-${index + 1}`)
+
+  return buildTechnicalConfigurationHierarchyAggregateStatus({
+    sections: [
+      {
+        id: "section-1",
+        criterionIds,
+        subgroups: [],
+      },
+    ],
+    statusByCriterionId: new Map(
+      criterionIds.map((criterionId, index) => [criterionId, statuses[index]])
+    ),
+  })
+}
+
+describe("technical configuration hierarchy aggregate status", () => {
+  it("publishes stable aggregate states and Vietnamese labels", () => {
+    expect(TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_VALUES).toEqual([
+      "no_criteria",
+      "failed",
+      "in_progress",
+      "needs_clarification",
+      "not_applicable",
+      "passed",
+    ])
+    expect(TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS).toEqual({
+      no_criteria: "Chưa có tiêu chí",
+      failed: "Không đạt",
+      in_progress: "Đang đánh giá",
+      needs_clarification: "Cần làm rõ",
+      not_applicable: "Không áp dụng",
+      passed: "Đạt",
+    })
+  })
+
+  it("returns no criteria and zero counts for an empty structural row", () => {
+    const model = buildSingleSectionModel([])
+
+    expect(model.criterionIds).toEqual([])
+    expect(model.sections[0]).toMatchObject({
+      id: "section-1",
+      status: "no_criteria",
+      descendantCriterionIds: [],
+      descendantCount: 0,
+      statusCounts: ALL_STATUS_COUNTS,
+    })
+  })
+
+  it.each(TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES)(
+    "handles the canonical %s leaf status explicitly",
+    (status) => {
+      const model = buildSingleSectionModel([status])
+
+      expect(model.sections[0]?.status).toBe(SINGLE_STATUS_EXPECTED_AGGREGATE[status])
+    }
+  )
+
+  it.each([
+    {
+      name: "fails immediately even while another leaf is incomplete",
+      statuses: ["not_evaluated", "fails", "unclear"],
+      expected: "failed",
+    },
+    {
+      name: "stays in progress before review-required states can win",
+      statuses: ["meets", "not_evaluated", "insufficient_evidence"],
+      expected: "in_progress",
+    },
+    {
+      name: "requires clarification for unclear leaves after evaluation is complete",
+      statuses: ["meets", "unclear"],
+      expected: "needs_clarification",
+    },
+    {
+      name: "requires clarification for insufficient evidence",
+      statuses: ["exceeds", "insufficient_evidence"],
+      expected: "needs_clarification",
+    },
+    {
+      name: "is not applicable when every descendant is not applicable",
+      statuses: ["not_applicable", "not_applicable"],
+      expected: "not_applicable",
+    },
+    {
+      name: "passes when at least one applicable descendant meets",
+      statuses: ["not_applicable", "meets"],
+      expected: "passed",
+    },
+    {
+      name: "passes without introducing a separate exceeds aggregate state",
+      statuses: ["meets", "exceeds", "exceeds"],
+      expected: "passed",
+    },
+  ] as const)("$name", ({ statuses, expected }) => {
+    const model = buildSingleSectionModel(statuses)
+
+    expect(model.sections[0]?.status).toBe(expected)
+  })
+
+  it("counts every canonical derived status exactly", () => {
+    const statuses = [
+      "not_evaluated",
+      "not_applicable",
+      "fails",
+      "unclear",
+      "insufficient_evidence",
+      "exceeds",
+      "meets",
+    ] as const satisfies readonly TechnicalConfigurationDerivedStatus[]
+
+    const model = buildSingleSectionModel(statuses)
+
+    expect(model.sections[0]).toMatchObject({
+      status: "failed",
+      descendantCount: statuses.length,
+      statusCounts: {
+        not_evaluated: 1,
+        not_applicable: 1,
+        fails: 1,
+        unclear: 1,
+        insufficient_evidence: 1,
+        exceeds: 1,
+        meets: 1,
+      },
+    })
+  })
+
+  it("treats a missing canonical leaf status as not evaluated", () => {
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "section-1",
+          criterionIds: ["criterion-1"],
+          subgroups: [],
+        },
+      ],
+      statusByCriterionId: new Map(),
+    })
+
+    expect(model.sections[0]).toMatchObject({
+      status: "in_progress",
+      descendantCount: 1,
+      statusCounts: {
+        ...ALL_STATUS_COUNTS,
+        not_evaluated: 1,
+      },
+    })
+    expect(model.leafCriteria).toEqual([{ criterionId: "criterion-1", status: "not_evaluated" }])
+    expect(model.statusCounts).toEqual({
+      ...ALL_STATUS_COUNTS,
+      not_evaluated: 1,
+    })
+  })
+
+  it("fails closed for an unknown runtime leaf status", () => {
+    const statusByCriterionId = new Map([
+      ["criterion-1", "future_review_status"],
+    ]) as unknown as ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+
+    expect(() =>
+      buildTechnicalConfigurationHierarchyAggregateStatus({
+        sections: [
+          {
+            id: "section-1",
+            criterionIds: ["criterion-1"],
+            subgroups: [],
+          },
+        ],
+        statusByCriterionId,
+      })
+    ).toThrow("Unsupported technical configuration derived status: future_review_status")
+  })
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ] as const)("fails closed for a present %s runtime leaf status", (_, invalidStatus) => {
+    const statusByCriterionId = new Map([["criterion-1", invalidStatus]]) as unknown as ReadonlyMap<
+      string,
+      TechnicalConfigurationDerivedStatus
+    >
+
+    expect(() =>
+      buildTechnicalConfigurationHierarchyAggregateStatus({
+        sections: [
+          {
+            id: "section-1",
+            criterionIds: ["criterion-1"],
+            subgroups: [],
+          },
+        ],
+        statusByCriterionId,
+      })
+    ).toThrow(`Unsupported technical configuration derived status: ${String(invalidStatus)}`)
+  })
+
+  it("rolls subgroups and sections up over unique leaf criterion IDs", () => {
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "section-1",
+          criterionIds: ["criterion-a", "criterion-shared", "criterion-a"],
+          subgroups: [
+            {
+              id: "subgroup-1",
+              criterionIds: ["criterion-b", "criterion-shared", "criterion-b"],
+            },
+            {
+              id: "subgroup-2",
+              criterionIds: ["criterion-c", "criterion-b"],
+            },
+          ],
+        },
+      ],
+      statusByCriterionId: new Map([
+        ["criterion-a", "meets"],
+        ["criterion-shared", "fails"],
+        ["criterion-b", "not_applicable"],
+        ["criterion-c", "exceeds"],
+      ]),
+    })
+
+    expect(model.criterionIds).toEqual([
+      "criterion-a",
+      "criterion-shared",
+      "criterion-b",
+      "criterion-c",
+    ])
+    expect(model.sections[0]).toMatchObject({
+      id: "section-1",
+      status: "failed",
+      descendantCriterionIds: ["criterion-a", "criterion-shared", "criterion-b", "criterion-c"],
+      descendantCount: 4,
+      statusCounts: {
+        ...ALL_STATUS_COUNTS,
+        not_applicable: 1,
+        fails: 1,
+        exceeds: 1,
+        meets: 1,
+      },
+    })
+    expect(model.sections[0]?.subgroups).toEqual([
+      {
+        id: "subgroup-1",
+        status: "failed",
+        descendantCriterionIds: ["criterion-b", "criterion-shared"],
+        descendantCount: 2,
+        statusCounts: {
+          ...ALL_STATUS_COUNTS,
+          not_applicable: 1,
+          fails: 1,
+        },
+      },
+      {
+        id: "subgroup-2",
+        status: "passed",
+        descendantCriterionIds: ["criterion-c", "criterion-b"],
+        descendantCount: 2,
+        statusCounts: {
+          ...ALL_STATUS_COUNTS,
+          not_applicable: 1,
+          exceeds: 1,
+        },
+      },
+    ])
+  })
+
+  it("fails a section when only a subgroup-exclusive descendant fails", () => {
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "section-1",
+          criterionIds: ["criterion-direct"],
+          subgroups: [
+            {
+              id: "subgroup-1",
+              criterionIds: ["criterion-subgroup"],
+            },
+          ],
+        },
+      ],
+      statusByCriterionId: new Map([
+        ["criterion-direct", "meets"],
+        ["criterion-subgroup", "fails"],
+      ]),
+    })
+
+    expect(model.sections[0]).toMatchObject({
+      status: "failed",
+      descendantCriterionIds: ["criterion-direct", "criterion-subgroup"],
+    })
+    expect(model.sections[0]?.subgroups[0]).toMatchObject({
+      status: "failed",
+      descendantCriterionIds: ["criterion-subgroup"],
+    })
+  })
+})

--- a/src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts
+++ b/src/lib/__tests__/technical-configuration-hierarchy-aggregate-status.test.ts
@@ -34,7 +34,9 @@ const SINGLE_STATUS_EXPECTED_AGGREGATE = {
   TechnicalConfigurationAggregateStatus
 >
 
-function buildSingleSectionModel(statuses: readonly TechnicalConfigurationDerivedStatus[]) {
+function buildSingleSectionModel(
+  statuses: readonly TechnicalConfigurationDerivedStatus[]
+): ReturnType<typeof buildTechnicalConfigurationHierarchyAggregateStatus> {
   const criterionIds = statuses.map((_, index) => `criterion-${index + 1}`)
 
   return buildTechnicalConfigurationHierarchyAggregateStatus({

--- a/src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts
+++ b/src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts
@@ -9,7 +9,7 @@ function expectEmptyAggregate(
     | ReturnType<
         typeof buildTechnicalConfigurationHierarchyAggregateStatus
       >["sections"][number]["subgroups"][number]
-) {
+): void {
   expect(aggregate).toMatchObject({
     status: "no_criteria",
     descendantCriterionIds: [],

--- a/src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts
+++ b/src/lib/__tests__/technical-configuration-hierarchy-aggregate-structure.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest"
+
+import { buildTechnicalConfigurationHierarchyAggregateStatus } from "@/lib/technical-configuration-hierarchy-aggregate-status"
+import type { TechnicalConfigurationDerivedStatus } from "@/lib/technical-configuration-evaluation"
+
+function expectEmptyAggregate(
+  aggregate:
+    | ReturnType<typeof buildTechnicalConfigurationHierarchyAggregateStatus>["sections"][number]
+    | ReturnType<
+        typeof buildTechnicalConfigurationHierarchyAggregateStatus
+      >["sections"][number]["subgroups"][number]
+) {
+  expect(aggregate).toMatchObject({
+    status: "no_criteria",
+    descendantCriterionIds: [],
+    descendantCount: 0,
+    statusCounts: {
+      not_evaluated: 0,
+      not_applicable: 0,
+      fails: 0,
+      unclear: 0,
+      insufficient_evidence: 0,
+      exceeds: 0,
+      meets: 0,
+    },
+  })
+}
+
+describe("technical configuration hierarchy aggregate structure", () => {
+  it("deduplicates the hierarchy-wide leaf universe without changing owner rollups", () => {
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "section-1",
+          criterionIds: ["criterion-shared", "criterion-a"],
+          subgroups: [],
+        },
+        {
+          id: "section-2",
+          criterionIds: [],
+          subgroups: [
+            {
+              id: "subgroup-2",
+              criterionIds: ["criterion-shared", "criterion-b"],
+            },
+          ],
+        },
+      ],
+      statusByCriterionId: new Map([
+        ["criterion-shared", "fails"],
+        ["criterion-a", "meets"],
+        ["criterion-b", "exceeds"],
+      ]),
+    })
+
+    expect(model.criterionIds).toEqual(["criterion-shared", "criterion-a", "criterion-b"])
+    expect(model.leafCriteria).toEqual([
+      { criterionId: "criterion-shared", status: "fails" },
+      { criterionId: "criterion-a", status: "meets" },
+      { criterionId: "criterion-b", status: "exceeds" },
+    ])
+    expect(model.statusCounts).toEqual({
+      not_evaluated: 0,
+      not_applicable: 0,
+      fails: 1,
+      unclear: 0,
+      insufficient_evidence: 0,
+      exceeds: 1,
+      meets: 1,
+    })
+    expect(model.sections[0]).toMatchObject({
+      descendantCriterionIds: ["criterion-shared", "criterion-a"],
+      descendantCount: 2,
+      status: "failed",
+    })
+    expect(model.sections[1]).toMatchObject({
+      descendantCriterionIds: ["criterion-shared", "criterion-b"],
+      descendantCount: 2,
+      status: "failed",
+    })
+    expect(model.sections[1]?.subgroups[0]).toMatchObject({
+      descendantCriterionIds: ["criterion-shared", "criterion-b"],
+      descendantCount: 2,
+      status: "failed",
+    })
+  })
+
+  it("returns explicit empty aggregates for empty sections and subgroups", () => {
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "empty-section",
+          criterionIds: [],
+          subgroups: [{ id: "empty-subgroup", criterionIds: [] }],
+        },
+      ],
+      statusByCriterionId: new Map(),
+    })
+
+    expect(model.criterionIds).toEqual([])
+    expectEmptyAggregate(model.sections[0]!)
+    expectEmptyAggregate(model.sections[0]!.subgroups[0]!)
+  })
+
+  it("returns a snapshot independent from later input mutations", () => {
+    const directCriterionIds = ["criterion-a"]
+    const subgroupCriterionIds = ["criterion-b"]
+    const subgroups = [{ id: "subgroup-1", criterionIds: subgroupCriterionIds }]
+    const sections = [{ id: "section-1", criterionIds: directCriterionIds, subgroups }]
+    const statusByCriterionId = new Map<string, TechnicalConfigurationDerivedStatus>([
+      ["criterion-a", "meets"],
+      ["criterion-b", "exceeds"],
+    ])
+    const originalInput = structuredClone(sections)
+
+    const model = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections,
+      statusByCriterionId,
+    })
+
+    expect(sections).toEqual(originalInput)
+
+    directCriterionIds.push("criterion-late")
+    subgroupCriterionIds.push("criterion-late-subgroup")
+    subgroups.push({ id: "subgroup-late", criterionIds: [] })
+    sections.push({ id: "section-late", criterionIds: [], subgroups: [] })
+    statusByCriterionId.set("criterion-a", "fails")
+
+    expect(model.criterionIds).toEqual(["criterion-a", "criterion-b"])
+    expect(model.sections).toHaveLength(1)
+    expect(model.sections[0]).toMatchObject({
+      status: "passed",
+      descendantCriterionIds: ["criterion-a", "criterion-b"],
+      descendantCount: 2,
+    })
+    expect(model.sections[0]?.subgroups).toHaveLength(1)
+  })
+
+  it("keeps structural rows out of denominator, filter, ranking, and score inputs", () => {
+    const statusByCriterionId = new Map<string, TechnicalConfigurationDerivedStatus>([
+      ["criterion-a", "not_evaluated"],
+      ["criterion-b", "fails"],
+      ["criterion-c", "insufficient_evidence"],
+      ["criterion-d", "exceeds"],
+    ])
+    const flat = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "flat-section",
+          criterionIds: ["criterion-a", "criterion-b", "criterion-c", "criterion-d"],
+          subgroups: [],
+        },
+      ],
+      statusByCriterionId,
+    })
+    const nested = buildTechnicalConfigurationHierarchyAggregateStatus({
+      sections: [
+        {
+          id: "section-1",
+          criterionIds: ["criterion-a"],
+          subgroups: [
+            {
+              id: "subgroup-1",
+              criterionIds: ["criterion-b", "criterion-c", "criterion-d"],
+            },
+            {
+              id: "subgroup-duplicate",
+              criterionIds: ["criterion-b"],
+            },
+          ],
+        },
+        {
+          id: "empty-section",
+          criterionIds: [],
+          subgroups: [{ id: "empty-subgroup", criterionIds: [] }],
+        },
+      ],
+      statusByCriterionId,
+    })
+
+    expect(nested.criterionIds).toEqual([
+      "criterion-a",
+      "criterion-b",
+      "criterion-c",
+      "criterion-d",
+    ])
+    expect(nested.leafCriteria).toEqual(flat.leafCriteria)
+    expect(nested.statusCounts).toEqual(flat.statusCounts)
+
+    const progressDenominator = nested.leafCriteria.length
+    const filterTotals = nested.statusCounts
+    const rankingInputs = {
+      criterionIds: nested.criterionIds,
+      failed_count: nested.statusCounts.fails,
+      insufficient_evidence_count: nested.statusCounts.insufficient_evidence,
+      exceeds_count: nested.statusCounts.exceeds,
+    }
+    const scoreInputs = nested.leafCriteria
+
+    expect(progressDenominator).toBe(4)
+    expect(filterTotals).toEqual({
+      not_evaluated: 1,
+      not_applicable: 0,
+      fails: 1,
+      unclear: 0,
+      insufficient_evidence: 1,
+      exceeds: 1,
+      meets: 0,
+    })
+    expect(rankingInputs).toEqual({
+      criterionIds: ["criterion-a", "criterion-b", "criterion-c", "criterion-d"],
+      failed_count: 1,
+      insufficient_evidence_count: 1,
+      exceeds_count: 1,
+    })
+    expect(scoreInputs).toEqual([
+      { criterionId: "criterion-a", status: "not_evaluated" },
+      { criterionId: "criterion-b", status: "fails" },
+      { criterionId: "criterion-c", status: "insufficient_evidence" },
+      { criterionId: "criterion-d", status: "exceeds" },
+    ])
+    expect(scoreInputs.every(({ criterionId }) => criterionId.startsWith("criterion-"))).toBe(true)
+  })
+})

--- a/src/lib/technical-configuration-hierarchy-aggregate-status.ts
+++ b/src/lib/technical-configuration-hierarchy-aggregate-status.ts
@@ -116,11 +116,13 @@ function buildLeafCriteria(
 function countLeafStatuses(
   leafCriteria: readonly TechnicalConfigurationAggregateLeafCriterion[]
 ): Record<TechnicalConfigurationDerivedStatus, number> {
-  const statusCounts = createEmptyStatusCounts()
-  for (const criterion of leafCriteria) {
-    statusCounts[criterion.status] += 1
-  }
-  return statusCounts
+  return leafCriteria.reduce(
+    (statusCounts, criterion) => ({
+      ...statusCounts,
+      [criterion.status]: statusCounts[criterion.status] + 1,
+    }),
+    createEmptyStatusCounts()
+  )
 }
 
 function deriveAggregateStatus(

--- a/src/lib/technical-configuration-hierarchy-aggregate-status.ts
+++ b/src/lib/technical-configuration-hierarchy-aggregate-status.ts
@@ -1,0 +1,194 @@
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+
+/** Stable aggregate states derived for section and subgroup structural rows. */
+export const TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_VALUES = [
+  "no_criteria",
+  "failed",
+  "in_progress",
+  "needs_clarification",
+  "not_applicable",
+  "passed",
+] as const
+
+export type TechnicalConfigurationAggregateStatus =
+  (typeof TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_VALUES)[number]
+
+/** Vietnamese display labels for hierarchy aggregate states. */
+export const TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS = {
+  no_criteria: "Chưa có tiêu chí",
+  failed: "Không đạt",
+  in_progress: "Đang đánh giá",
+  needs_clarification: "Cần làm rõ",
+  not_applicable: "Không áp dụng",
+  passed: "Đạt",
+} as const satisfies Record<TechnicalConfigurationAggregateStatus, string>
+
+export type TechnicalConfigurationDerivedStatusCounts = Readonly<
+  Record<TechnicalConfigurationDerivedStatus, number>
+>
+
+export type TechnicalConfigurationAggregateSubgroupInput = Readonly<{
+  id: string
+  criterionIds: readonly string[]
+}>
+
+export type TechnicalConfigurationAggregateSectionInput = Readonly<{
+  id: string
+  criterionIds: readonly string[]
+  subgroups: readonly TechnicalConfigurationAggregateSubgroupInput[]
+}>
+
+export type TechnicalConfigurationStructuralAggregate = Readonly<{
+  id: string
+  status: TechnicalConfigurationAggregateStatus
+  descendantCriterionIds: readonly string[]
+  descendantCount: number
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+}>
+
+export type TechnicalConfigurationSectionAggregate = TechnicalConfigurationStructuralAggregate &
+  Readonly<{
+    subgroups: readonly TechnicalConfigurationStructuralAggregate[]
+  }>
+
+export type TechnicalConfigurationAggregateLeafCriterion = Readonly<{
+  criterionId: string
+  status: TechnicalConfigurationDerivedStatus
+}>
+
+export type TechnicalConfigurationHierarchyAggregateStatusModel = Readonly<{
+  criterionIds: readonly string[]
+  leafCriteria: readonly TechnicalConfigurationAggregateLeafCriterion[]
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+  sections: readonly TechnicalConfigurationSectionAggregate[]
+}>
+
+type BuildTechnicalConfigurationHierarchyAggregateStatusInput = Readonly<{
+  sections: readonly TechnicalConfigurationAggregateSectionInput[]
+  statusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+}>
+
+function uniqueCriterionIds(criterionIds: readonly string[]): string[] {
+  return [...new Set(criterionIds)]
+}
+
+function createEmptyStatusCounts(): Record<TechnicalConfigurationDerivedStatus, number> {
+  return Object.fromEntries(
+    TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES.map((status) => [status, 0])
+  ) as Record<TechnicalConfigurationDerivedStatus, number>
+}
+
+function isTechnicalConfigurationDerivedStatus(
+  value: unknown
+): value is TechnicalConfigurationDerivedStatus {
+  return (
+    typeof value === "string" &&
+    (TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES as readonly string[]).includes(value)
+  )
+}
+
+function resolveTechnicalConfigurationDerivedStatus(
+  criterionId: string,
+  statusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+): TechnicalConfigurationDerivedStatus {
+  const status = statusByCriterionId.has(criterionId)
+    ? statusByCriterionId.get(criterionId)
+    : "not_evaluated"
+  if (!isTechnicalConfigurationDerivedStatus(status)) {
+    throw new Error(`Unsupported technical configuration derived status: ${String(status)}`)
+  }
+  return status
+}
+
+function buildLeafCriteria(
+  criterionIds: readonly string[],
+  statusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+): TechnicalConfigurationAggregateLeafCriterion[] {
+  return criterionIds.map((criterionId) => ({
+    criterionId,
+    status: resolveTechnicalConfigurationDerivedStatus(criterionId, statusByCriterionId),
+  }))
+}
+
+function countLeafStatuses(
+  leafCriteria: readonly TechnicalConfigurationAggregateLeafCriterion[]
+): Record<TechnicalConfigurationDerivedStatus, number> {
+  const statusCounts = createEmptyStatusCounts()
+  for (const criterion of leafCriteria) {
+    statusCounts[criterion.status] += 1
+  }
+  return statusCounts
+}
+
+function deriveAggregateStatus(
+  descendantCount: number,
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+): TechnicalConfigurationAggregateStatus {
+  if (descendantCount === 0) return "no_criteria"
+  if (statusCounts.fails > 0) return "failed"
+  if (statusCounts.not_evaluated > 0) return "in_progress"
+  if (statusCounts.unclear > 0 || statusCounts.insufficient_evidence > 0) {
+    return "needs_clarification"
+  }
+  if (statusCounts.not_applicable === descendantCount) return "not_applicable"
+
+  const passingCount = statusCounts.meets + statusCounts.exceeds
+  if (passingCount > 0 && passingCount + statusCounts.not_applicable === descendantCount) {
+    return "passed"
+  }
+
+  throw new Error("Unsupported technical configuration aggregate status combination")
+}
+
+function buildStructuralAggregate(
+  id: string,
+  criterionIds: readonly string[],
+  statusByCriterionId: ReadonlyMap<string, TechnicalConfigurationDerivedStatus>
+): TechnicalConfigurationStructuralAggregate {
+  const descendantCriterionIds = uniqueCriterionIds(criterionIds)
+  const leafCriteria = buildLeafCriteria(descendantCriterionIds, statusByCriterionId)
+  const statusCounts = countLeafStatuses(leafCriteria)
+
+  return {
+    id,
+    status: deriveAggregateStatus(descendantCriterionIds.length, statusCounts),
+    descendantCriterionIds,
+    descendantCount: descendantCriterionIds.length,
+    statusCounts,
+  }
+}
+
+/** Builds unique leaf projections and structural rollups for one hierarchy snapshot. */
+export function buildTechnicalConfigurationHierarchyAggregateStatus({
+  sections,
+  statusByCriterionId,
+}: BuildTechnicalConfigurationHierarchyAggregateStatusInput): TechnicalConfigurationHierarchyAggregateStatusModel {
+  const sectionAggregates = sections.map((section) => {
+    const subgroups = section.subgroups.map((subgroup) =>
+      buildStructuralAggregate(subgroup.id, subgroup.criterionIds, statusByCriterionId)
+    )
+    const descendantCriterionIds = uniqueCriterionIds([
+      ...section.criterionIds,
+      ...subgroups.flatMap((subgroup) => subgroup.descendantCriterionIds),
+    ])
+
+    return {
+      ...buildStructuralAggregate(section.id, descendantCriterionIds, statusByCriterionId),
+      subgroups,
+    }
+  })
+  const criterionIds = uniqueCriterionIds(
+    sectionAggregates.flatMap((section) => section.descendantCriterionIds)
+  )
+  const leafCriteria = buildLeafCriteria(criterionIds, statusByCriterionId)
+
+  return {
+    criterionIds,
+    leafCriteria,
+    statusCounts: countLeafStatuses(leafCriteria),
+    sections: sectionAggregates,
+  }
+}


### PR DESCRIPTION
## Summary
- add a pure aggregate status model for technical-configuration sections and subgroups
- expose unique hierarchy-wide leaf IDs, canonical leaf-status projection, exact counts, and fail-closed rollups
- cover P5A.1-P5A.3 precedence, cross-owner deduplication, structural-row invariants, runtime validation, and snapshot independence
- mark OpenSpec P5A.1-P5A.3 complete and add the phase TDD plan

## Scope
- pure model and tests only
- no production UI, migration, RPC, generated DB type, or live DB change
- no numeric or weighted score; score/ranking inputs remain leaf-only and preserve existing contracts

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused and adjacent tests: 73/73
- full technical-configuration regression suite: 947/947
- React Doctor: 100/100, no issues
- `openspec validate revise-technical-configuration-baseline-hierarchy --strict`
- final xhigh review: Zero findings

Closes #890

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pure TypeScript aggregate status model for technical-configuration sections and subgroups. It dedupes leaf criteria, projects leaf statuses with exact counts, and rolls up strict, fail-closed aggregate states with Vietnamese labels. Implements P5A.1–P5A.3 for #890 with tests only; no production wiring.

- **New Features**
  - Stable aggregate states with Vietnamese labels: no_criteria, failed, in_progress, needs_clarification, not_applicable, passed.
  - Precedence and validation: fail-fast on fails; incomplete beats review-required; missing resolves to not_evaluated; unknown (incl. null/undefined) throws.
  - Structure and counts: unique leaf IDs; subgroup uses direct leaves; section unions direct + subgroup leaves; returns `criterionIds`, `leafCriteria`, and hierarchy `statusCounts`.
  - Invariants: structural rows excluded from denominators/filters/ranking/score; snapshot independence.
  - Tests and docs: focused suites for precedence, counts, rollups, and structure; updated OpenSpec tasks and added the P5A TDD plan.

<sup>Written for commit b8d10b3f3446d140f48fb0eea0651cebc1b5d2e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added aggregate status reporting for technical-configuration hierarchies, including hierarchy, section, and subgroup rollups.
  - Added stable status values, Vietnamese labels, status counts, and canonical criterion mapping.
  - Duplicate criteria are consolidated, while structural rows are excluded from progress, ranking, filtering, and scoring calculations.
  - Empty sections and subgroup-based failures are represented consistently.
  - Added validation for unsupported or invalid statuses and comprehensive coverage for aggregation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->