### PR TITLE
feat: add P5C evaluation hierarchy and progress

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/design.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/design.md
@@ -150,6 +150,37 @@ do not expose response or assessment controls.
 Progress, filtering, ranking inputs, and denominators count each leaf criterion exactly
 once. Structural rows never create synthetic criteria or duplicate descendant counts.
 
+Evaluation owns a separate presentation row model. One evaluation-specific canonical
+leaf flattener is the only baseline-to-leaf traversal used by evaluation projection,
+legacy fallback, navigator rows, progress, and aggregate inputs. Its canonical tuple is:
+
+1. main-section `sort_order`;
+2. main-section ID;
+3. direct criterion before subgroup criterion;
+4. subgroup `sort_order` for subgroup criteria;
+5. subgroup ID for subgroup criteria;
+6. criterion `sort_order`;
+7. criterion ID.
+
+Legacy two-level snapshots are normalized as direct criteria and remain supported.
+Navigator heading rows wrap only leaf criteria visible on the current filtered
+presentation page. Empty sections and subgroups remain visible in the complete
+progress/summary surface, but do not create orphan navigator headings.
+
+The navigator/presentation layer constructs that page-local section/subgroup/criterion
+row union exactly once from the canonical leaf page. The navigator pane forwards the
+readonly row union and expansion controls; the criterion list renders and filters that
+union directly. It does not flatten leaves or rebuild hierarchy independently. This
+keeps the active workspace, controlled ancestor expansion, and local collapse on one
+presentation contract instead of allowing competing row projections.
+
+Structural rows start expanded. Collapse/expand is local presentation state only:
+collapsing hides descendant presentation rows without changing leaf totals, filter
+totals, pagination, selected criterion, save/save-next, dirty guards, denominator,
+ranking, or score. When filter, page navigation, direct selection, or
+`Lưu & tiếp tục` selects a leaf hidden by local collapse state, its section and subgroup
+ancestors expand before focus moves to that leaf.
+
 ### 4. Aggregate status is transparent and fail-fast
 
 A subgroup aggregates only its direct leaf criteria. A main section aggregates:
@@ -175,6 +206,51 @@ status with a new structural `Vượt yêu cầu` state.
 The aggregate changes immediately after a successful assessment result is adopted
 into the authoritative complete cache. Unsaved local assessment drafts do not mutate
 the persisted aggregate.
+
+Aggregate status and counts always derive from the complete baseline descendant
+universe and the authoritative complete assessment cache. Active filters, transport
+pages, comparison pages, navigator collapse state, and unsaved drafts never change the
+aggregate input.
+
+Complete-cache adoption distinguishes three states:
+
+- a known-complete cache, including a successfully loaded empty map, receives the saved
+  assessment by criterion ID before aggregate refresh;
+- a known-empty comparison set created by the current save is seeded with the saved
+  assessment;
+- an unavailable, loading, or failed cache for an existing comparison set is never
+  promoted to authoritative from one saved assessment.
+
+If filtered-navigation refresh fails after persistence succeeds, the UI keeps the
+already authoritative aggregate when one exists, exposes an actionable retry state for
+the failed filtered read, and never replaces the aggregate with a partial cache.
+
+### 4A. Upgrade the evaluation read contract before hierarchy UI
+
+P5C owns a superseding
+`technical_configuration_evaluation_criteria_list(UUID, UUID, TEXT, INTEGER, INTEGER)`
+definition. It preserves the existing signature, JSON response shape, accepted
+filters, JWT/auth guards, `SECURITY DEFINER` and `search_path`, grants, assessment
+persistence, and transport page-size bound of `100`.
+
+The RPC computes `canonical_index` over the complete baseline leaf universe before
+applying the status filter. It uses the evaluation canonical tuple defined above,
+derives `canonical_page` with the comparison criterion page size `50`, and orders both
+the filtered transport page and JSON aggregation by `canonical_index`. Deterministic ID
+ties are part of the contract, not an implementation detail.
+
+The read-contract migration is deploy-safe before subgroup data or evaluation UI
+activation. The hierarchy UI depends on that migration being present and applied in
+the target environment. Creating the local migration does not authorize applying it to
+live Supabase; live application requires a separate explicit user approval. Migration
+source tests inspect the superseding file directly. Query plans are inspected with
+`EXPLAIN` before any index is proposed; P5C does not add speculative indexes.
+
+P5C adds its own hierarchy-order and security phase gates. The stale
+`technical-configuration-baseline-hierarchy-apply-migration.test.ts` and
+`technical-configuration-baseline-subgroup-mutations-migration.test.ts` assertions
+remain owned by Issue #903 and are reported separately rather than changed to satisfy
+P5C.
 
 ### 5. Introduce a user-facing baseline XLSX contract
 
@@ -321,11 +397,14 @@ Deployment order follows expand/migrate/contract principles:
 4. deploy hidden/library-only workbook and aggregate models;
 5. wire subgroup-producing authoring/import UI without mounting it on production
    screens;
-6. update baseline, comparison, evaluation, and export readers in separate leaves;
-7. enable server-side subgroup mutations and XLSX v2 apply only after every production
+6. update baseline and comparison readers in separate leaves;
+7. deploy the hierarchy-aware evaluation criteria read contract before activating the
+   evaluation hierarchy UI;
+8. update evaluation/progress and result export in separate leaves;
+9. enable server-side subgroup mutations and XLSX v2 apply only after every production
    reader is hierarchy-aware;
-8. mount subgroup-producing production controls in a later UI-only leaf;
-9. remove compatibility behavior only in a later explicit change.
+10. mount subgroup-producing production controls in a later UI-only leaf;
+11. remove compatibility behavior only in a later explicit change.
 
 No leaf may require an unmerged next PR to restore the existing user workflow. New
 controls remain absent or disabled until all dependencies needed by that control are
@@ -362,12 +441,14 @@ already deployed.
 5. Release new workbook codec with legacy read compatibility, wire the new download
    and import actions without mounting them on production screens.
 6. Wire hierarchy-aware baseline authoring without enabling subgroup creation.
-7. Update aggregate models, comparison, evaluation, progress, and export in separate
-   leaves.
-8. Run cross-surface regression, then enable server-side subgroup writes.
-9. Mount XLSX v2 import/download and subgroup authoring in a UI-only activation leaf.
-10. Run representative browser and authorized live-database acceptance.
-11. Keep rollback forward-compatible; do not drop populated hierarchy data.
+7. Update aggregate models and comparison in separate leaves.
+8. Deploy the hierarchy-aware evaluation criteria read contract, then update
+   evaluation/progress without changing comparison or result export.
+9. Update result export in its own leaf.
+10. Run cross-surface regression, then enable server-side subgroup writes.
+11. Mount XLSX v2 import/download and subgroup authoring in a UI-only activation leaf.
+12. Run representative browser and authorized live-database acceptance.
+13. Keep rollback forward-compatible; do not drop populated hierarchy data.
 
 ## Open Questions
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p5c-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p5c-tdd-plan.md
@@ -1,0 +1,417 @@
+# P5C TDD Plan - Evaluation Hierarchy And Progress
+
+> **For agentic workers:** REQUIRED: use subagent-driven implementation with one
+> worker per deploy-safe leaf and independent review after each leaf.
+
+**Goal:** Implement Issue #904 P5C with a hierarchy-aware evaluation read contract,
+page-local navigator headings, and full-universe authoritative aggregate progress.
+
+**Architecture:** Land P5C0 first as a backward-compatible RPC replacement. Then use
+one evaluation-specific canonical leaf flattener as the shared source for projection,
+fallback selection, presentation rows, progress, and aggregate inputs. Keep comparison,
+result export, and criterion assessment persistence unchanged.
+
+**Tech stack:** PostgreSQL/Supabase migrations, TypeScript, React, TanStack Query,
+Vitest/Testing Library, OpenSpec.
+
+---
+
+## Scope
+
+Implement P5C.0-P5C.7 only:
+
+- replace `technical_configuration_evaluation_criteria_list` with canonical three-level
+  leaf ordering while preserving its public contract;
+- render section/subgroup aggregate progress from the complete baseline and
+  authoritative complete assessment cache;
+- render only current filtered page ancestors in the evaluation navigator;
+- keep structural collapse local, non-selectable, and assessment-free;
+- preserve selection, filters, pagination, save, `Lưu & tiếp tục`, dirty guards,
+  denominator, ranking, and score.
+
+Do not change:
+
+- `src/app/(app)/technical-configurations/_components/comparison/**`;
+- comparison RPCs, comparison page size, option/evidence/detail behavior;
+- result-export components, hooks, RPCs, migrations, workbook shape, or snapshots;
+- assessment upsert signature/persistence;
+- `src/app/api/rpc/__tests__/technical-configuration-baseline-hierarchy-apply-migration.test.ts`;
+- `src/app/api/rpc/__tests__/technical-configuration-baseline-subgroup-mutations-migration.test.ts`.
+
+The last two files are the stale phase-gate tests tracked by Issue #903. They are
+distinct from the new P5C hierarchy-order phase gates.
+
+Live Supabase apply is not part of this plan without separate explicit user
+authorization.
+
+## Assumptions And Contracts
+
+- Start from `main@c6d3d6b9eecabc2a7dd229ad4ff13535d8785908` on
+  `feat/issue-904-p5c-evaluation-hierarchy`.
+- GitNexus is indexed at `c6d3d6b9`; do not reindex unless changed symbols cannot be
+  mapped.
+- `TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE` remains `50`.
+- RPC transport `p_page_size` remains bounded to `1..100`.
+- P5C0 canonical tuple is:
+  `group.sort_order`, `group.id`, direct-before-subgroup discriminator,
+  `subgroup.sort_order`, `subgroup.id`, `criterion.sort_order`, `criterion.id`.
+- Direct criteria use the direct discriminator and deterministic neutral subgroup keys;
+  subgroup criteria use the subgroup discriminator and real subgroup keys.
+- `canonical_index` is calculated over the complete leaf universe before status
+  filtering. `canonical_page` derives from `canonical_index` with page size `50`.
+- Filtered transport rows and `jsonb_agg` are ordered only by `canonical_index`.
+- One evaluation-specific flattener owns canonical leaf traversal. Independent
+  group-only loops are forbidden because they drop subgroup leaves.
+- Navigator headings wrap only leaves on the current filtered presentation page.
+  Empty structures appear only in the full summary.
+- The navigator/presentation layer constructs the page-local
+  `TechnicalConfigurationEvaluationHierarchyRow[]` exactly once. The navigator pane
+  forwards `readonly TechnicalConfigurationEvaluationHierarchyRow[]`; the criterion
+  list renders and filters those supplied rows directly and MUST NOT rebuild hierarchy
+  from a leaf projection.
+- Structural rows start expanded. Selecting a hidden leaf auto-expands its ancestors
+  before focus/selection commits. Controlled expanded-ID input and an expansion-change
+  callback remain available at the presentation boundary for that integration.
+- Aggregate inputs are full-baseline descendants plus authoritative complete
+  assessments. Filter/page/collapse and unsaved drafts are presentation state only.
+- Complete-cache states are distinct:
+  - known complete, including a successfully loaded empty map: merge saved assessment;
+  - known empty because the current save created the comparison set: seed saved
+    assessment;
+  - unavailable/loading/failed existing cache: do not create a partial authoritative
+    map.
+- P5C0 may deploy before subgroup data/UI. P5C UI must not activate in an environment
+  where P5C0 has not been applied.
+
+## Deploy-Safe Leaves
+
+### Leaf A - P5C0 evaluation read contract
+
+Safe to merge and deploy alone. Old clients receive the same signature and JSON shape,
+but direct/subgroup leaves gain deterministic canonical positions.
+
+### Leaf B - Canonical evaluation model and aggregate progress
+
+Depends on Leaf A being represented in the repository. Pure model/progress changes
+remain compatible with legacy two-level snapshots.
+
+### Leaf C - Navigator rows, collapse, cache adoption, and integration
+
+Depends on Leaves A-B. Production activation requires P5C0 to be applied in the target
+environment. No next PR is required to restore existing evaluation behavior.
+
+## File Map
+
+Create:
+
+- `supabase/migrations/20260812140500_technical_configuration_evaluation_hierarchy_order.sql`
+  - copies the latest RPC definition and changes only canonical hierarchy ordering.
+- `src/app/api/rpc/__tests__/technical-configuration-evaluation-hierarchy-order-migration.test.ts`
+  - inspects the superseding migration directly for signature, auth, grants, filters,
+    ordering, pagination, response-shape, and rollback comments.
+- `supabase/tests/technical_configuration_evaluation_hierarchy_order_phase_gate.sql`
+  - executable post-apply contract for direct/subgroup ordering and boundaries
+    `50/51`, `100/101`; do not modify Issue #903 phase-gate files.
+- `supabase/tests/technical_configuration_evaluation_hierarchy_order_security_phase_gate.sql`
+  - executable post-apply contract for unchanged auth, grants, tenant scope, and
+    transport bounds.
+- `src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-hierarchy.ts`
+  - owns canonical leaf flattening, ancestry, legacy normalization, and page-local
+    presentation row construction.
+- `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationHierarchyPresentation.ts`
+  - owns local default-expanded state and controlled expansion synchronization without
+    changing leaf projection, selection, or aggregate inputs.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy.test.ts`
+  - owns tuple ties, direct/subgroup order, legacy fallback, subgroup retention,
+    current-page headings, empty structures, and collapse invariants.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx`
+  - owns structural rendering, controls, default expansion, local collapse, and
+    ancestor auto-expand accessibility behavior.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx`
+  - owns known-complete, known-empty-new-set, unavailable/failed-existing-cache, and
+    filtered-refetch-failure behavior.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption-test-support.ts`
+  - keeps cache-state fixtures out of the dedicated cache-adoption test.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx`
+  - owns guarded navigation, dirty-cancel, save-next, controlled ancestor expansion,
+    legacy behavior, and the 101+ mixed hierarchy fixture crossing `50/51` and
+    `100/101`.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx`
+  - owns the integration boundary that passes prebuilt page-local rows and controlled
+    expansion from the active workspace into the navigator pane.
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test-support.ts`
+  - keeps mixed-status, empty-structure, and full-universe progress fixtures out of the
+    progress test.
+
+Modify:
+
+- `src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts`
+  - consumes the shared flattener for server projection and local criterion fallback.
+- `src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts`
+  - consumes the shared flattener and P5A aggregate model for section/subgroup progress.
+- `src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-matrix-presentation.ts`
+  - exposes full-universe progress/aggregate plus filtered presentation inputs without
+    deriving aggregates from the filter.
+- `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts`
+  - exposes current filtered page leaves/rows and expands hidden ancestors on committed
+    navigation without changing leaf selection semantics.
+- `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx`
+  - accepts `readonly TechnicalConfigurationEvaluationHierarchyRow[]` directly and
+    renders/filters the supplied union; it never rebuilds hierarchy, and only leaf rows
+    own the existing selection button.
+- `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx`
+  - forwards prebuilt page-local rows plus controlled/local expansion state to the
+    criterion list without projecting the rows again.
+- `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx`
+  - mounts the page-local hierarchy navigator, wires complete authoritative progress,
+    and keeps result-export props byte-for-byte unchanged.
+- `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx`
+  - renders section/subgroup aggregate labels/counts, including empty structures.
+- `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts`
+  - adopts saved rows only under the three explicit complete-cache states and preserves
+    actionable filtered-read failure.
+- `openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md`
+  - checks P5C.0-P5C.7 only after evidence and zero-finding review.
+
+Do not enlarge
+`src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx`
+(the existing large workspace suite, currently 21 Vitest cases). Reuse its exported
+test support where practical; otherwise keep new fixtures/support in the dedicated P5C
+files above.
+
+## TDD Sequence
+
+### RED A1 - Superseding migration contract
+
+1. Create the dedicated migration source test before the migration.
+2. Assert the test reads exactly
+   `20260812140500_technical_configuration_evaluation_hierarchy_order.sql`, not a
+   concatenation of all migrations.
+3. Assert unchanged function signature, return JSON keys, accepted filters,
+   `SECURITY DEFINER`, `SET search_path = public, pg_temp`, JWT/tenant guards,
+   revoke/grant contract, assessment joins, and `p_page_size <= 100`.
+4. Assert canonical tuple includes group order/ID, direct discriminator, subgroup
+   order/ID, criterion order/ID.
+5. Assert the window computes `canonical_index` before status filtering.
+6. Assert `canonical_page` divides by constant comparison page size `50`.
+7. Assert filtered pagination and JSON aggregation order by `canonical_index`.
+8. Run the focused test and confirm RED because the superseding migration is absent.
+
+### GREEN A1 - Minimal read-contract replacement
+
+1. Copy the latest complete RPC definition into timestamp
+   `20260812140500`.
+2. Add the subgroup join needed for canonical ordering without changing selected JSON
+   fields or filter derivation.
+3. Build the exact canonical tuple with deterministic ID ties.
+4. Compute the window across all leaves, then filter, transport-page, and aggregate by
+   `canonical_index`.
+5. Preserve function signature, auth, grants, response shape, comparison page size
+   `50`, and transport bound `100`.
+6. Run the migration source test to GREEN.
+7. Inspect read-only `EXPLAIN` for representative direct/subgroup and filtered queries.
+   Add an index only if the plan demonstrates a concrete regression; otherwise add no
+   index.
+
+### RED A2 - Executable boundary contract
+
+1. Add two rollback-only P5C phase gates: one for deterministic
+   section/subgroup/criterion ordering and one for unchanged security/transport
+   boundaries.
+2. Insert at least 101 leaves spanning direct criteria and multiple subgroup blocks.
+3. Assert order and canonical transitions at `50/51` and `100/101`.
+4. Assert filtering retains full-universe `canonical_index`/`canonical_page`.
+5. Assert the security gate preserves auth, grants, tenant scope, and rejects transport
+   requests above `100`.
+6. Keep both new P5C files independent from the two stale Issue #903 tests.
+
+### RED B1 - One canonical evaluation flattener
+
+1. Write pure tests for direct criteria before complete subgroup blocks.
+2. Cover ties at every tuple level using deterministic IDs.
+3. Cover multiple subgroups, subgroup criteria, empty structures, and legacy snapshots
+   with no subgroup array.
+4. Assert projection, local fallback, page rows, and progress all consume the same
+   flattened leaf IDs in the same order.
+5. Confirm RED because current independent loops only traverse `group.criteria`.
+
+### GREEN B1 - Minimal shared hierarchy model
+
+1. Implement `flattenTechnicalConfigurationEvaluationLeaves` as an immutable,
+   deterministic, linear traversal plus stable sort.
+2. Include section and optional subgroup ancestry on each canonical leaf.
+3. Build page-local presentation rows from a supplied leaf page; emit a section or
+   subgroup heading only when that page has a descendant leaf.
+4. Normalize legacy rows as direct criteria.
+5. Replace group-only traversal in navigation fallback and progress with the flattener.
+6. Run pure hierarchy/navigation/progress tests to GREEN.
+
+### RED B2 - Full-universe aggregate and empty structures
+
+1. Add mixed-status tests for direct and subgroup descendants.
+2. Assert section/subgroup counts derive from all canonical leaves and complete
+   assessments, independent of active filter/page.
+3. Assert unsaved drafts never affect aggregate.
+4. Assert empty section/subgroup structures render `Chưa có tiêu chí` with zero counts
+   in the full summary.
+5. Assert structural rows never change denominator, ranking input, or score.
+
+### GREEN B2 - Aggregate progress presentation
+
+1. Reuse `buildTechnicalConfigurationHierarchyAggregateStatus` from P5A.
+2. Feed it canonical leaves and complete assessments only.
+3. Extend progress types with section/subgroup aggregate results without duplicating
+   status precedence.
+4. Render aggregate labels and exact descendant counts in the full summary.
+5. Do not pass filter/page/collapse/draft state into aggregate construction.
+6. Run aggregate/progress/summary tests to GREEN.
+
+### RED C1 - Page-local navigator rows and collapse
+
+1. Add an integration-shaped UI test that passes a prebuilt readonly
+   section/subgroup/criterion row union through the navigator pane into the criterion
+   list.
+2. Confirm RED at the presentation boundary because the criterion list still expects a
+   leaf projection or rebuilds hierarchy instead of consuming the supplied row union.
+3. Add UI tests for current-page section/subgroup ancestor headings only.
+4. Assert no orphan heading for empty or filtered-out structures.
+5. Assert structural rows have no assessment control and cannot call
+   `onSelectCriterion`.
+6. Assert rows start expanded and collapse hides descendants only.
+7. Assert selection, filter totals, pagination, selected criterion, save/save-next,
+   dirty guards, denominator, ranking, and score are unchanged after collapse.
+8. Assert page/filter/direct/save-next navigation auto-expands ancestors of a hidden
+   target before focus commits.
+
+### GREEN C1 - Minimal navigator presentation state
+
+1. Expose the current filtered leaf page from the navigator hook and build its row union
+   once with the shared evaluation hierarchy model.
+2. Pass the prebuilt readonly row union through the active workspace and navigator pane.
+3. Make the criterion list consume the row union directly; remove any call that rebuilds
+   hierarchy from criteria/leaves.
+4. Keep expanded IDs in local navigator presentation state and expose controlled
+   expanded-ID input plus an expansion-change callback for ancestor auto-expand.
+5. Render structural rows as buttons only for expand/collapse; criterion selection
+   remains on leaf buttons.
+6. Mount the page-local navigator in the active evaluation workspace without changing
+   the unified comparison matrix contract.
+7. Expand target ancestors inside committed navigation, after dirty guard approval and
+   before leaf focus.
+8. Preserve canonical selection and save-next logic on leaf IDs/indexes only.
+9. Run hierarchy UI, hierarchy navigator, and active-workspace hierarchy tests to GREEN.
+
+### RED C2 - Authoritative complete-cache adoption
+
+1. Add a known-complete cache test, including a successfully loaded empty map.
+2. Add a known-empty newly created comparison-set test.
+3. Add loading, unavailable, and failed existing-cache tests.
+4. Assert one saved row never promotes an unknown/failed existing cache to
+   authoritative.
+5. Assert successful save adopts/seed authoritative cache before aggregate refresh.
+6. Force filtered criteria refetch failure after successful persistence; assert
+   actionable retry state and unchanged authoritative aggregate.
+7. Assert complete-cache refetch failure never replaces full data with the saved row
+   alone.
+
+### GREEN C2 - Minimal cache-state handling
+
+1. Make cache completeness explicit from query/comparison-set lifecycle state.
+2. Merge into known-complete data.
+3. Seed only when the current mutation created the previously absent comparison set.
+4. Leave existing unavailable/failed cache non-authoritative and trigger complete
+   refetch/error presentation.
+5. Keep filtered criteria invalidation separate from aggregate cache adoption.
+6. Run the dedicated cache-adoption tests to GREEN.
+
+### RED/GREEN C3 - Navigator and workspace regressions
+
+1. Use the dedicated hierarchy-navigator 101+ mixed hierarchy fixture and assert exact
+   leaves at `50/51` and `100/101`.
+2. Cover direct/subgroup filtered navigation, dirty-cancel restoration, save-next, end
+   state, collapse auto-expand, and filtered refetch failure.
+3. Keep an explicit legacy two-level navigator/workspace fixture.
+4. Confirm RED for each missing hierarchy behavior, implement only the minimum wiring,
+   and run
+   `technical-configuration-evaluation-hierarchy-navigator.test.tsx` plus
+   `technical-configuration-evaluation-active-workspace-hierarchy.test.tsx` to GREEN.
+5. Run all 21 cases in the existing large
+   `technical-configuration-evaluation-workspace.test.tsx` unchanged as regression
+   coverage.
+
+### REFACTOR
+
+1. Verify all evaluation baseline traversal routes through the shared flattener.
+2. Remove duplicate sorting/grouping introduced by the change.
+3. Keep new source files below 350 lines and every source file below 450 lines.
+4. Do not move or refactor comparison/result-export code.
+5. Run focused P5C tests again after cleanup.
+
+## Verification
+
+Run the TypeScript/React gates in repository order through one context-mode batch:
+
+1. `node scripts/npm-run.js run format:check`
+2. `node scripts/npm-run.js run verify:no-explicit-any`
+3. `node scripts/npm-run.js run verify:dedupe`
+4. `node scripts/npm-run.js run typecheck`
+5. focused migration, hierarchy, progress, UI, cache, and workspace tests
+6. existing evaluation navigation/progress/workspace regressions
+7. `node scripts/npm-run.js run react-doctor`
+8. `npx openspec validate revise-technical-configuration-baseline-hierarchy --strict`
+9. broad technical-configuration suite
+
+Focused files include:
+
+- `src/app/api/rpc/__tests__/technical-configuration-evaluation-hierarchy-order-migration.test.ts`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy.test.ts`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-navigation.test.ts`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx`
+- `src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx`
+- `supabase/tests/technical_configuration_evaluation_hierarchy_order_phase_gate.sql`
+- `supabase/tests/technical_configuration_evaluation_hierarchy_order_security_phase_gate.sql`
+
+If the two known stale phase-gate assertions reproduce, report them separately as
+Issue #903 baseline failures. Do not edit
+`technical-configuration-baseline-hierarchy-apply-migration.test.ts` or
+`technical-configuration-baseline-subgroup-mutations-migration.test.ts` in P5C.
+
+## Scope And Review Guards
+
+Before each commit and push:
+
+1. List changed files against `main`.
+2. Fail the scope check if source changes appear under comparison components/RPCs,
+   result export, assessment persistence SQL, or either exact Issue #903 test named
+   above.
+3. Allow the existing OpenSpec delta file
+   `specs/technical-configuration-comparison/spec.md`; it documents the shared
+   capability but does not authorize comparison implementation changes.
+4. Search changed evaluation code for independent `group.criteria` loops; each
+   baseline-to-leaf traversal must reuse the canonical flattener.
+5. Run Code Review Graph `detect_changes` with minimal detail.
+6. Run GitNexus changed-file impact without reindex. Reindex only if the graph cannot
+   map a changed production symbol.
+7. Review the full diff for canonical tuple/order leakage, partial-cache authority,
+   orphan headings, structural interaction leaks, comparison/export scope leakage, and
+   missing legacy coverage.
+8. Fix all actionable findings and repeat review until zero findings.
+
+## Completion Boundary
+
+Report before land. P5C is ready to land only when:
+
+- P5C.0-P5C.7 are checked in `tasks.md`;
+- Leaf A migration is represented locally and its apply status is stated explicitly;
+- RED/GREEN evidence exists for every focused behavior;
+- the 101+ fixture proves `50/51` and `100/101`;
+- required gates, OpenSpec strict, and broad technical-configuration tests pass;
+- Issue #903 baseline failures, if any, are reported separately;
+- changed-file scope guards pass and comparison/result export remain unchanged;
+- Code Review Graph and GitNexus review report zero actionable findings;
+- the committed branch is pushed and its results are reported before merge.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/specs/technical-configuration-comparison/spec.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/specs/technical-configuration-comparison/spec.md
@@ -225,6 +225,26 @@ chí hậu duệ mà không tạo assessment riêng cho structural row.
   status
 - **AND** có thể mở structural row để xem các tiêu chí tạo nên kết quả
 
+#### Scenario: Keep aggregate independent from presentation state
+
+- **WHEN** người dùng đổi filter, transport page, comparison page hoặc thu gọn structural
+  row
+- **THEN** aggregate status/counts vẫn lấy từ authoritative complete assessment cache
+  trên toàn bộ descendant leaf criteria của baseline
+- **AND** unsaved assessment draft không thay đổi aggregate
+- **AND** full progress/summary vẫn hiển thị empty section/subgroup với descendant
+  counts bằng `0`
+
+#### Scenario: Adopt only authoritative complete assessment state
+
+- **WHEN** lưu assessment thành công
+- **THEN** known-complete cache được cập nhật theo criterion ID trước aggregate refresh
+- **AND** known-empty comparison set vừa được tạo có thể được seed bằng assessment đã lưu
+- **AND** cache unavailable/failed của comparison set đã tồn tại không được coi là
+  authoritative từ một assessment riêng lẻ
+- **AND** filtered-navigation refresh failure hiển thị lỗi có thể retry mà không làm
+  hỏng aggregate authoritative hiện có
+
 #### Scenario: Count each criterion once
 
 - **WHEN** hệ thống tính progress, filter totals, aggregate hoặc ranking input
@@ -254,6 +274,54 @@ evaluation và result export.
 - **WHEN** người dùng dùng evaluation navigator, filter hoặc `Lưu & tiếp tục`
 - **THEN** selection và navigation chỉ đi qua leaf criteria
 - **AND** structural rows vẫn hiển thị aggregate status và descendant progress
+
+#### Scenario: Preserve canonical evaluation leaf order
+
+- **WHEN** evaluation read contract liệt kê direct criteria và subgroup criteria
+- **THEN** thứ tự canonical dùng main-section `sort_order`, main-section ID,
+  direct-before-subgroup discriminator, subgroup `sort_order`, subgroup ID, criterion
+  `sort_order`, criterion ID
+- **AND** `canonical_index` được tính trên toàn bộ leaf universe trước status filter
+- **AND** `canonical_page` dùng comparison page size `50`
+- **AND** filtered page và JSON aggregate đều được sắp theo `canonical_index`
+- **AND** transport page size vẫn bị chặn ở tối đa `100`
+
+#### Scenario: Render page-local evaluation headings
+
+- **WHEN** navigator hiển thị một filtered presentation page
+- **THEN** chỉ section/subgroup ancestors của leaf criteria trên page đó được hiển thị
+- **AND** empty structures chỉ xuất hiện trong full progress/summary, không tạo orphan
+  navigator heading
+- **AND** legacy two-level baseline vẫn hiển thị criteria như direct children
+
+#### Scenario: Consume one prebuilt evaluation hierarchy row union
+
+- **WHEN** evaluation presentation nhận canonical leaves của filtered page hiện tại
+- **THEN** presentation layer chỉ dựng một ordered section/subgroup/criterion row union
+- **AND** navigator pane chuyển tiếp readonly row union đó cho criterion renderer
+- **AND** criterion renderer render/filter trực tiếp row union đã nhận, không flatten
+  hoặc dựng lại hierarchy từ leaf projection
+- **AND** controlled expanded-ID input và expansion-change callback vẫn hỗ trợ
+  auto-expand ancestors của selected hidden leaf
+
+#### Scenario: Collapse evaluation presentation locally
+
+- **WHEN** structural rows được mở mặc định và người dùng thu gọn một row
+- **THEN** chỉ descendant presentation rows bị ẩn
+- **AND** leaf totals, filter totals, pagination, selection, save/save-next, dirty guard,
+  denominator, ranking và score không đổi
+- **AND** navigation tự mở ancestors trước khi chọn một hidden leaf
+- **AND** structural rows không selectable và không có assessment control
+
+#### Scenario: Keep adjacent P5C surfaces unchanged
+
+- **WHEN** P5C hierarchy/progress được triển khai
+- **THEN** comparison behavior và result-export contract không thay đổi
+- **AND** criterion assessment persistence không thay đổi
+- **AND** hai stale phase-gate tests
+  `technical-configuration-baseline-hierarchy-apply-migration.test.ts` và
+  `technical-configuration-baseline-subgroup-mutations-migration.test.ts` do Issue
+  #903 theo dõi không thuộc scope P5C
 
 #### Scenario: Preserve hierarchy in final export
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/specs/technical-configuration-comparison/spec.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/specs/technical-configuration-comparison/spec.md
@@ -318,10 +318,6 @@ evaluation và result export.
 - **WHEN** P5C hierarchy/progress được triển khai
 - **THEN** comparison behavior và result-export contract không thay đổi
 - **AND** criterion assessment persistence không thay đổi
-- **AND** hai stale phase-gate tests
-  `technical-configuration-baseline-hierarchy-apply-migration.test.ts` và
-  `technical-configuration-baseline-subgroup-mutations-migration.test.ts` do Issue
-  #903 theo dõi không thuộc scope P5C
 
 #### Scenario: Preserve hierarchy in final export
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -334,9 +334,10 @@ persistence, comparison, and result export remain unchanged.
       one saved row. Keep filtered-navigation refresh failures fail fast and actionable
       without corrupting the aggregate.
 - [x] P5C.6 Add dedicated mixed-status, empty-aggregate, filtered navigation,
-      collapse/auto-expand, dirty-cancel, save-next, cache-refetch-failure, legacy, and >100-criterion regressions. The large fixture MUST cross canonical boundaries
-      `50/51` and `100/101`; the existing large workspace suite's 21 cases MUST pass
-      unchanged and its file MUST NOT be enlarged.
+      collapse/auto-expand, dirty-cancel, save-next, cache-refetch-failure, legacy,
+      and >100-criterion regressions. The large fixture MUST cross canonical
+      boundaries `50/51` and `100/101`; the existing large workspace suite's 21
+      cases MUST pass unchanged and its file MUST NOT be enlarged.
 - [x] P5C.7 Run migration source-contract tests against the superseding migration,
       both new P5C executable phase gates, required repository gates, focused and broad
       regressions, and OpenSpec strict. Inspect `EXPLAIN` before adding any index,

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -337,7 +337,7 @@ persistence, comparison, and result export remain unchanged.
       collapse/auto-expand, dirty-cancel, save-next, cache-refetch-failure, legacy, and >100-criterion regressions. The large fixture MUST cross canonical boundaries
       `50/51` and `100/101`; the existing large workspace suite's 21 cases MUST pass
       unchanged and its file MUST NOT be enlarged.
-- [ ] P5C.7 Run migration source-contract tests against the superseding migration,
+- [x] P5C.7 Run migration source-contract tests against the superseding migration,
       both new P5C executable phase gates, required repository gates, focused and broad
       regressions, and OpenSpec strict. Inspect `EXPLAIN` before adding any index,
       enforce changed-file scope guards, repeat review to zero actionable findings, and
@@ -346,9 +346,10 @@ persistence, comparison, and result export remain unchanged.
       `technical-configuration-baseline-subgroup-mutations-migration.test.ts`, the two
       stale phase-gate tests tracked by Issue #903, outside P5C.
 
-P5C.7 status: local source-contract, repository, regression, scope, graph, and review
-gates are complete. The two executable SQL phase gates remain pending until the local
-migration is applied to a target environment with separate live-write authorization.
+P5C.7 status: complete. The migration was applied to the target environment, both
+rollback-only executable SQL phase gates passed, and post-gate verification found no
+P5C0 fixture residue. Local source-contract, repository, regression, scope, graph,
+review, and OpenSpec strict gates are complete.
 
 ## Phase P5D - Hierarchy-Aware Result Export
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -299,18 +299,56 @@ unchanged until their own leaves.
 
 Depends on: P1C, P5A, and the parent evaluation workflow being stable on `main`.
 
-Deploy boundary: evaluation navigator and summaries become hierarchy-aware without
-changing criterion assessment persistence.
+Deploy boundary: P5C0 is a read-only RPC replacement that is safe before subgroup
+data or UI activation. The P5C UI leaf depends on that contract being represented
+locally and applied in each target environment as appropriate. Criterion assessment
+persistence, comparison, and result export remain unchanged.
 
-- [ ] P5C.1 Show aggregate status/counts on sections and subgroups.
-- [ ] P5C.2 Add the evaluation-specific hierarchy row model and render section/subgroup
-      rows around leaf criteria.
-- [ ] P5C.3 Keep selection, filters, pagination, save, and `Lưu & tiếp tục` restricted
-      to leaf criteria.
-- [ ] P5C.4 Preserve complete-cache adoption and fail-fast aggregate refresh after a
-      successful save.
-- [ ] P5C.5 Add mixed-status, empty-aggregate, filtered navigation, dirty-cancel,
-      save-next, and >100-criterion regressions.
+- [x] P5C.0 Replace `technical_configuration_evaluation_criteria_list` without changing
+      its signature, response shape, filters, grants, auth guards, assessment
+      persistence, comparison, or result export. Compute the canonical leaf tuple as
+      section `sort_order`, section ID, direct-before-subgroup discriminator, subgroup
+      `sort_order`, subgroup ID, criterion `sort_order`, criterion ID; compute
+      `canonical_index` across the complete leaf universe before filtering, derive
+      `canonical_page` with comparison page size `50`, order filtered pages and JSON
+      aggregation by `canonical_index`, and keep transport page size bounded at `100`.
+- [x] P5C.1 Add one evaluation-specific canonical leaf flattener reused by projection,
+      legacy fallback, hierarchy rows, progress, and aggregate inputs so subgroup leaves
+      cannot be dropped by independent loops.
+- [x] P5C.2 Show authoritative aggregate status/counts for sections and subgroups over
+      the complete baseline descendant universe, independent of active filter/page.
+      Include empty structures in the full progress/summary surface.
+- [x] P5C.3 Construct the current filtered presentation page's hierarchy row union once
+      at the navigator/presentation boundary, pass the readonly rows through the
+      navigator pane, and render them directly in the criterion list without rebuilding
+      hierarchy from a leaf projection. Show only ancestor section/subgroup headings,
+      keep structural rows non-selectable and assessment-free, and preserve legacy
+      two-level fixtures.
+- [x] P5C.4 Default structural rows to expanded. Keep collapse/expand as local
+      presentation state only, auto-expand ancestors when navigation selects a hidden
+      leaf, and prove collapse cannot change totals, filters, pagination, selection,
+      save/save-next, dirty guards, denominator, ranking, or score.
+- [x] P5C.5 Preserve authoritative complete-cache adoption before aggregate refresh:
+      merge into a known-complete cache, seed a known-empty newly created comparison
+      set, and never mark an unavailable or failed existing cache as authoritative from
+      one saved row. Keep filtered-navigation refresh failures fail-fast/actionable
+      without corrupting the aggregate.
+- [x] P5C.6 Add dedicated mixed-status, empty-aggregate, filtered navigation,
+      collapse/auto-expand, dirty-cancel, save-next, cache-refetch-failure, legacy, and >100-criterion regressions. The large fixture MUST cross canonical boundaries
+      `50/51` and `100/101`; the existing large workspace suite's 21 cases MUST pass
+      unchanged and its file MUST NOT be enlarged.
+- [ ] P5C.7 Run migration source-contract tests against the superseding migration,
+      both new P5C executable phase gates, required repository gates, focused and broad
+      regressions, and OpenSpec strict. Inspect `EXPLAIN` before adding any index,
+      enforce changed-file scope guards, repeat review to zero actionable findings, and
+      keep
+      `technical-configuration-baseline-hierarchy-apply-migration.test.ts` plus
+      `technical-configuration-baseline-subgroup-mutations-migration.test.ts`, the two
+      stale phase-gate tests tracked by Issue #903, outside P5C.
+
+P5C.7 status: local source-contract, repository, regression, scope, graph, and review
+gates are complete. The two executable SQL phase gates remain pending until the local
+migration is applied to a target environment with separate live-write authorization.
 
 ## Phase P5D - Hierarchy-Aware Result Export
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -299,7 +299,7 @@ unchanged until their own leaves.
 
 Depends on: P1C, P5A, and the parent evaluation workflow being stable on `main`.
 
-Deploy boundary: P5C0 is a read-only RPC replacement that is safe before subgroup
+Deploy boundary: P5C.0 is a read-only RPC replacement that is safe before subgroup
 data or UI activation. The P5C UI leaf depends on that contract being represented
 locally and applied in each target environment as appropriate. Criterion assessment
 persistence, comparison, and result export remain unchanged.
@@ -331,7 +331,7 @@ persistence, comparison, and result export remain unchanged.
 - [x] P5C.5 Preserve authoritative complete-cache adoption before aggregate refresh:
       merge into a known-complete cache, seed a known-empty newly created comparison
       set, and never mark an unavailable or failed existing cache as authoritative from
-      one saved row. Keep filtered-navigation refresh failures fail-fast/actionable
+      one saved row. Keep filtered-navigation refresh failures fail fast and actionable
       without corrupting the aggregate.
 - [x] P5C.6 Add dedicated mixed-status, empty-aggregate, filtered navigation,
       collapse/auto-expand, dirty-cancel, save-next, cache-refetch-failure, legacy, and >100-criterion regressions. The large fixture MUST cross canonical boundaries
@@ -340,11 +340,10 @@ persistence, comparison, and result export remain unchanged.
 - [x] P5C.7 Run migration source-contract tests against the superseding migration,
       both new P5C executable phase gates, required repository gates, focused and broad
       regressions, and OpenSpec strict. Inspect `EXPLAIN` before adding any index,
-      enforce changed-file scope guards, repeat review to zero actionable findings, and
-      keep
-      `technical-configuration-baseline-hierarchy-apply-migration.test.ts` plus
-      `technical-configuration-baseline-subgroup-mutations-migration.test.ts`, the two
-      stale phase-gate tests tracked by Issue #903, outside P5C.
+      enforce changed-file scope guards, and repeat review to zero actionable findings.
+      Keep the two stale phase-gate tests tracked by Issue #903 outside P5C:
+      `technical-configuration-baseline-hierarchy-apply-migration.test.ts` and
+      `technical-configuration-baseline-subgroup-mutations-migration.test.ts`.
 
 P5C.7 status: complete. The migration was applied to the target environment, both
 rollback-only executable SQL phase gates passed, and post-gate verification found no

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-active-workspace-regressions.test.tsx
@@ -16,6 +16,15 @@ type MatrixState = ReturnType<
 >
 
 type ComparisonRequest = { optionIds: string[]; page: number }
+type NavigatorPaneProps = {
+  criteria: readonly unknown[]
+  progress: unknown
+  listOnly?: boolean
+  isLoading: boolean
+  isError: boolean
+  expandedRowIds?: ReadonlySet<string>
+  onExpandedRowIdsChange?: (rowIds: ReadonlySet<string>) => void
+}
 
 const mocks = vi.hoisted(() => {
   let comparisonRequests: ComparisonRequest[] = []
@@ -23,6 +32,12 @@ const mocks = vi.hoisted(() => {
   let panelResult: TechnicalConfigurationComparisonResult | undefined
   let isTransitionPending = false
   let isSaving = false
+  let isAssessmentLoading = false
+  let assessmentError: Error | null = null
+  let navigatorPaneProps: NavigatorPaneProps | null = null
+  const hierarchyRows = [{ kind: "section", id: "group-1", name: "Thông số chính" }]
+  const expandedRowIds = new Set(["group-1"])
+  const onExpandedRowIdsChange = vi.fn()
 
   return {
     recordComparisonRequest(request: ComparisonRequest) {
@@ -43,16 +58,41 @@ const mocks = vi.hoisted(() => {
     getIsSaving() {
       return isSaving
     },
+    getIsAssessmentLoading() {
+      return isAssessmentLoading
+    },
+    getAssessmentError() {
+      return assessmentError
+    },
+    getHierarchyRows() {
+      return hierarchyRows
+    },
+    getExpandedRowIds() {
+      return expandedRowIds
+    },
+    getOnExpandedRowIdsChange() {
+      return onExpandedRowIdsChange
+    },
+    recordNavigatorPaneProps(props: NavigatorPaneProps) {
+      navigatorPaneProps = props
+    },
+    getNavigatorPaneProps() {
+      return navigatorPaneProps
+    },
     setScenario(scenario: {
       page?: number
       panelResult?: TechnicalConfigurationComparisonResult
       isTransitionPending?: boolean
       isSaving?: boolean
+      isAssessmentLoading?: boolean
+      assessmentError?: Error | null
     }) {
       page = scenario.page ?? page
       if ("panelResult" in scenario) panelResult = scenario.panelResult
       isTransitionPending = scenario.isTransitionPending ?? isTransitionPending
       isSaving = scenario.isSaving ?? isSaving
+      isAssessmentLoading = scenario.isAssessmentLoading ?? isAssessmentLoading
+      if ("assessmentError" in scenario) assessmentError = scenario.assessmentError ?? null
     },
     reset() {
       comparisonRequests = []
@@ -60,6 +100,10 @@ const mocks = vi.hoisted(() => {
       panelResult = undefined
       isTransitionPending = false
       isSaving = false
+      isAssessmentLoading = false
+      assessmentError = null
+      navigatorPaneProps = null
+      onExpandedRowIdsChange.mockReset()
     },
   }
 })
@@ -92,6 +136,9 @@ vi.mock("../_hooks/useTechnicalConfigurationEvaluationNavigator", () => ({
     criterionId: mocks.getPage() === 1 ? "criterion-1" : "criterion-3",
     selectedOption: createOption("option-1", "Nhà cung cấp A · Model A"),
     projection: [],
+    hierarchyRows: mocks.getHierarchyRows(),
+    expandedRowIds: mocks.getExpandedRowIds(),
+    onExpandedRowIdsChange: mocks.getOnExpandedRowIdsChange(),
     statusFilter: "all",
     isTransitionPending: mocks.getIsTransitionPending(),
     criteriaQuery: {
@@ -103,12 +150,17 @@ vi.mock("../_hooks/useTechnicalConfigurationEvaluationNavigator", () => ({
     isCurrentCriterionFilteredOut: false,
     hasNoMoreMatches: false,
     isPanelOpen: true,
+    changeCriterion: vi.fn(),
   }),
 }))
 
 vi.mock("../_hooks/useTechnicalConfigurationEvaluationDraft", () => ({
   useTechnicalConfigurationEvaluationDraft: () => ({
-    assessmentQuery: { isLoading: false, isError: false, error: null },
+    assessmentQuery: {
+      isLoading: mocks.getIsAssessmentLoading(),
+      isError: mocks.getAssessmentError() !== null,
+      error: mocks.getAssessmentError(),
+    },
     comparisonSetQuery: { isLoading: false, isError: false, error: null },
     assessmentsByCriterionId: {},
     draft: null,
@@ -160,6 +212,12 @@ vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationMatrixToolbar
 }))
 vi.mock("../_components/evaluation/TechnicalConfigurationProgressSummary", () => ({
   TechnicalConfigurationProgressSummary: () => null,
+}))
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane", () => ({
+  TechnicalConfigurationEvaluationNavigatorPane: (props: NavigatorPaneProps) => {
+    mocks.recordNavigatorPaneProps(props)
+    return <div data-testid="navigator-pane-probe" />
+  },
 }))
 vi.mock("../_components/evaluation/TechnicalConfigurationResultExportControl", () => ({
   TechnicalConfigurationResultExportControl: () => null,
@@ -251,5 +309,43 @@ describe("technical configuration evaluation active workspace regressions", () =
     renderWorkspace("option-1")
 
     expect(screen.getByTestId("save-actions-probe")).toHaveAttribute("data-saving", "false")
+  })
+
+  it("passes page-local hierarchy rows and controlled expansion to the navigator pane", () => {
+    renderWorkspace("option-1")
+
+    const props = mocks.getNavigatorPaneProps()
+    expect(props).not.toBeNull()
+    expect(props?.criteria).toBe(mocks.getHierarchyRows())
+    expect(props?.progress).toBeDefined()
+    expect(props?.listOnly).toBe(true)
+    expect(props?.expandedRowIds).toBe(mocks.getExpandedRowIds())
+    expect(props?.onExpandedRowIdsChange).toBe(mocks.getOnExpandedRowIdsChange())
+  })
+
+  it.each([
+    {
+      label: "loading",
+      scenario: { isAssessmentLoading: true, assessmentError: null },
+      expectedLoading: true,
+      expectedError: false,
+    },
+    {
+      label: "error",
+      scenario: {
+        isAssessmentLoading: false,
+        assessmentError: new Error("assessment read failed"),
+      },
+      expectedLoading: false,
+      expectedError: true,
+    },
+  ])("routes assessment cache $label state into the hierarchy navigator", (state) => {
+    mocks.setScenario(state.scenario)
+    renderWorkspace("option-1")
+
+    expect(mocks.getNavigatorPaneProps()).toMatchObject({
+      isLoading: state.expectedLoading,
+      isError: state.expectedError,
+    })
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
@@ -64,18 +64,25 @@ describe("P12A1 evaluation core composition", () => {
     const user = userEvent.setup()
     const onSelectCriterion = vi.fn()
     const comparison = createComparisonResult()
-    const canonicalCriteria = [...comparison.data.criteria].sort(
-      (left, right) =>
-        left.group.sortOrder - right.group.sortOrder ||
-        left.group.id.localeCompare(right.group.id) ||
-        left.criterion.sortOrder - right.criterion.sortOrder ||
-        left.criterion.id.localeCompare(right.criterion.id)
-    )
+    const canonicalCriteria = [...comparison.data.criteria]
+      .sort(
+        (left, right) =>
+          left.group.sortOrder - right.group.sortOrder ||
+          left.group.id.localeCompare(right.group.id) ||
+          left.criterion.sortOrder - right.criterion.sortOrder ||
+          left.criterion.id.localeCompare(right.criterion.id)
+      )
+      .map((row, index) => ({
+        ...row,
+        canonicalIndex: index + 1,
+        canonicalPage: 1,
+      }))
     const rows = buildTechnicalConfigurationEvaluationHierarchyRows(canonicalCriteria)
 
     render(
       <TechnicalConfigurationCriterionList
         rows={rows}
+        hierarchyProgress={null}
         assessmentsByCriterionId={{
           "criterion-2": {
             ...assessment,

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
@@ -8,6 +8,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { TechnicalConfigurationAssessmentControls } from "../_components/evaluation/TechnicalConfigurationAssessmentControls"
 import { TechnicalConfigurationCriterionList } from "../_components/evaluation/TechnicalConfigurationCriterionList"
 import { TechnicalConfigurationEvaluationPanel } from "../_components/evaluation/TechnicalConfigurationEvaluationPanel"
+import { buildTechnicalConfigurationEvaluationHierarchyRows } from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
 import type { TechnicalConfigurationCriterionDetail } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
 import { assessment } from "./assessment-test-fixtures"
 import { createComparisonResult } from "./comparison-matrix-test-fixtures"
@@ -59,14 +60,22 @@ afterAll(() => {
 })
 
 describe("P12A1 evaluation core composition", () => {
-  it("orders criteria canonically and renders only the current derived-status badge", async () => {
+  it("renders a prebuilt canonical criterion sequence with only the current status badge", async () => {
     const user = userEvent.setup()
     const onSelectCriterion = vi.fn()
     const comparison = createComparisonResult()
+    const canonicalCriteria = [...comparison.data.criteria].sort(
+      (left, right) =>
+        left.group.sortOrder - right.group.sortOrder ||
+        left.group.id.localeCompare(right.group.id) ||
+        left.criterion.sortOrder - right.criterion.sortOrder ||
+        left.criterion.id.localeCompare(right.criterion.id)
+    )
+    const rows = buildTechnicalConfigurationEvaluationHierarchyRows(canonicalCriteria)
 
     render(
       <TechnicalConfigurationCriterionList
-        criteria={comparison.data.criteria}
+        rows={rows}
         assessmentsByCriterionId={{
           "criterion-2": {
             ...assessment,
@@ -227,6 +236,7 @@ describe("P12A1 evaluation core composition", () => {
       [
         "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx",
         "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx",
+        "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationHierarchyPresentation.ts",
         "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts",
         "src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationWorkspaceActions.ts",
       ].sort()

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -229,7 +229,7 @@ describe("P12A1 evaluation draft state", () => {
     expect(onDossierRevisionChange).not.toHaveBeenCalled()
   })
 
-  it("keeps the first-save draft while the newly created comparison set starts loading", async () => {
+  it("keeps the first-save draft while the newly created comparison-set snapshot loads", async () => {
     const onDossierRevisionChange = vi.fn()
     let resolveAssessmentList!: (value: TechnicalConfigurationAssessmentListWireResponse) => void
     const pendingAssessmentList = new Promise<TechnicalConfigurationAssessmentListWireResponse>(
@@ -260,8 +260,32 @@ describe("P12A1 evaluation draft state", () => {
       result.current.setNotes("Đánh giá lần đầu.")
     })
 
+    let savePromise!: Promise<void>
     await act(async () => {
-      await result.current.save()
+      savePromise = result.current.save()
+      await Promise.resolve()
+    })
+
+    expect(result.current.draft).toMatchObject({
+      criterionId,
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đánh giá lần đầu.",
+      expectedAssessmentRevision: 0,
+      expectedDossierRevision: 6,
+      isDirty: true,
+    })
+    expect(result.current.isSaving).toBe(true)
+    expect(onDossierRevisionChange).toHaveBeenCalledWith(7)
+
+    await act(async () => {
+      resolveAssessmentList({
+        data: [savedAssessment],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      await savePromise
     })
 
     expect(result.current.draft).toMatchObject({
@@ -291,16 +315,6 @@ describe("P12A1 evaluation draft state", () => {
       },
       { signal: undefined }
     )
-
-    await act(async () => {
-      resolveAssessmentList({
-        data: [savedAssessment],
-        total: 1,
-        page: 1,
-        page_size: 100,
-      })
-      await pendingAssessmentList
-    })
   })
 
   it("propagates the acquired comparison-set revision when assessment upsert fails", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx
@@ -1,0 +1,85 @@
+import "@testing-library/jest-dom"
+import fs from "node:fs"
+import path from "node:path"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationEvaluationNavigatorPane } from "../_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane"
+import type { TechnicalConfigurationEvaluationHierarchyRow } from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
+import type { TechnicalConfigurationEvaluationCriterionListItem } from "../_components/evaluation/technical-configuration-evaluation-navigation"
+
+const workspacePath = path.join(
+  process.cwd(),
+  "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx"
+)
+const hierarchyRows: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[] =
+  [{ kind: "section", id: "section-1", name: "Thông số chính" }]
+
+describe("P5C active evaluation workspace hierarchy integration", () => {
+  it("passes page-local hierarchy rows and controlled expansion to the navigator pane", () => {
+    const source = fs.readFileSync(workspacePath, "utf8")
+
+    expect(source).toContain(
+      'import { TechnicalConfigurationEvaluationNavigatorPane } from "./TechnicalConfigurationEvaluationNavigatorPane"'
+    )
+    expect(source).toMatch(
+      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?criteria=\{navigator\.hierarchyRows\}[\s\S]*?progress=\{matrixPresentation\.progress\}[\s\S]*?listOnly[\s\S]*?expandedRowIds=\{navigator\.expandedRowIds\}[\s\S]*?onExpandedRowIdsChange=\{navigator\.onExpandedRowIdsChange\}[\s\S]*?\/>/
+    )
+    expect(source).not.toMatch(
+      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?criteria=\{navigator\.projection\}/
+    )
+  })
+
+  it("routes assessment cache loading and error state into the hierarchy navigator", () => {
+    const source = fs.readFileSync(workspacePath, "utf8")
+
+    expect(source).toMatch(
+      /const isEvaluationReadLoading = comparisonSetQuery\.isLoading \|\| assessmentQuery\.isLoading/
+    )
+    expect(source).toMatch(
+      /const hasEvaluationReadError = comparisonSetQuery\.isError \|\| assessmentQuery\.isError/
+    )
+    expect(source).toMatch(
+      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?isLoading=\{[\s\S]*?isEvaluationReadLoading[\s\S]*?isError=\{navigator\.criteriaQuery\.isError \|\| hasEvaluationReadError\}/
+    )
+  })
+
+  it.each([
+    { label: "loading", isLoading: true, isError: false, error: null },
+    {
+      label: "error",
+      isLoading: false,
+      isError: true,
+      error: new Error("assessment read failed"),
+    },
+  ])("does not render navigator hierarchy while the assessment cache is $label", (state) => {
+    render(
+      <TechnicalConfigurationEvaluationNavigatorPane
+        statusFilter="all"
+        onStatusFilterChange={vi.fn()}
+        criteria={hierarchyRows}
+        progress={null}
+        assessmentsByCriterionId={{}}
+        currentCriterionId={null}
+        onSelectCriterion={vi.fn()}
+        listOnly
+        page={1}
+        pageSize={50}
+        total={1}
+        onPageChange={vi.fn()}
+        disabled={false}
+        isLoading={state.isLoading}
+        isError={state.isError}
+        error={state.error}
+        onRetry={vi.fn()}
+        isCurrentCriterionFilteredOut={false}
+        hasNoMoreMatches={false}
+      />
+    )
+
+    expect(
+      screen.queryByRole("navigation", { name: "Danh sách tiêu chí đánh giá" })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId(/evaluation-hierarchy-section-/)).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-active-workspace-hierarchy.test.tsx
@@ -1,58 +1,16 @@
 import "@testing-library/jest-dom"
-import fs from "node:fs"
-import path from "node:path"
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
-import { TechnicalConfigurationEvaluationNavigatorPane } from "../_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane"
-import type { TechnicalConfigurationEvaluationHierarchyRow } from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
-import type { TechnicalConfigurationEvaluationCriterionListItem } from "../_components/evaluation/technical-configuration-evaluation-navigation"
+import { TechnicalConfigurationEvaluationNavigatorPane } from "@/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane"
+import type { TechnicalConfigurationEvaluationHierarchyRow } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-hierarchy"
+import type { TechnicalConfigurationEvaluationCriterionListItem } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation"
 
-const workspacePath = path.join(
-  process.cwd(),
-  "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx"
-)
 const hierarchyRows: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[] =
   [{ kind: "section", id: "section-1", name: "Thông số chính" }]
 
 describe("P5C active evaluation workspace hierarchy integration", () => {
-  it("passes page-local hierarchy rows and controlled expansion to the navigator pane", () => {
-    const source = fs.readFileSync(workspacePath, "utf8")
-
-    expect(source).toContain(
-      'import { TechnicalConfigurationEvaluationNavigatorPane } from "./TechnicalConfigurationEvaluationNavigatorPane"'
-    )
-    expect(source).toMatch(
-      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?criteria=\{navigator\.hierarchyRows\}[\s\S]*?progress=\{matrixPresentation\.progress\}[\s\S]*?listOnly[\s\S]*?expandedRowIds=\{navigator\.expandedRowIds\}[\s\S]*?onExpandedRowIdsChange=\{navigator\.onExpandedRowIdsChange\}[\s\S]*?\/>/
-    )
-    expect(source).not.toMatch(
-      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?criteria=\{navigator\.projection\}/
-    )
-  })
-
-  it("routes assessment cache loading and error state into the hierarchy navigator", () => {
-    const source = fs.readFileSync(workspacePath, "utf8")
-
-    expect(source).toMatch(
-      /const isEvaluationReadLoading = comparisonSetQuery\.isLoading \|\| assessmentQuery\.isLoading/
-    )
-    expect(source).toMatch(
-      /const hasEvaluationReadError = comparisonSetQuery\.isError \|\| assessmentQuery\.isError/
-    )
-    expect(source).toMatch(
-      /<TechnicalConfigurationEvaluationNavigatorPane[\s\S]*?isLoading=\{[\s\S]*?isEvaluationReadLoading[\s\S]*?isError=\{navigator\.criteriaQuery\.isError \|\| hasEvaluationReadError\}/
-    )
-  })
-
-  it.each([
-    { label: "loading", isLoading: true, isError: false, error: null },
-    {
-      label: "error",
-      isLoading: false,
-      isError: true,
-      error: new Error("assessment read failed"),
-    },
-  ])("does not render navigator hierarchy while the assessment cache is $label", (state) => {
+  it("renders a list-only loading indicator without rendering the hierarchy", () => {
     render(
       <TechnicalConfigurationEvaluationNavigatorPane
         statusFilter="all"
@@ -68,9 +26,9 @@ describe("P5C active evaluation workspace hierarchy integration", () => {
         total={1}
         onPageChange={vi.fn()}
         disabled={false}
-        isLoading={state.isLoading}
-        isError={state.isError}
-        error={state.error}
+        isLoading
+        isError={false}
+        error={null}
         onRetry={vi.fn()}
         isCurrentCriterionFilteredOut={false}
         hasNoMoreMatches={false}
@@ -81,5 +39,42 @@ describe("P5C active evaluation workspace hierarchy integration", () => {
       screen.queryByRole("navigation", { name: "Danh sách tiêu chí đánh giá" })
     ).not.toBeInTheDocument()
     expect(screen.queryByTestId(/evaluation-hierarchy-section-/)).not.toBeInTheDocument()
+    expect(screen.getByRole("status")).toHaveTextContent("Đang tải tiêu chí đánh giá...")
+  })
+
+  it("renders a list-only error without duplicating the workspace retry action", () => {
+    const onRetry = vi.fn()
+
+    render(
+      <TechnicalConfigurationEvaluationNavigatorPane
+        statusFilter="all"
+        onStatusFilterChange={vi.fn()}
+        criteria={hierarchyRows}
+        progress={null}
+        assessmentsByCriterionId={{}}
+        currentCriterionId={null}
+        onSelectCriterion={vi.fn()}
+        listOnly
+        page={1}
+        pageSize={50}
+        total={1}
+        onPageChange={vi.fn()}
+        disabled={false}
+        isLoading={false}
+        isError
+        error={new Error("assessment read failed")}
+        onRetry={onRetry}
+        isCurrentCriterionFilteredOut={false}
+        hasNoMoreMatches={false}
+      />
+    )
+
+    expect(
+      screen.queryByRole("navigation", { name: "Danh sách tiêu chí đánh giá" })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId(/evaluation-hierarchy-section-/)).not.toBeInTheDocument()
+    expect(screen.getByText("Không thể tải tiêu chí đánh giá")).toBeInTheDocument()
+    expect(screen.getByText("assessment read failed")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Thử lại" })).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption-test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption-test-support.ts
@@ -1,0 +1,23 @@
+import { technicalConfigurationAssessmentsQueryKeyPrefix } from "../technical-configuration-query-keys"
+import { comparisonSetId } from "./assessment-test-fixtures"
+import { createAssessmentTestQueryClient } from "./assessment-hook-test-support"
+
+export function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+export function completeQueryKey(id = comparisonSetId) {
+  return [...technicalConfigurationAssessmentsQueryKeyPrefix(id), "complete"] as const
+}
+
+export function pinAssessmentCache(
+  queryClient: ReturnType<typeof createAssessmentTestQueryClient>
+) {
+  queryClient.setQueryDefaults(technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId), {
+    gcTime: Infinity,
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx
@@ -152,7 +152,7 @@ describe("P5C authoritative assessment cache adoption", () => {
     })
   })
 
-  it("seeds a delayed known-absent snapshot before aggregate refresh without delaying save", async () => {
+  it("waits for a delayed known-absent snapshot before completing the save and refreshing aggregates", async () => {
     const listDeferred = createDeferred<typeof assessmentListResponse>()
     mocks.readComparisonSet.mockResolvedValue(null)
     mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
@@ -181,24 +181,78 @@ describe("P5C authoritative assessment cache adoption", () => {
     const { result } = renderAssessmentsHook(queryClient)
 
     await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
-    await expect(
-      act(async () => result.current.upsertAssessment.mutateAsync(assessmentUpsertInput))
-    ).resolves.toEqual({ comparisonSet, assessment: savedAssessment })
+    let saveSettled = false
+    let savePromise!: Promise<unknown>
+    await act(async () => {
+      savePromise = result.current.upsertAssessment
+        .mutateAsync(assessmentUpsertInput)
+        .finally(() => {
+          saveSettled = true
+        })
+      await Promise.resolve()
+    })
 
     expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
     expect(assessmentInvalidationSnapshots).toEqual([])
+    expect(saveSettled).toBe(false)
 
-    listDeferred.resolve({ ...assessmentListResponse, data: [], total: 0, page_size: 100 })
+    await act(async () => {
+      listDeferred.resolve({ ...assessmentListResponse, data: [], total: 0, page_size: 100 })
+      await savePromise
+    })
 
-    await waitFor(() =>
-      expect(assessmentInvalidationSnapshots).toEqual([
-        {
-          [criterionId]: savedAssessment,
-        },
-      ])
-    )
+    expect(assessmentInvalidationSnapshots).toEqual([
+      {
+        [criterionId]: savedAssessment,
+      },
+    ])
     expect(queryClient.getQueryData(completeQueryKey())).toEqual({
       [criterionId]: savedAssessment,
+    })
+  })
+
+  it("does not replace a newer cached revision when an older known-absent save settles later", async () => {
+    const listDeferred = createDeferred<typeof assessmentListResponse>()
+    const upsertDeferred = createDeferred<{ data: typeof savedAssessment }>()
+    const newerAssessment = {
+      ...savedAssessment,
+      revision: savedAssessment.revision + 1,
+      notes: "newer save",
+    }
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return listDeferred.promise
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return upsertDeferred.promise
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue()
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    let savePromise!: Promise<unknown>
+    await act(async () => {
+      savePromise = result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      queryClient.setQueryData(completeQueryKey(), {
+        [criterionId]: newerAssessment,
+      })
+      listDeferred.resolve({ ...assessmentListResponse, data: [], total: 0, page_size: 100 })
+      upsertDeferred.resolve({ data: savedAssessment })
+      await savePromise
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [criterionId]: newerAssessment,
     })
   })
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-cache-adoption.test.tsx
@@ -1,0 +1,391 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { useQuery } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import { useTechnicalConfigurationAssessments } from "../_hooks/useTechnicalConfigurationAssessments"
+import {
+  technicalConfigurationAssessmentsQueryKeyPrefix,
+  technicalConfigurationEvaluationCriteriaQueryKeyPrefix,
+} from "../technical-configuration-query-keys"
+import {
+  createAssessmentQueryWrapper,
+  createAssessmentTestQueryClient,
+  renderAssessmentsHook,
+  renderCompleteAssessmentsHook,
+} from "./assessment-hook-test-support"
+import {
+  assessment,
+  assessmentListResponse,
+  assessmentUpsertInput,
+  baselineVersionId,
+  comparisonSet,
+  comparisonSetId,
+  criterionId,
+  optionId,
+  savedAssessment,
+} from "./assessment-test-fixtures"
+import {
+  completeQueryKey,
+  createDeferred,
+  pinAssessmentCache,
+} from "./technical-configuration-evaluation-cache-adoption-test-support"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  readComparisonSet: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+vi.mock("../technical-configuration-option-response-operations", () => ({
+  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    mocks.getOrCreateComparisonSet(...args),
+  readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
+}))
+
+function mockExistingSetSave() {
+  mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+  mocks.callRpc.mockImplementation((fn: string) => {
+    if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+      return Promise.resolve(assessmentListResponse)
+    }
+    if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+      return Promise.resolve({ data: savedAssessment })
+    }
+    return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+  })
+}
+
+describe("P5C authoritative assessment cache adoption", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    mocks.getOrCreateComparisonSet.mockReset()
+    mocks.readComparisonSet.mockReset()
+  })
+
+  it.each([
+    ["loaded data", { [criterionId]: assessment }],
+    ["loaded empty map", {}],
+  ])("merges a saved assessment into a known-complete %s cache", async (_label, current) => {
+    mockExistingSetSave()
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    queryClient.setQueryData(completeQueryKey(), current)
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.assessmentsQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      ...current,
+      [criterionId]: savedAssessment,
+    })
+  })
+
+  it("seeds the authoritative cache when this save creates a known-absent comparison set", async () => {
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string, args: { p_page_size?: number }) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        expect(args.p_page_size).toBe(100)
+        return Promise.resolve({ ...assessmentListResponse, data: [], total: 0, page_size: 100 })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [criterionId]: savedAssessment,
+    })
+  })
+
+  it("preserves concurrent assessments created after the known-absent read", async () => {
+    const concurrentAssessment = {
+      ...assessment,
+      id: "00000000-0000-0000-0000-000000000007",
+      criterion_id: "00000000-0000-0000-0000-000000000008",
+    }
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string, args: { p_page_size?: number }) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        expect(args.p_page_size).toBe(100)
+        return Promise.resolve({
+          ...assessmentListResponse,
+          data: [concurrentAssessment],
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [concurrentAssessment.criterion_id]: concurrentAssessment,
+      [criterionId]: savedAssessment,
+    })
+  })
+
+  it("seeds a delayed known-absent snapshot before aggregate refresh without delaying save", async () => {
+    const listDeferred = createDeferred<typeof assessmentListResponse>()
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return listDeferred.promise
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    const assessmentInvalidationSnapshots: unknown[] = []
+    const assessmentQueryPrefix = technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId)
+    vi.spyOn(queryClient, "invalidateQueries").mockImplementation(async (filters) => {
+      const queryKey = filters?.queryKey
+      if (
+        Array.isArray(queryKey) &&
+        assessmentQueryPrefix.every((part, index) => queryKey[index] === part)
+      ) {
+        assessmentInvalidationSnapshots.push(queryClient.getQueryData(completeQueryKey()))
+      }
+    })
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    await expect(
+      act(async () => result.current.upsertAssessment.mutateAsync(assessmentUpsertInput))
+    ).resolves.toEqual({ comparisonSet, assessment: savedAssessment })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
+    expect(assessmentInvalidationSnapshots).toEqual([])
+
+    listDeferred.resolve({ ...assessmentListResponse, data: [], total: 0, page_size: 100 })
+
+    await waitFor(() =>
+      expect(assessmentInvalidationSnapshots).toEqual([
+        {
+          [criterionId]: savedAssessment,
+        },
+      ])
+    )
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [criterionId]: savedAssessment,
+    })
+  })
+
+  it("continues the save without seeding when the known-absent complete load fails", async () => {
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.reject(new Error("complete cache unavailable"))
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    await expect(
+      act(async () => result.current.upsertAssessment.mutateAsync(assessmentUpsertInput))
+    ).resolves.toEqual({ comparisonSet, assessment: savedAssessment })
+    expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
+  })
+
+  it("does not promote an unavailable existing complete cache from one saved row", async () => {
+    mockExistingSetSave()
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.assessmentsQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(
+      mocks.callRpc.mock.calls.filter(
+        ([fn, args]) => fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments && args.p_page_size === 100
+      )
+    ).toHaveLength(0)
+    expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
+  })
+
+  it("does not promote a loading existing complete cache from one saved row", async () => {
+    const listDeferred = createDeferred<typeof assessmentListResponse>()
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return listDeferred.promise
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        expect(
+          mocks.callRpc.mock.calls.filter(
+            ([calledFn]) => calledFn === ASSESSMENT_RPC_FUNCTIONS.listAssessments
+          )
+        ).toHaveLength(1)
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue()
+    const { result } = renderCompleteAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isFetching).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
+    listDeferred.resolve(assessmentListResponse)
+  })
+
+  it("does not promote a failed existing complete cache from one saved row", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.reject(new Error("complete cache unavailable"))
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        expect(
+          mocks.callRpc.mock.calls.filter(
+            ([calledFn]) => calledFn === ASSESSMENT_RPC_FUNCTIONS.listAssessments
+          )
+        ).toHaveLength(1)
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue()
+    const { result } = renderCompleteAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isError).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey())).toBeUndefined()
+  })
+
+  it("retains the full authoritative cache when its post-save refetch fails", async () => {
+    const otherAssessment = {
+      ...assessment,
+      id: "00000000-0000-0000-0000-000000000007",
+      criterion_id: "00000000-0000-0000-0000-000000000008",
+    }
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.reject(new Error("complete cache refresh failed"))
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    queryClient.setQueryData(completeQueryKey(), {
+      [criterionId]: assessment,
+      [otherAssessment.criterion_id]: otherAssessment,
+    })
+    const { result } = renderCompleteAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isError).toBe(true))
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [criterionId]: savedAssessment,
+      [otherAssessment.criterion_id]: otherAssessment,
+    })
+    expect(result.current.completeAssessmentsQuery.refetch).toEqual(expect.any(Function))
+  })
+
+  it("keeps authoritative aggregate data and exposes retry when filtered refresh fails", async () => {
+    mockExistingSetSave()
+    const filteredQueryKey = [
+      ...technicalConfigurationEvaluationCriteriaQueryKeyPrefix(optionId, baselineVersionId),
+      "all",
+    ] as const
+    const filteredQueryFn = vi
+      .fn()
+      .mockResolvedValueOnce("initial")
+      .mockRejectedValueOnce(new Error("filtered refresh failed"))
+      .mockResolvedValueOnce("retried")
+    const queryClient = createAssessmentTestQueryClient()
+    pinAssessmentCache(queryClient)
+    queryClient.setQueryData(completeQueryKey(), { [criterionId]: assessment })
+    const { result } = renderHook(
+      () => ({
+        assessments: useTechnicalConfigurationAssessments({
+          optionId,
+          baselineVersionId,
+          page: 1,
+          pageSize: 25,
+        }),
+        filteredQuery: useQuery({
+          queryKey: filteredQueryKey,
+          queryFn: filteredQueryFn,
+          retry: false,
+        }),
+      }),
+      { wrapper: createAssessmentQueryWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.filteredQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await result.current.assessments.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+    await waitFor(() => expect(result.current.filteredQuery.isError).toBe(true))
+
+    expect(queryClient.getQueryData(completeQueryKey())).toEqual({
+      [criterionId]: savedAssessment,
+    })
+    expect(result.current.filteredQuery.refetch).toEqual(expect.any(Function))
+
+    await act(async () => {
+      await result.current.filteredQuery.refetch()
+    })
+    await waitFor(() => expect(result.current.filteredQuery.data).toBe("retried"))
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx
@@ -245,6 +245,21 @@ describe("P5C evaluation hierarchy navigator presentation", () => {
     expect(result.current.hasNoMoreMatches).toBe(false)
   })
 
+  it("keeps the canonical fallback criterion stable across unrelated rerenders", () => {
+    const { result, rerender } = renderNavigator()
+
+    act(() => {
+      result.current.changeCriterion("criterion-2", (commit) => commit())
+    })
+    criteriaMocks.data = [entries[0]]
+    rerender()
+    const fallbackCriterion = result.current.currentCriterion
+
+    expect(fallbackCriterion?.criterion.id).toBe("criterion-2")
+    rerender()
+    expect(result.current.currentCriterion).toBe(fallbackCriterion)
+  })
+
   it("keeps legacy direct-only rows unchanged", () => {
     const { result } = renderNavigator(createBaselineGroups())
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-navigator.test.tsx
@@ -1,0 +1,258 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TechnicalConfigurationEvaluationCriterionWire } from "../assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../baseline-types"
+import { useTechnicalConfigurationEvaluationNavigator } from "../_hooks/useTechnicalConfigurationEvaluationNavigator"
+import {
+  createBaselineGroups,
+  createOption,
+} from "./technical-configuration-evaluation-workspace.test-support"
+
+const criteriaMocks = vi.hoisted(() => ({
+  data: [] as TechnicalConfigurationEvaluationCriterionWire[],
+  loadCriteria: vi.fn(),
+  refetch: vi.fn(),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationEvaluationCriteria", () => ({
+  useTechnicalConfigurationEvaluationCriteria: () => ({
+    criteriaQuery: {
+      data: criteriaMocks.data,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: criteriaMocks.refetch,
+    },
+    loadCriteria: criteriaMocks.loadCriteria,
+  }),
+}))
+
+function createHierarchyGroups(): TechnicalConfigurationBaselineGroupWire[] {
+  const groups = createBaselineGroups()
+  const subgroupCriterion = {
+    ...groups[0].criteria[1],
+    subgroup_id: "subgroup-1",
+  }
+  groups[0].criteria = [groups[0].criteria[0]]
+  groups[0].subgroups = [
+    {
+      id: "subgroup-1",
+      baseline_version_id: groups[0].baseline_version_id,
+      group_id: groups[0].id,
+      name: "Nhóm con",
+      sort_order: 1,
+      created_at: groups[0].created_at,
+      created_by: groups[0].created_by,
+      updated_at: groups[0].updated_at,
+      updated_by: groups[0].updated_by,
+      criteria: [subgroupCriterion],
+    },
+  ]
+  return groups
+}
+
+function createSharedAncestorPageBoundaryFixture() {
+  const groups = createHierarchyGroups()
+  const group = groups[0]
+  const subgroup = group.subgroups?.[0]
+  if (!subgroup) throw new Error("Expected subgroup fixture")
+
+  const criterionTemplate = subgroup.criteria[0]
+  subgroup.criteria = Array.from({ length: 51 }, (_, index) => ({
+    ...criterionTemplate,
+    id: `criterion-${index + 1}`,
+    criterion_code: `TC-${index + 1}`,
+    sort_order: index + 1,
+  }))
+  group.criteria = []
+
+  return {
+    groups: [group],
+    entries: subgroup.criteria.map((criterion, index) => ({
+      criterion_id: criterion.id,
+      canonical_index: index + 1,
+      canonical_page: Math.floor(index / 50) + 1,
+    })),
+  }
+}
+
+const entries: TechnicalConfigurationEvaluationCriterionWire[] = [
+  { criterion_id: "criterion-1", canonical_index: 1, canonical_page: 1 },
+  { criterion_id: "criterion-2", canonical_index: 2, canonical_page: 1 },
+  { criterion_id: "criterion-3", canonical_index: 3, canonical_page: 2 },
+]
+
+function renderNavigator(groups = createHierarchyGroups(), pageSize = 2) {
+  return renderHook(() =>
+    useTechnicalConfigurationEvaluationNavigator({
+      options: [
+        createOption("option-1", "Nhà cung cấp A"),
+        createOption("option-2", "Nhà cung cấp B"),
+      ],
+      baselineGroups: groups,
+      baselineVersionId: "baseline-1",
+      pageSize,
+    })
+  )
+}
+
+function rowKeys(
+  rows: ReturnType<typeof useTechnicalConfigurationEvaluationNavigator>["hierarchyRows"]
+) {
+  return rows.map((row) =>
+    row.kind === "criterion" ? `criterion:${row.row.criterion.id}` : `${row.kind}:${row.id}`
+  )
+}
+
+describe("P5C evaluation hierarchy navigator presentation", () => {
+  beforeEach(() => {
+    criteriaMocks.data = entries
+    criteriaMocks.loadCriteria.mockReset()
+    criteriaMocks.loadCriteria.mockResolvedValue(entries)
+    criteriaMocks.refetch.mockReset()
+  })
+
+  it("exposes only current canonical-page rows and defaults their ancestors expanded", () => {
+    const { result } = renderNavigator()
+
+    expect(rowKeys(result.current.hierarchyRows)).toEqual([
+      "section:group-1",
+      "criterion:criterion-1",
+      "subgroup:subgroup-1",
+      "criterion:criterion-2",
+    ])
+    expect([...result.current.expandedRowIds]).toEqual(["group-1", "subgroup-1"])
+
+    act(() => {
+      result.current.onExpandedRowIdsChange(new Set(["group-1"]))
+    })
+
+    expect([...result.current.expandedRowIds]).toEqual(["group-1"])
+    expect(result.current.projection.map((item) => item.criterion.id)).toEqual([
+      "criterion-1",
+      "criterion-2",
+      "criterion-3",
+    ])
+
+    act(() => {
+      result.current.changePage(2, (commit) => commit())
+    })
+
+    expect(rowKeys(result.current.hierarchyRows)).toEqual([
+      "section:group-2",
+      "criterion:criterion-3",
+    ])
+    expect([...result.current.expandedRowIds]).toEqual(["group-2"])
+  })
+
+  it("resets collapsed ancestors across canonical pages 50/51 with the same hierarchy", () => {
+    const fixture = createSharedAncestorPageBoundaryFixture()
+    criteriaMocks.data = fixture.entries
+    criteriaMocks.loadCriteria.mockResolvedValue(fixture.entries)
+    const { result } = renderNavigator(fixture.groups, 50)
+
+    expect(result.current.hierarchyRows.at(-1)).toMatchObject({
+      kind: "criterion",
+      row: { criterion: { id: "criterion-50" } },
+    })
+
+    act(() => {
+      result.current.onExpandedRowIdsChange(new Set())
+    })
+    expect([...result.current.expandedRowIds]).toEqual([])
+
+    act(() => {
+      result.current.changePage(2, (commit) => commit())
+    })
+
+    expect(rowKeys(result.current.hierarchyRows)).toEqual([
+      "section:group-1",
+      "subgroup:subgroup-1",
+      "criterion:criterion-51",
+    ])
+    expect([...result.current.expandedRowIds]).toEqual(["group-1", "subgroup-1"])
+  })
+
+  it("keeps expansion and selection unchanged when guarded criterion navigation is cancelled", () => {
+    const beforeOpen = vi.fn()
+    let commitNavigation: (() => void) | null = null
+    const { result } = renderNavigator()
+
+    act(() => {
+      result.current.onExpandedRowIdsChange(new Set())
+      result.current.changeCriterion(
+        "criterion-2",
+        (commit) => {
+          commitNavigation = commit
+        },
+        beforeOpen
+      )
+    })
+
+    expect([...result.current.expandedRowIds]).toEqual([])
+    expect(result.current.criterionId).toBe("criterion-1")
+    expect(beforeOpen).not.toHaveBeenCalled()
+
+    act(() => {
+      commitNavigation?.()
+    })
+
+    expect([...result.current.expandedRowIds]).toEqual(["group-1", "subgroup-1"])
+    expect(result.current.criterionId).toBe("criterion-2")
+    expect(beforeOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it("auto-expands a guarded target after approval without changing projection", async () => {
+    let commitNavigation: (() => void) | null = null
+    const { result } = renderNavigator()
+
+    act(() => {
+      result.current.onExpandedRowIdsChange(new Set())
+      result.current.changeTarget("option-2", "criterion-2", (commit) => {
+        commitNavigation = commit
+      })
+    })
+
+    expect([...result.current.expandedRowIds]).toEqual([])
+    expect(result.current.activeSelectedOptionId).toBe("option-1")
+
+    act(() => {
+      commitNavigation?.()
+    })
+
+    await waitFor(() => expect(result.current.activeSelectedOptionId).toBe("option-2"))
+    expect([...result.current.expandedRowIds]).toEqual(["group-1", "subgroup-1"])
+    expect(result.current.criterionId).toBe("criterion-2")
+    expect(result.current.projection).toHaveLength(3)
+  })
+
+  it("auto-expands the next matching leaf after save without altering next resolution", async () => {
+    const { result } = renderNavigator()
+
+    act(() => {
+      result.current.onExpandedRowIdsChange(new Set())
+    })
+
+    let nextCriterionId: string | undefined
+    await act(async () => {
+      nextCriterionId = (await result.current.advanceAfterSave())?.criterion.id
+    })
+
+    expect(nextCriterionId).toBe("criterion-2")
+    expect(result.current.criterionId).toBe("criterion-2")
+    expect([...result.current.expandedRowIds]).toEqual(["group-1", "subgroup-1"])
+    expect(result.current.hasNoMoreMatches).toBe(false)
+  })
+
+  it("keeps legacy direct-only rows unchanged", () => {
+    const { result } = renderNavigator(createBaselineGroups())
+
+    expect(rowKeys(result.current.hierarchyRows)).toEqual([
+      "section:group-1",
+      "criterion:criterion-1",
+      "criterion:criterion-2",
+    ])
+    expect([...result.current.expandedRowIds]).toEqual(["group-1"])
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx
@@ -185,6 +185,7 @@ describe("P5C evaluation hierarchy presentation", () => {
     const sectionCounts = within(sectionRow).getByTestId(
       "evaluation-hierarchy-section-status-counts-group-main"
     )
+    expect(sectionRow.querySelector("div")).toBeNull()
     expect(within(sectionRow).getByText("Không đạt", { exact: true })).toBeInTheDocument()
     expect(within(sectionCounts).getByText("Không đạt: 1")).toBeInTheDocument()
     expect(within(sectionCounts).getByText("Đạt: 1")).toBeInTheDocument()
@@ -194,6 +195,7 @@ describe("P5C evaluation hierarchy presentation", () => {
     const subgroupCounts = within(subgroupRow).getByTestId(
       "evaluation-hierarchy-subgroup-status-counts-subgroup-performance"
     )
+    expect(subgroupRow.querySelector("div")).toBeNull()
     expect(within(subgroupRow).getByText("Đạt", { exact: true })).toBeInTheDocument()
     expect(within(subgroupCounts).getByText("Đạt: 1")).toBeInTheDocument()
     expect(within(subgroupCounts).getByText("Không đạt: 0")).toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy-ui.test.tsx
@@ -1,0 +1,328 @@
+import "@testing-library/jest-dom"
+import { StrictMode } from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationCriterionList } from "../_components/evaluation/TechnicalConfigurationCriterionList"
+import type { TechnicalConfigurationEvaluationHierarchyRow } from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
+import type { TechnicalConfigurationEvaluationCriterionListItem } from "../_components/evaluation/technical-configuration-evaluation-navigation"
+import type { TechnicalConfigurationEvaluationProgress } from "../_components/evaluation/technical-configuration-evaluation-progress"
+
+function createCriterion(
+  id: string,
+  canonicalIndex: number,
+  group: { id: string; name: string; sortOrder: number },
+  subgroup?: { id: string; name: string; sortOrder: number }
+): TechnicalConfigurationEvaluationCriterionListItem {
+  return {
+    group,
+    ...(subgroup ? { subgroup } : {}),
+    criterion: {
+      id,
+      criterionCode: `TC-${String(canonicalIndex).padStart(2, "0")}`,
+      title: `Tiêu chí ${canonicalIndex}`,
+      sortOrder: canonicalIndex,
+    },
+    canonicalIndex,
+    canonicalPage: 1,
+  }
+}
+
+const mainGroup = { id: "group-main", name: "Thông số chính", sortOrder: 1 }
+const safetyGroup = { id: "group-safety", name: "An toàn", sortOrder: 2 }
+const performanceSubgroup = {
+  id: "subgroup-performance",
+  name: "Hiệu năng",
+  sortOrder: 1,
+}
+const pageCriteria = [
+  createCriterion("criterion-direct", 1, mainGroup),
+  createCriterion("criterion-subgroup", 2, mainGroup, performanceSubgroup),
+  createCriterion("criterion-safety", 3, safetyGroup),
+] as const
+const pageRows: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[] =
+  [
+    { kind: "section", id: mainGroup.id, name: mainGroup.name },
+    { kind: "criterion", row: pageCriteria[0] },
+    {
+      kind: "subgroup",
+      id: performanceSubgroup.id,
+      sectionId: mainGroup.id,
+      name: performanceSubgroup.name,
+    },
+    { kind: "criterion", row: pageCriteria[1] },
+    { kind: "section", id: safetyGroup.id, name: safetyGroup.name },
+    { kind: "criterion", row: pageCriteria[2] },
+  ]
+const emptyStatusCounts = {
+  not_evaluated: 0,
+  not_applicable: 0,
+  fails: 0,
+  unclear: 0,
+  insufficient_evidence: 0,
+  exceeds: 0,
+  meets: 0,
+} as const
+const hierarchyProgress: TechnicalConfigurationEvaluationProgress["hierarchy"] = [
+  {
+    id: mainGroup.id,
+    name: mainGroup.name,
+    sortOrder: mainGroup.sortOrder,
+    total: 2,
+    evaluated: 2,
+    status: "failed",
+    statusCounts: {
+      ...emptyStatusCounts,
+      fails: 1,
+      meets: 1,
+    },
+    subgroups: [
+      {
+        id: performanceSubgroup.id,
+        name: performanceSubgroup.name,
+        sortOrder: performanceSubgroup.sortOrder,
+        total: 1,
+        evaluated: 1,
+        status: "passed",
+        statusCounts: {
+          ...emptyStatusCounts,
+          meets: 1,
+        },
+      },
+    ],
+  },
+  {
+    id: safetyGroup.id,
+    name: safetyGroup.name,
+    sortOrder: safetyGroup.sortOrder,
+    total: 1,
+    evaluated: 0,
+    status: "in_progress",
+    statusCounts: {
+      ...emptyStatusCounts,
+      not_evaluated: 1,
+    },
+    subgroups: [],
+  },
+]
+
+function getCriterion(criterionId: string): HTMLElement | undefined {
+  return screen
+    .queryAllByTestId("evaluation-criterion")
+    .find((criterion) => criterion.getAttribute("data-criterion-id") === criterionId)
+}
+
+describe("P5C evaluation hierarchy presentation", () => {
+  it("renders and collapses a prebuilt page-local hierarchy row union", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId="criterion-subgroup"
+        onSelectCriterion={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId("evaluation-hierarchy-section-group-main")).toBeInTheDocument()
+    expect(
+      screen.getByTestId("evaluation-hierarchy-subgroup-subgroup-performance")
+    ).toBeInTheDocument()
+    expect(getCriterion("criterion-subgroup")).toHaveAttribute("aria-current", "true")
+
+    await user.click(screen.getByTestId("evaluation-hierarchy-section-group-main"))
+
+    expect(getCriterion("criterion-direct")).toBeUndefined()
+    expect(getCriterion("criterion-subgroup")).toBeUndefined()
+    expect(getCriterion("criterion-safety")).toBeInTheDocument()
+  })
+
+  it("renders only page-local ancestors and keeps structural rows assessment-free", async () => {
+    const user = userEvent.setup()
+    const onSelectCriterion = vi.fn()
+
+    render(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId="criterion-subgroup"
+        onSelectCriterion={onSelectCriterion}
+      />
+    )
+
+    const sectionRow = screen.getByTestId("evaluation-hierarchy-section-group-main")
+    const subgroupRow = screen.getByTestId("evaluation-hierarchy-subgroup-subgroup-performance")
+    expect(within(sectionRow).getByText("Thông số chính")).toBeInTheDocument()
+    expect(within(subgroupRow).getByText("Hiệu năng")).toBeInTheDocument()
+    expect(screen.getByText("An toàn")).toBeInTheDocument()
+    expect(screen.queryByText("Nhóm trống ngoài trang")).not.toBeInTheDocument()
+    expect(within(sectionRow).queryByRole("radio")).not.toBeInTheDocument()
+    expect(within(subgroupRow).queryByRole("radio")).not.toBeInTheDocument()
+    expect(sectionRow).not.toHaveAttribute("data-criterion-id")
+    expect(subgroupRow).not.toHaveAttribute("data-criterion-id")
+
+    await user.click(sectionRow)
+    await user.click(subgroupRow)
+    expect(onSelectCriterion).not.toHaveBeenCalled()
+  })
+
+  it("renders authoritative aggregate labels and exact canonical counts on structural rows", () => {
+    render(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId={null}
+        onSelectCriterion={vi.fn()}
+      />
+    )
+
+    const sectionRow = screen.getByTestId("evaluation-hierarchy-section-group-main")
+    const sectionCounts = within(sectionRow).getByTestId(
+      "evaluation-hierarchy-section-status-counts-group-main"
+    )
+    expect(within(sectionRow).getByText("Không đạt", { exact: true })).toBeInTheDocument()
+    expect(within(sectionCounts).getByText("Không đạt: 1")).toBeInTheDocument()
+    expect(within(sectionCounts).getByText("Đạt: 1")).toBeInTheDocument()
+    expect(within(sectionCounts).getByText("Chưa đánh giá: 0")).toBeInTheDocument()
+
+    const subgroupRow = screen.getByTestId("evaluation-hierarchy-subgroup-subgroup-performance")
+    const subgroupCounts = within(subgroupRow).getByTestId(
+      "evaluation-hierarchy-subgroup-status-counts-subgroup-performance"
+    )
+    expect(within(subgroupRow).getByText("Đạt", { exact: true })).toBeInTheDocument()
+    expect(within(subgroupCounts).getByText("Đạt: 1")).toBeInTheDocument()
+    expect(within(subgroupCounts).getByText("Không đạt: 0")).toBeInTheDocument()
+  })
+
+  it("starts expanded and collapses only presentation descendants", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId="criterion-subgroup"
+        onSelectCriterion={vi.fn()}
+      />
+    )
+
+    const mainSection = screen.getByTestId("evaluation-hierarchy-section-group-main")
+    const subgroup = screen.getByTestId("evaluation-hierarchy-subgroup-subgroup-performance")
+    expect(mainSection).toHaveAttribute("aria-expanded", "true")
+    expect(subgroup).toHaveAttribute("aria-expanded", "true")
+    expect(getCriterion("criterion-direct")).toBeInTheDocument()
+    expect(getCriterion("criterion-subgroup")).toBeInTheDocument()
+    expect(getCriterion("criterion-safety")).toBeInTheDocument()
+
+    await user.click(subgroup)
+    expect(subgroup).toHaveAttribute("aria-expanded", "false")
+    expect(getCriterion("criterion-direct")).toBeInTheDocument()
+    expect(getCriterion("criterion-subgroup")).toBeUndefined()
+    expect(getCriterion("criterion-safety")).toBeInTheDocument()
+
+    await user.click(mainSection)
+    expect(mainSection).toHaveAttribute("aria-expanded", "false")
+    expect(getCriterion("criterion-direct")).toBeUndefined()
+    expect(
+      screen.queryByTestId("evaluation-hierarchy-subgroup-subgroup-performance")
+    ).not.toBeInTheDocument()
+    expect(getCriterion("criterion-safety")).toBeInTheDocument()
+  })
+
+  it("emits one uncontrolled expansion change per structural toggle in StrictMode", async () => {
+    const user = userEvent.setup()
+    const onExpandedRowIdsChange = vi.fn()
+
+    render(
+      <StrictMode>
+        <TechnicalConfigurationCriterionList
+          rows={pageRows}
+          hierarchyProgress={hierarchyProgress}
+          assessmentsByCriterionId={{}}
+          currentCriterionId={null}
+          onSelectCriterion={vi.fn()}
+          onExpandedRowIdsChange={onExpandedRowIdsChange}
+        />
+      </StrictMode>
+    )
+
+    await user.click(screen.getByTestId("evaluation-hierarchy-section-group-main"))
+
+    expect(onExpandedRowIdsChange).toHaveBeenCalledTimes(1)
+    expect(onExpandedRowIdsChange).toHaveBeenCalledWith(
+      new Set([performanceSubgroup.id, safetyGroup.id])
+    )
+  })
+
+  it("supports controlled ancestor expansion for a selected hidden leaf", async () => {
+    const user = userEvent.setup()
+    const onExpandedRowIdsChange = vi.fn()
+    const { rerender } = render(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId="criterion-subgroup"
+        onSelectCriterion={vi.fn()}
+        expandedRowIds={new Set([mainGroup.id, safetyGroup.id])}
+        onExpandedRowIdsChange={onExpandedRowIdsChange}
+      />
+    )
+
+    expect(getCriterion("criterion-subgroup")).toBeUndefined()
+
+    rerender(
+      <TechnicalConfigurationCriterionList
+        rows={pageRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId="criterion-subgroup"
+        onSelectCriterion={vi.fn()}
+        expandedRowIds={new Set([mainGroup.id, performanceSubgroup.id, safetyGroup.id])}
+        onExpandedRowIdsChange={onExpandedRowIdsChange}
+      />
+    )
+
+    expect(getCriterion("criterion-subgroup")).toHaveAttribute("aria-current", "true")
+    await user.click(screen.getByTestId("evaluation-hierarchy-subgroup-subgroup-performance"))
+    expect(onExpandedRowIdsChange).toHaveBeenCalledWith(new Set([mainGroup.id, safetyGroup.id]))
+  })
+
+  it("preserves legacy direct-criterion rendering without subgroup rows", () => {
+    const legacyRows: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[] =
+      [
+        { kind: "section", id: mainGroup.id, name: mainGroup.name },
+        {
+          kind: "criterion",
+          row: createCriterion("criterion-legacy-1", 1, mainGroup),
+        },
+        { kind: "section", id: safetyGroup.id, name: safetyGroup.name },
+        {
+          kind: "criterion",
+          row: createCriterion("criterion-legacy-2", 2, safetyGroup),
+        },
+      ]
+
+    render(
+      <TechnicalConfigurationCriterionList
+        rows={legacyRows}
+        hierarchyProgress={hierarchyProgress}
+        assessmentsByCriterionId={{}}
+        currentCriterionId={null}
+        onSelectCriterion={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByTestId("evaluation-criterion")).toHaveLength(2)
+    expect(
+      screen.getAllByTestId(/^evaluation-hierarchy-section-(group-main|group-safety)$/)
+    ).toHaveLength(2)
+    expect(screen.queryByTestId(/evaluation-hierarchy-subgroup-/)).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-hierarchy.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildTechnicalConfigurationEvaluationHierarchyRows,
+  buildTechnicalConfigurationEvaluationHierarchySections,
+  flattenTechnicalConfigurationEvaluationLeaves,
+} from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+  TechnicalConfigurationBaselineSubgroupWire,
+} from "../baseline-types"
+
+const TIMESTAMP = "2026-08-12T00:00:00.000Z"
+
+function createCriterion({
+  id,
+  groupId,
+  sortOrder,
+  subgroupId,
+}: {
+  id: string
+  groupId: string
+  sortOrder: number
+  subgroupId?: string | null
+}): TechnicalConfigurationBaselineCriterionWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    group_id: groupId,
+    subgroup_id: subgroupId,
+    criterion_code: id.toUpperCase(),
+    title: id,
+    requirement_text: `Requirement ${id}`,
+    sort_order: sortOrder,
+    source_criterion_id: null,
+    created_at: TIMESTAMP,
+    created_by: 1,
+    updated_at: TIMESTAMP,
+    updated_by: 1,
+  }
+}
+
+function createSubgroup({
+  id,
+  groupId,
+  sortOrder,
+  criteria = [],
+}: {
+  id: string
+  groupId: string
+  sortOrder: number
+  criteria?: TechnicalConfigurationBaselineCriterionWire[]
+}): TechnicalConfigurationBaselineSubgroupWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    group_id: groupId,
+    name: id,
+    sort_order: sortOrder,
+    created_at: TIMESTAMP,
+    created_by: 1,
+    updated_at: TIMESTAMP,
+    updated_by: 1,
+    criteria,
+  }
+}
+
+function createGroup({
+  id,
+  sortOrder,
+  criteria = [],
+  subgroups,
+}: {
+  id: string
+  sortOrder: number
+  criteria?: TechnicalConfigurationBaselineCriterionWire[]
+  subgroups?: TechnicalConfigurationBaselineSubgroupWire[]
+}): TechnicalConfigurationBaselineGroupWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    name: id,
+    sort_order: sortOrder,
+    created_at: TIMESTAMP,
+    created_by: 1,
+    updated_at: TIMESTAMP,
+    updated_by: 1,
+    criteria,
+    ...(subgroups ? { subgroups } : {}),
+  }
+}
+
+describe("P5C evaluation hierarchy model", () => {
+  it("sorts the canonical tuple with direct leaves before complete subgroup blocks", () => {
+    const groups = [
+      createGroup({
+        id: "section-b",
+        sortOrder: 1,
+        criteria: [createCriterion({ id: "direct-b", groupId: "section-b", sortOrder: 1 })],
+      }),
+      createGroup({
+        id: "section-a",
+        sortOrder: 1,
+        criteria: [
+          createCriterion({ id: "direct-z", groupId: "section-a", sortOrder: 1 }),
+          createCriterion({ id: "direct-a", groupId: "section-a", sortOrder: 1 }),
+        ],
+        subgroups: [
+          createSubgroup({
+            id: "subgroup-b",
+            groupId: "section-a",
+            sortOrder: 1,
+            criteria: [
+              createCriterion({
+                id: "subgroup-b-leaf",
+                groupId: "section-a",
+                subgroupId: "subgroup-b",
+                sortOrder: 1,
+              }),
+            ],
+          }),
+          createSubgroup({
+            id: "subgroup-a",
+            groupId: "section-a",
+            sortOrder: 1,
+            criteria: [
+              createCriterion({
+                id: "subgroup-leaf-z",
+                groupId: "section-a",
+                subgroupId: "subgroup-a",
+                sortOrder: 1,
+              }),
+              createCriterion({
+                id: "subgroup-leaf-a",
+                groupId: "section-a",
+                subgroupId: "subgroup-a",
+                sortOrder: 1,
+              }),
+            ],
+          }),
+        ],
+      }),
+    ]
+    const originalGroupIds = groups.map((group) => group.id)
+
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+
+    expect(leaves.map((leaf) => leaf.criterion.id)).toEqual([
+      "direct-a",
+      "direct-z",
+      "subgroup-leaf-a",
+      "subgroup-leaf-z",
+      "subgroup-b-leaf",
+      "direct-b",
+    ])
+    expect(leaves.map((leaf) => leaf.canonicalIndex)).toEqual([1, 2, 3, 4, 5, 6])
+    expect(leaves[2]).toMatchObject({
+      group: { id: "section-a" },
+      subgroup: { id: "subgroup-a" },
+      criterion: { id: "subgroup-leaf-a" },
+    })
+    expect(groups.map((group) => group.id)).toEqual(originalGroupIds)
+  })
+
+  it("validates ownership and keeps the first canonical occurrence of duplicate IDs", () => {
+    const groups = [
+      createGroup({
+        id: "section-a",
+        sortOrder: 1,
+        criteria: [
+          createCriterion({ id: "criterion-shared", groupId: "section-a", sortOrder: 1 }),
+          createCriterion({ id: "wrong-group", groupId: "section-b", sortOrder: 2 }),
+          createCriterion({
+            id: "misplaced-subgroup",
+            groupId: "section-a",
+            subgroupId: "subgroup-a",
+            sortOrder: 3,
+          }),
+        ],
+        subgroups: [
+          createSubgroup({
+            id: "subgroup-a",
+            groupId: "section-a",
+            sortOrder: 1,
+            criteria: [
+              createCriterion({
+                id: "criterion-shared",
+                groupId: "section-a",
+                subgroupId: "subgroup-a",
+                sortOrder: 1,
+              }),
+              createCriterion({
+                id: "wrong-subgroup",
+                groupId: "section-a",
+                subgroupId: "subgroup-b",
+                sortOrder: 2,
+              }),
+              createCriterion({
+                id: "valid-subgroup",
+                groupId: "section-a",
+                subgroupId: "subgroup-a",
+                sortOrder: 3,
+              }),
+            ],
+          }),
+          createSubgroup({
+            id: "foreign-subgroup",
+            groupId: "section-b",
+            sortOrder: 2,
+            criteria: [
+              createCriterion({
+                id: "foreign-leaf",
+                groupId: "section-a",
+                subgroupId: "foreign-subgroup",
+                sortOrder: 1,
+              }),
+            ],
+          }),
+        ],
+      }),
+    ]
+
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+
+    expect(leaves.map((leaf) => leaf.criterion.id)).toEqual(["criterion-shared", "valid-subgroup"])
+    expect(leaves[0]?.subgroup).toBeUndefined()
+  })
+
+  it("supports legacy direct-only snapshots without a subgroup array", () => {
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves([
+      createGroup({
+        id: "section-legacy",
+        sortOrder: 1,
+        criteria: [
+          createCriterion({ id: "legacy-b", groupId: "section-legacy", sortOrder: 2 }),
+          createCriterion({ id: "legacy-a", groupId: "section-legacy", sortOrder: 1 }),
+        ],
+      }),
+    ])
+
+    expect(leaves.map((leaf) => leaf.criterion.id)).toEqual(["legacy-a", "legacy-b"])
+    expect(leaves.every((leaf) => leaf.subgroup === undefined)).toBe(true)
+  })
+
+  it("builds page-local rows and omits empty structures", () => {
+    const groups = [
+      createGroup({
+        id: "section-a",
+        sortOrder: 1,
+        subgroups: [
+          createSubgroup({ id: "subgroup-empty", groupId: "section-a", sortOrder: 1 }),
+          createSubgroup({
+            id: "subgroup-full",
+            groupId: "section-a",
+            sortOrder: 2,
+            criteria: [
+              createCriterion({
+                id: "subgroup-leaf",
+                groupId: "section-a",
+                subgroupId: "subgroup-full",
+                sortOrder: 1,
+              }),
+            ],
+          }),
+        ],
+      }),
+      createGroup({ id: "section-empty", sortOrder: 2 }),
+      createGroup({
+        id: "section-b",
+        sortOrder: 3,
+        criteria: [createCriterion({ id: "direct-leaf", groupId: "section-b", sortOrder: 1 })],
+      }),
+    ]
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+
+    const rows = buildTechnicalConfigurationEvaluationHierarchyRows(leaves)
+
+    expect(
+      rows.map((row) =>
+        row.kind === "criterion" ? `${row.kind}:${row.row.criterion.id}` : `${row.kind}:${row.id}`
+      )
+    ).toEqual([
+      "section:section-a",
+      "subgroup:subgroup-full",
+      "criterion:subgroup-leaf",
+      "section:section-b",
+      "criterion:direct-leaf",
+    ])
+  })
+
+  it("keeps empty sections and subgroups in full-universe aggregate inputs", () => {
+    const groups = [
+      createGroup({
+        id: "section-a",
+        sortOrder: 1,
+        subgroups: [createSubgroup({ id: "subgroup-empty", groupId: "section-a", sortOrder: 1 })],
+      }),
+    ]
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+
+    expect(buildTechnicalConfigurationEvaluationHierarchySections(groups, leaves)).toEqual([
+      {
+        id: "section-a",
+        name: "section-a",
+        sortOrder: 1,
+        criterionIds: [],
+        subgroups: [
+          {
+            id: "subgroup-empty",
+            name: "subgroup-empty",
+            sortOrder: 1,
+            criterionIds: [],
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-navigation.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-navigation.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildTechnicalConfigurationEvaluationHierarchyRows,
+  flattenTechnicalConfigurationEvaluationLeaves,
+} from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
+import {
   buildTechnicalConfigurationEvaluationProjection,
+  findTechnicalConfigurationEvaluationCriterion,
   findNextTechnicalConfigurationEvaluationCriterion,
   getTechnicalConfigurationEvaluationPage,
 } from "../_components/evaluation/technical-configuration-evaluation-navigation"
+import { buildTechnicalConfigurationEvaluationProgress } from "../_components/evaluation/technical-configuration-evaluation-progress"
+import { createAssessment } from "./technical-configuration-evaluation-progress.test-support"
 import { createBaselineGroups } from "./technical-configuration-evaluation-workspace.test-support"
 
 const serverEntries = [
@@ -63,5 +70,121 @@ describe("P12B2 evaluation navigation projection", () => {
         currentCanonicalIndex: 3,
       })
     ).toBeNull()
+  })
+
+  it("projects and resolves criteria nested under a subgroup", () => {
+    const groups = createBaselineGroups()
+    const subgroupCriterion = {
+      ...groups[0].criteria[0],
+      id: "criterion-subgroup",
+      subgroup_id: "subgroup-1",
+    }
+    groups[0].subgroups = [
+      {
+        id: "subgroup-1",
+        baseline_version_id: groups[0].baseline_version_id,
+        group_id: groups[0].id,
+        name: "Nhóm con",
+        sort_order: 1,
+        created_at: groups[0].created_at,
+        created_by: groups[0].created_by,
+        updated_at: groups[0].updated_at,
+        updated_by: groups[0].updated_by,
+        criteria: [subgroupCriterion],
+      },
+    ]
+
+    const projection = buildTechnicalConfigurationEvaluationProjection({
+      groups,
+      entries: [
+        {
+          criterion_id: subgroupCriterion.id,
+          canonical_index: 4,
+          canonical_page: 2,
+        },
+      ],
+    })
+
+    expect(projection).toHaveLength(1)
+    expect(projection[0]).toMatchObject({
+      subgroup: { id: "subgroup-1", name: "Nhóm con", sortOrder: 1 },
+      criterion: { id: subgroupCriterion.id },
+      canonicalIndex: 4,
+      canonicalPage: 2,
+    })
+    expect(
+      findTechnicalConfigurationEvaluationCriterion({
+        groups,
+        criterionId: subgroupCriterion.id,
+        pageSize: 2,
+      })
+    ).toMatchObject({
+      subgroup: { id: "subgroup-1" },
+      criterion: { id: subgroupCriterion.id },
+      canonicalIndex: 3,
+      canonicalPage: 2,
+    })
+  })
+
+  it("keeps invalid subgroup ownership out of every evaluation leaf surface", () => {
+    const groups = createBaselineGroups()
+    const invalidCriterionId = "criterion-invalid-subgroup"
+    groups[0].criteria.push({
+      ...groups[0].criteria[0],
+      id: invalidCriterionId,
+      subgroup_id: "missing-subgroup",
+    })
+    const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+    const canonicalCriterionIds = leaves.map((leaf) => leaf.criterion.id)
+
+    const projection = buildTechnicalConfigurationEvaluationProjection({
+      groups,
+      entries: [
+        ...leaves.map((leaf) => ({
+          criterion_id: leaf.criterion.id,
+          canonical_index: leaf.canonicalIndex,
+          canonical_page: Math.ceil(leaf.canonicalIndex / 2),
+        })),
+        { criterion_id: invalidCriterionId, canonical_index: 4, canonical_page: 2 },
+      ],
+    })
+    const hierarchyCriterionIds = buildTechnicalConfigurationEvaluationHierarchyRows(leaves)
+      .filter((row) => row.kind === "criterion")
+      .map((row) => row.row.criterion.id)
+    const progress = buildTechnicalConfigurationEvaluationProgress({
+      groups,
+      assessments: [
+        ...canonicalCriterionIds.map((criterionId) => createAssessment(criterionId, "meets")),
+        createAssessment(invalidCriterionId, "fails"),
+      ],
+    })
+
+    expect(projection.map((item) => item.criterion.id)).toEqual(canonicalCriterionIds)
+    expect(hierarchyCriterionIds).toEqual(canonicalCriterionIds)
+    expect(
+      canonicalCriterionIds.map(
+        (criterionId) =>
+          findTechnicalConfigurationEvaluationCriterion({
+            groups,
+            criterionId,
+            pageSize: 2,
+          })?.criterion.id
+      )
+    ).toEqual(canonicalCriterionIds)
+    expect(
+      findTechnicalConfigurationEvaluationCriterion({
+        groups,
+        criterionId: invalidCriterionId,
+        pageSize: 2,
+      })
+    ).toBeNull()
+    expect(progress).toMatchObject({
+      total: canonicalCriterionIds.length,
+      evaluated: canonicalCriterionIds.length,
+      statusCounts: {
+        meets: canonicalCriterionIds.length,
+        fails: 0,
+      },
+    })
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test-support.ts
@@ -1,0 +1,95 @@
+import { expect } from "vitest"
+
+import type {
+  TechnicalConfigurationDerivedStatus,
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+import type { TechnicalConfigurationEvaluationProgress } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
+import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+} from "@/app/(app)/technical-configurations/baseline-types"
+
+const STATUS_AXES: Record<
+  TechnicalConfigurationDerivedStatus,
+  readonly [TechnicalConfigurationTechnicalAxis | null, TechnicalConfigurationEvidenceAxis | null]
+> = {
+  not_evaluated: [null, null],
+  not_applicable: ["not_applicable", null],
+  fails: ["fails", null],
+  unclear: ["unclear", null],
+  insufficient_evidence: ["meets", "partial"],
+  exceeds: ["exceeds", "complete"],
+  meets: ["meets", "complete"],
+}
+
+export function createCriterion(
+  groupId: string,
+  index: number
+): TechnicalConfigurationBaselineCriterionWire {
+  const id = `${groupId}-criterion-${index}`
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    group_id: groupId,
+    criterion_code: `TC-${index.toString().padStart(3, "0")}`,
+    title: `Tiêu chí ${index}`,
+    requirement_text: `Yêu cầu ${index}`,
+    sort_order: index,
+    source_criterion_id: null,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+  }
+}
+
+export function createGroup(
+  id: string,
+  name: string,
+  criterionCount: number
+): TechnicalConfigurationBaselineGroupWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    name,
+    sort_order: Number(id.replace(/\D/g, "")) || 1,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    criteria: Array.from({ length: criterionCount }, (_, index) => createCriterion(id, index + 1)),
+  }
+}
+
+export function createAssessment(
+  criterionId: string,
+  status: TechnicalConfigurationDerivedStatus,
+  optionId = "option-1"
+): TechnicalConfigurationAssessmentWire {
+  const [technicalAxis, evidenceAxis] = STATUS_AXES[status]
+  return {
+    id: `${optionId}-${criterionId}`,
+    comparison_set_id: `comparison-set-${optionId}`,
+    baseline_version_id: "baseline-1",
+    criterion_id: criterionId,
+    technical_axis: technicalAxis,
+    evidence_axis: evidenceAxis,
+    notes: "",
+    revision: 1,
+    created_by: 1,
+    created_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+  }
+}
+
+export function expectReconciledTotals(progress: TechnicalConfigurationEvaluationProgress): void {
+  expect(progress.groups.reduce((sum, group) => sum + group.total, 0)).toBe(progress.total)
+  expect(progress.groups.reduce((sum, group) => sum + group.evaluated, 0)).toBe(progress.evaluated)
+  expect(Object.values(progress.statusCounts).reduce((sum, count) => sum + count, 0)).toBe(
+    progress.total
+  )
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
@@ -1,101 +1,12 @@
 import { describe, expect, it } from "vitest"
 
-import type {
-  TechnicalConfigurationDerivedStatus,
-  TechnicalConfigurationEvidenceAxis,
-  TechnicalConfigurationTechnicalAxis,
-} from "@/lib/technical-configuration-evaluation"
+import { buildTechnicalConfigurationEvaluationProgress } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
 import {
-  buildTechnicalConfigurationEvaluationProgress,
-  type TechnicalConfigurationEvaluationProgress,
-} from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
-import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
-import type {
-  TechnicalConfigurationBaselineCriterionWire,
-  TechnicalConfigurationBaselineGroupWire,
-} from "@/app/(app)/technical-configurations/baseline-types"
-
-const STATUS_AXES: Record<
-  TechnicalConfigurationDerivedStatus,
-  readonly [TechnicalConfigurationTechnicalAxis | null, TechnicalConfigurationEvidenceAxis | null]
-> = {
-  not_evaluated: [null, null],
-  not_applicable: ["not_applicable", null],
-  fails: ["fails", null],
-  unclear: ["unclear", null],
-  insufficient_evidence: ["meets", "partial"],
-  exceeds: ["exceeds", "complete"],
-  meets: ["meets", "complete"],
-}
-
-function createCriterion(
-  groupId: string,
-  index: number
-): TechnicalConfigurationBaselineCriterionWire {
-  const id = `${groupId}-criterion-${index}`
-  return {
-    id,
-    baseline_version_id: "baseline-1",
-    group_id: groupId,
-    criterion_code: `TC-${index.toString().padStart(3, "0")}`,
-    title: `Tiêu chí ${index}`,
-    requirement_text: `Yêu cầu ${index}`,
-    sort_order: index,
-    source_criterion_id: null,
-    created_at: "2026-07-30T00:00:00.000Z",
-    created_by: 1,
-    updated_at: "2026-07-30T00:00:00.000Z",
-    updated_by: 1,
-  }
-}
-
-function createGroup(
-  id: string,
-  name: string,
-  criterionCount: number
-): TechnicalConfigurationBaselineGroupWire {
-  return {
-    id,
-    baseline_version_id: "baseline-1",
-    name,
-    sort_order: Number(id.replace(/\D/g, "")) || 1,
-    created_at: "2026-07-30T00:00:00.000Z",
-    created_by: 1,
-    updated_at: "2026-07-30T00:00:00.000Z",
-    updated_by: 1,
-    criteria: Array.from({ length: criterionCount }, (_, index) => createCriterion(id, index + 1)),
-  }
-}
-
-function createAssessment(
-  criterionId: string,
-  status: TechnicalConfigurationDerivedStatus,
-  optionId = "option-1"
-): TechnicalConfigurationAssessmentWire {
-  const [technicalAxis, evidenceAxis] = STATUS_AXES[status]
-  return {
-    id: `${optionId}-${criterionId}`,
-    comparison_set_id: `comparison-set-${optionId}`,
-    baseline_version_id: "baseline-1",
-    criterion_id: criterionId,
-    technical_axis: technicalAxis,
-    evidence_axis: evidenceAxis,
-    notes: "",
-    revision: 1,
-    created_by: 1,
-    created_at: "2026-07-30T00:00:00.000Z",
-    updated_by: 1,
-    updated_at: "2026-07-30T00:00:00.000Z",
-  }
-}
-
-function expectReconciledTotals(progress: TechnicalConfigurationEvaluationProgress): void {
-  expect(progress.groups.reduce((sum, group) => sum + group.total, 0)).toBe(progress.total)
-  expect(progress.groups.reduce((sum, group) => sum + group.evaluated, 0)).toBe(progress.evaluated)
-  expect(Object.values(progress.statusCounts).reduce((sum, count) => sum + count, 0)).toBe(
-    progress.total
-  )
-}
+  createAssessment,
+  createCriterion,
+  createGroup,
+  expectReconciledTotals,
+} from "./technical-configuration-evaluation-progress.test-support"
 
 describe("P12B1 selected-option evaluation progress", () => {
   it("returns a stable zero model for an empty criterion universe", () => {
@@ -104,7 +15,7 @@ describe("P12B1 selected-option evaluation progress", () => {
       assessments: [],
     })
 
-    expect(progress).toEqual({
+    expect(progress).toMatchObject({
       total: 0,
       evaluated: 0,
       statusCounts: {
@@ -139,7 +50,7 @@ describe("P12B1 selected-option evaluation progress", () => {
 
     const progress = buildTechnicalConfigurationEvaluationProgress({ groups, assessments })
 
-    expect(progress).toEqual({
+    expect(progress).toMatchObject({
       total: 9,
       evaluated: 7,
       statusCounts: {
@@ -186,6 +97,165 @@ describe("P12B1 selected-option evaluation progress", () => {
       { id: "group-1", name: "Nhóm một", total: 60, evaluated: 60 },
       { id: "group-2", name: "Nhóm hai", total: 55, evaluated: 40 },
     ])
+    expectReconciledTotals(progress)
+  })
+
+  it("counts subgroup-exclusive criteria in full-universe progress", () => {
+    const group = createGroup("group-1", "Thông số chính", 1)
+    const subgroupCriterion = {
+      ...createCriterion(group.id, 2),
+      subgroup_id: "subgroup-1",
+    }
+    group.subgroups = [
+      {
+        id: "subgroup-1",
+        baseline_version_id: group.baseline_version_id,
+        group_id: group.id,
+        name: "Nhóm con",
+        sort_order: 1,
+        created_at: group.created_at,
+        created_by: group.created_by,
+        updated_at: group.updated_at,
+        updated_by: group.updated_by,
+        criteria: [subgroupCriterion],
+      },
+    ]
+
+    const progress = buildTechnicalConfigurationEvaluationProgress({
+      groups: [group],
+      assessments: [createAssessment(subgroupCriterion.id, "fails")],
+    })
+
+    expect(progress).toMatchObject({
+      total: 2,
+      evaluated: 1,
+      statusCounts: {
+        not_evaluated: 1,
+        fails: 1,
+      },
+      groups: [{ id: group.id, total: 2, evaluated: 1 }],
+    })
+  })
+
+  it("exposes mixed and empty section and subgroup aggregates", () => {
+    const group = createGroup("group-1", "Thông số chính", 1)
+    const subgroupCriterion = {
+      ...createCriterion(group.id, 2),
+      subgroup_id: "subgroup-mixed",
+    }
+    group.subgroups = [
+      {
+        id: "subgroup-empty",
+        baseline_version_id: group.baseline_version_id,
+        group_id: group.id,
+        name: "Nhóm trống",
+        sort_order: 1,
+        created_at: group.created_at,
+        created_by: group.created_by,
+        updated_at: group.updated_at,
+        updated_by: group.updated_by,
+        criteria: [],
+      },
+      {
+        id: "subgroup-mixed",
+        baseline_version_id: group.baseline_version_id,
+        group_id: group.id,
+        name: "Nhóm hỗn hợp",
+        sort_order: 2,
+        created_at: group.created_at,
+        created_by: group.created_by,
+        updated_at: group.updated_at,
+        updated_by: group.updated_by,
+        criteria: [subgroupCriterion],
+      },
+    ]
+
+    const progress = buildTechnicalConfigurationEvaluationProgress({
+      groups: [group, createGroup("group-2", "Nhóm trống", 0)],
+      assessments: [
+        createAssessment(group.criteria[0].id, "meets"),
+        createAssessment(subgroupCriterion.id, "fails"),
+      ],
+    })
+
+    expect(progress.hierarchy).toEqual([
+      expect.objectContaining({
+        id: "group-1",
+        total: 2,
+        evaluated: 2,
+        status: "failed",
+        subgroups: [
+          expect.objectContaining({
+            id: "subgroup-empty",
+            total: 0,
+            evaluated: 0,
+            status: "no_criteria",
+          }),
+          expect.objectContaining({
+            id: "subgroup-mixed",
+            total: 1,
+            evaluated: 1,
+            status: "failed",
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        id: "group-2",
+        total: 0,
+        evaluated: 0,
+        status: "no_criteria",
+        subgroups: [],
+      }),
+    ])
+  })
+
+  it("counts more than 100 mixed direct and subgroup leaves exactly once", () => {
+    const group = createGroup("group-1", "Thông số chính", 51)
+    const subgroupCriteria = Array.from({ length: 55 }, (_, index) => ({
+      ...createCriterion(group.id, index + 52),
+      subgroup_id: "subgroup-1",
+    }))
+    group.subgroups = [
+      {
+        id: "subgroup-1",
+        baseline_version_id: group.baseline_version_id,
+        group_id: group.id,
+        name: "Nhóm con",
+        sort_order: 1,
+        created_at: group.created_at,
+        created_by: group.created_by,
+        updated_at: group.updated_at,
+        updated_by: group.updated_by,
+        criteria: subgroupCriteria,
+      },
+    ]
+    const assessedCriteria = [...group.criteria, ...subgroupCriteria].slice(0, 101)
+
+    const progress = buildTechnicalConfigurationEvaluationProgress({
+      groups: [group],
+      assessments: assessedCriteria.map((criterion) => createAssessment(criterion.id, "meets")),
+    })
+
+    expect(progress).toMatchObject({
+      total: 106,
+      evaluated: 101,
+      statusCounts: { meets: 101, not_evaluated: 5 },
+      groups: [{ id: "group-1", total: 106, evaluated: 101 }],
+      hierarchy: [
+        expect.objectContaining({
+          id: "group-1",
+          total: 106,
+          evaluated: 101,
+          subgroups: [
+            expect.objectContaining({
+              id: "subgroup-1",
+              total: 55,
+              evaluated: 50,
+            }),
+          ],
+        }),
+      ],
+    })
     expectReconciledTotals(progress)
   })
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
@@ -20,9 +20,9 @@ const progress: TechnicalConfigurationEvaluationProgress = {
   evaluated: 4,
   statusCounts: {
     not_evaluated: 2,
-    not_applicable: 1,
+    not_applicable: 0,
     fails: 1,
-    unclear: 0,
+    unclear: 1,
     insufficient_evidence: 1,
     exceeds: 0,
     meets: 1,
@@ -124,8 +124,9 @@ describe("P12B1 technical configuration progress summary", () => {
 
     const overallCounts = within(summary).getByTestId("evaluation-progress-status-counts-overall")
     expect(within(overallCounts).getByText("Chưa đánh giá: 2")).toBeInTheDocument()
-    expect(within(overallCounts).getByText("Không áp dụng: 1")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Không áp dụng: 0")).toBeInTheDocument()
     expect(within(overallCounts).getByText("Không đạt: 1")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Chưa rõ: 1")).toBeInTheDocument()
     expect(within(overallCounts).getByText("Chưa đủ bằng chứng: 1")).toBeInTheDocument()
     expect(within(overallCounts).getByText("Đạt: 1")).toBeInTheDocument()
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
@@ -5,6 +5,16 @@ import { describe, expect, it } from "vitest"
 import { TechnicalConfigurationProgressSummary } from "@/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary"
 import type { TechnicalConfigurationEvaluationProgress } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
 
+const emptyStatusCounts = {
+  not_evaluated: 0,
+  not_applicable: 0,
+  fails: 0,
+  unclear: 0,
+  insufficient_evidence: 0,
+  exceeds: 0,
+  meets: 0,
+} as const
+
 const progress: TechnicalConfigurationEvaluationProgress = {
   total: 6,
   evaluated: 4,
@@ -21,6 +31,61 @@ const progress: TechnicalConfigurationEvaluationProgress = {
     { id: "group-1", name: "Thông số chính", total: 4, evaluated: 3 },
     { id: "group-2", name: "An toàn", total: 2, evaluated: 1 },
   ],
+  hierarchy: [
+    {
+      id: "group-1",
+      name: "Thông số chính",
+      sortOrder: 1,
+      total: 4,
+      evaluated: 3,
+      status: "failed",
+      statusCounts: {
+        ...emptyStatusCounts,
+        not_evaluated: 1,
+        fails: 1,
+        insufficient_evidence: 1,
+        meets: 1,
+      },
+      subgroups: [
+        {
+          id: "subgroup-1",
+          name: "Hiệu năng",
+          sortOrder: 1,
+          total: 2,
+          evaluated: 1,
+          status: "in_progress",
+          statusCounts: {
+            ...emptyStatusCounts,
+            not_evaluated: 1,
+            meets: 1,
+          },
+        },
+        {
+          id: "subgroup-empty",
+          name: "Nhóm trống",
+          sortOrder: 2,
+          total: 0,
+          evaluated: 0,
+          status: "no_criteria",
+          statusCounts: emptyStatusCounts,
+        },
+      ],
+    },
+    {
+      id: "group-2",
+      name: "An toàn",
+      sortOrder: 2,
+      total: 2,
+      evaluated: 1,
+      status: "needs_clarification",
+      statusCounts: {
+        ...emptyStatusCounts,
+        not_evaluated: 1,
+        unclear: 1,
+      },
+      subgroups: [],
+    },
+  ],
 }
 
 const fiveCardProgress: TechnicalConfigurationEvaluationProgress = {
@@ -35,7 +100,7 @@ const fiveCardProgress: TechnicalConfigurationEvaluationProgress = {
 }
 
 describe("P12B1 technical configuration progress summary", () => {
-  it("renders overall and group progress as compact KPI cards", () => {
+  it("renders overall KPI cards and exact section/subgroup aggregates", () => {
     render(
       <TechnicalConfigurationProgressSummary
         progress={progress}
@@ -57,18 +122,43 @@ describe("P12B1 technical configuration progress summary", () => {
     expect(within(progressCards[2]!).getByText("An toàn")).toBeInTheDocument()
     expect(within(progressCards[2]!).getByText("1 / 2")).toBeInTheDocument()
 
+    const overallCounts = within(summary).getByTestId("evaluation-progress-status-counts-overall")
+    expect(within(overallCounts).getByText("Chưa đánh giá: 2")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Không áp dụng: 1")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Không đạt: 1")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Chưa đủ bằng chứng: 1")).toBeInTheDocument()
+    expect(within(overallCounts).getByText("Đạt: 1")).toBeInTheDocument()
+
     expect(within(summary).queryByRole("progressbar")).not.toBeInTheDocument()
     expect(within(summary).queryByText(/%/)).not.toBeInTheDocument()
-    for (const statusLabel of [
-      "Chưa đánh giá",
-      "Không áp dụng",
-      "Không đạt",
-      "Chưa rõ",
-      "Chưa đủ bằng chứng",
-      "Vượt yêu cầu",
-      "Đạt",
-    ]) {
-      expect(within(summary).queryByText(statusLabel, { exact: true })).not.toBeInTheDocument()
+    const mainSection = within(summary).getByTestId("evaluation-progress-section-group-1")
+    const performanceSubgroup = within(summary).getByTestId(
+      "evaluation-progress-subgroup-subgroup-1"
+    )
+    const emptySubgroup = within(summary).getByTestId("evaluation-progress-subgroup-subgroup-empty")
+    const sectionCounts = within(mainSection).getByTestId(
+      "evaluation-progress-section-status-counts-group-1"
+    )
+    const subgroupCounts = within(performanceSubgroup).getByTestId(
+      "evaluation-progress-subgroup-status-counts-subgroup-1"
+    )
+    const emptySubgroupCounts = within(emptySubgroup).getByTestId(
+      "evaluation-progress-subgroup-status-counts-subgroup-empty"
+    )
+    expect(within(mainSection).getByText("Không đạt", { exact: true })).toBeInTheDocument()
+    expect(within(mainSection).getByText("3 / 4 tiêu chí")).toBeInTheDocument()
+    expect(within(sectionCounts).getByText("Không đạt: 1")).toBeInTheDocument()
+    expect(within(sectionCounts).getByText("Đạt: 1")).toBeInTheDocument()
+    expect(within(performanceSubgroup).getByText("Đang đánh giá")).toBeInTheDocument()
+    expect(within(performanceSubgroup).getByText("1 / 2 tiêu chí")).toBeInTheDocument()
+    expect(within(subgroupCounts).getByText("Chưa đánh giá: 1")).toBeInTheDocument()
+    expect(within(subgroupCounts).getByText("Đạt: 1")).toBeInTheDocument()
+    expect(within(emptySubgroup).getByText("Chưa có tiêu chí")).toBeInTheDocument()
+    expect(within(emptySubgroup).getByText("0 / 0 tiêu chí")).toBeInTheDocument()
+    for (const count of Object.values(emptyStatusCounts)) {
+      expect(within(emptySubgroupCounts).getAllByText(new RegExp(`: ${count}$`))).not.toHaveLength(
+        0
+      )
     }
   })
 

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
@@ -134,8 +134,10 @@ export function TechnicalConfigurationCriterionList({
                   <span className="flex flex-wrap items-center justify-between gap-2">
                     <span className="break-words">{hierarchyRow.name}</span>
                     {progress ? (
-                      <Badge variant="outline">
-                        {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                      <Badge asChild variant="outline">
+                        <span>
+                          {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                        </span>
                       </Badge>
                     ) : null}
                   </span>
@@ -175,8 +177,10 @@ export function TechnicalConfigurationCriterionList({
                 <span className="flex flex-wrap items-center justify-between gap-2">
                   <span className="break-words">{hierarchyRow.name}</span>
                   {progress ? (
-                    <Badge variant="outline">
-                      {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                    <Badge asChild variant="outline">
+                      <span>
+                        {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                      </span>
                     </Badge>
                   ) : null}
                 </span>

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
@@ -1,63 +1,34 @@
 "use client"
 
+import * as React from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   deriveTechnicalConfigurationEvaluationStatus,
   TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
   type TechnicalConfigurationDerivedStatus,
 } from "@/lib/technical-configuration-evaluation"
+import { TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS } from "@/lib/technical-configuration-hierarchy-aggregate-status"
 import { cn } from "@/lib/utils"
 
 import type { TechnicalConfigurationAssessmentWire } from "../../assessment-types"
+import type { TechnicalConfigurationEvaluationHierarchyRow } from "./technical-configuration-evaluation-hierarchy"
 import type { TechnicalConfigurationEvaluationCriterionListItem } from "./technical-configuration-evaluation-navigation"
+import type { TechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
+import { TechnicalConfigurationEvaluationHierarchyStatusCounts } from "./TechnicalConfigurationEvaluationHierarchyStatusCounts"
 import { TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS } from "./technical-configuration-evaluation-status-badge"
 
 type TechnicalConfigurationCriterionListProps = {
-  criteria: readonly TechnicalConfigurationEvaluationCriterionListItem[]
+  rows: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[]
+  hierarchyProgress: TechnicalConfigurationEvaluationProgress["hierarchy"] | null
   assessmentsByCriterionId: Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
   currentCriterionId: string | null
   onSelectCriterion: (criterionId: string) => void
   disabled?: boolean
-}
-
-type TechnicalConfigurationCriterionGroup = {
-  id: string
-  name: string
-  criteria: TechnicalConfigurationEvaluationCriterionListItem[]
-}
-
-function compareCanonicalCriteria(
-  left: TechnicalConfigurationEvaluationCriterionListItem,
-  right: TechnicalConfigurationEvaluationCriterionListItem
-) {
-  return (
-    left.group.sortOrder - right.group.sortOrder ||
-    left.group.id.localeCompare(right.group.id) ||
-    left.criterion.sortOrder - right.criterion.sortOrder ||
-    left.criterion.id.localeCompare(right.criterion.id)
-  )
-}
-
-function groupCanonicalCriteria(
-  criteria: readonly TechnicalConfigurationEvaluationCriterionListItem[]
-): TechnicalConfigurationCriterionGroup[] {
-  const groups: TechnicalConfigurationCriterionGroup[] = []
-
-  for (const row of [...criteria].sort(compareCanonicalCriteria)) {
-    const currentGroup = groups.at(-1)
-    if (currentGroup?.id === row.group.id) {
-      currentGroup.criteria.push(row)
-      continue
-    }
-
-    groups.push({
-      id: row.group.id,
-      name: row.group.name,
-      criteria: [row],
-    })
-  }
-
-  return groups
+  expandedRowIds?: ReadonlySet<string>
+  onExpandedRowIdsChange?: (expandedRowIds: ReadonlySet<string>) => void
 }
 
 function getCriterionStatus(
@@ -71,65 +42,196 @@ function getCriterionStatus(
 
 /** Renders the canonical criterion sequence with one compact manual-status badge per row. */
 export function TechnicalConfigurationCriterionList({
-  criteria,
+  rows,
+  hierarchyProgress,
   assessmentsByCriterionId,
   currentCriterionId,
   onSelectCriterion,
   disabled = false,
+  expandedRowIds,
+  onExpandedRowIdsChange,
 }: Readonly<TechnicalConfigurationCriterionListProps>) {
-  const groups = groupCanonicalCriteria(criteria)
+  const structuralRowIds = React.useMemo(
+    () =>
+      rows.flatMap((row) => {
+        if (row.kind === "criterion") return []
+        return [row.id]
+      }),
+    [rows]
+  )
+  const [collapsedRowIds, setCollapsedRowIds] = React.useState<ReadonlySet<string>>(() => new Set())
+  const aggregateProgress = React.useMemo(() => {
+    const sections = new Map<
+      string,
+      TechnicalConfigurationEvaluationProgress["hierarchy"][number]
+    >()
+    const subgroups = new Map<
+      string,
+      TechnicalConfigurationEvaluationProgress["hierarchy"][number]["subgroups"][number]
+    >()
+
+    for (const section of hierarchyProgress ?? []) {
+      sections.set(section.id, section)
+      for (const subgroup of section.subgroups) subgroups.set(subgroup.id, subgroup)
+    }
+
+    return { sections, subgroups }
+  }, [hierarchyProgress])
+  const isExpanded = React.useCallback(
+    (rowId: string) => (expandedRowIds ? expandedRowIds.has(rowId) : !collapsedRowIds.has(rowId)),
+    [collapsedRowIds, expandedRowIds]
+  )
+  const toggleRow = React.useCallback(
+    (rowId: string) => {
+      if (expandedRowIds) {
+        const nextExpandedRowIds = new Set(
+          structuralRowIds.filter((structuralRowId) =>
+            structuralRowId === rowId
+              ? !expandedRowIds.has(structuralRowId)
+              : expandedRowIds.has(structuralRowId)
+          )
+        )
+        onExpandedRowIdsChange?.(nextExpandedRowIds)
+        return
+      }
+
+      const nextCollapsedRowIds = new Set(collapsedRowIds)
+      if (nextCollapsedRowIds.has(rowId)) nextCollapsedRowIds.delete(rowId)
+      else nextCollapsedRowIds.add(rowId)
+      setCollapsedRowIds(nextCollapsedRowIds)
+      onExpandedRowIdsChange?.(
+        new Set(
+          structuralRowIds.filter((structuralRowId) => !nextCollapsedRowIds.has(structuralRowId))
+        )
+      )
+    },
+    [collapsedRowIds, expandedRowIds, onExpandedRowIdsChange, structuralRowIds]
+  )
 
   return (
     <nav aria-label="Danh sách tiêu chí đánh giá" className="divide-y border-y">
-      {groups.map((group) => (
-        <section key={group.id} aria-labelledby={`evaluation-group-${group.id}`}>
-          <h3
-            id={`evaluation-group-${group.id}`}
-            className="bg-muted/40 px-3 py-2 text-xs font-semibold text-muted-foreground"
-          >
-            {group.name}
-          </h3>
-          <div className="divide-y">
-            {group.criteria.map((row) => {
-              const criterionId = row.criterion.id
-              const status = getCriterionStatus(assessmentsByCriterionId[criterionId])
-              const isCurrent = criterionId === currentCriterionId
-
-              return (
-                <button
-                  key={criterionId}
-                  type="button"
-                  data-testid="evaluation-criterion"
-                  data-criterion-id={criterionId}
-                  aria-current={isCurrent ? "true" : undefined}
-                  disabled={disabled}
-                  className={cn(
-                    "grid min-h-16 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-l-2 border-l-transparent px-3 py-2.5 text-left outline-none transition-colors",
-                    "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-                    isCurrent && "border-l-primary bg-primary/10"
-                  )}
-                  onClick={() => onSelectCriterion(criterionId)}
-                >
-                  <span className="min-w-0">
-                    <span className="block text-xs font-medium text-muted-foreground">
-                      {row.criterion.criterionCode}
-                    </span>
-                    <span className="mt-1 block break-words text-sm font-medium leading-5">
-                      {row.criterion.title ?? "Chưa có tiêu đề"}
-                    </span>
+      {rows.map((hierarchyRow) => {
+        if (hierarchyRow.kind === "section") {
+          const expanded = isExpanded(hierarchyRow.id)
+          const progress = aggregateProgress.sections.get(hierarchyRow.id)
+          return (
+            <h3 key={`section:${hierarchyRow.id}`}>
+              <Button
+                type="button"
+                variant="ghost"
+                data-testid={`evaluation-hierarchy-section-${hierarchyRow.id}`}
+                aria-expanded={expanded}
+                disabled={disabled}
+                className="h-auto min-h-10 w-full justify-start whitespace-normal rounded-none bg-muted/40 px-3 py-2 text-left text-xs font-semibold text-muted-foreground"
+                onClick={() => toggleRow(hierarchyRow.id)}
+              >
+                {expanded ? (
+                  <ChevronDown className="size-4 shrink-0" aria-hidden="true" />
+                ) : (
+                  <ChevronRight className="size-4 shrink-0" aria-hidden="true" />
+                )}
+                <span className="min-w-0 flex-1 space-y-1">
+                  <span className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="break-words">{hierarchyRow.name}</span>
+                    {progress ? (
+                      <Badge variant="outline">
+                        {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                      </Badge>
+                    ) : null}
                   </span>
-                  <Badge
-                    variant={TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS[status]}
-                    className="max-w-32 justify-center whitespace-normal text-center"
-                  >
-                    {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[status]}
-                  </Badge>
-                </button>
-              )
-            })}
-          </div>
-        </section>
-      ))}
+                  {progress ? (
+                    <TechnicalConfigurationEvaluationHierarchyStatusCounts
+                      statusCounts={progress.statusCounts}
+                      testId={`evaluation-hierarchy-section-status-counts-${hierarchyRow.id}`}
+                    />
+                  ) : null}
+                </span>
+              </Button>
+            </h3>
+          )
+        }
+
+        if (hierarchyRow.kind === "subgroup") {
+          if (!isExpanded(hierarchyRow.sectionId)) return null
+          const expanded = isExpanded(hierarchyRow.id)
+          const progress = aggregateProgress.subgroups.get(hierarchyRow.id)
+          return (
+            <Button
+              key={`subgroup:${hierarchyRow.id}`}
+              type="button"
+              variant="ghost"
+              data-testid={`evaluation-hierarchy-subgroup-${hierarchyRow.id}`}
+              aria-expanded={expanded}
+              disabled={disabled}
+              className="h-auto min-h-10 w-full justify-start whitespace-normal rounded-none bg-muted/20 px-6 py-2 text-left text-xs font-medium text-muted-foreground"
+              onClick={() => toggleRow(hierarchyRow.id)}
+            >
+              {expanded ? (
+                <ChevronDown className="size-4 shrink-0" aria-hidden="true" />
+              ) : (
+                <ChevronRight className="size-4 shrink-0" aria-hidden="true" />
+              )}
+              <span className="min-w-0 flex-1 space-y-1">
+                <span className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="break-words">{hierarchyRow.name}</span>
+                  {progress ? (
+                    <Badge variant="outline">
+                      {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[progress.status]}
+                    </Badge>
+                  ) : null}
+                </span>
+                {progress ? (
+                  <TechnicalConfigurationEvaluationHierarchyStatusCounts
+                    statusCounts={progress.statusCounts}
+                    testId={`evaluation-hierarchy-subgroup-status-counts-${hierarchyRow.id}`}
+                  />
+                ) : null}
+              </span>
+            </Button>
+          )
+        }
+
+        const row = hierarchyRow.row
+        if (!isExpanded(row.group.id) || (row.subgroup && !isExpanded(row.subgroup.id))) {
+          return null
+        }
+        const criterionId = row.criterion.id
+        const status = getCriterionStatus(assessmentsByCriterionId[criterionId])
+        const isCurrent = criterionId === currentCriterionId
+
+        return (
+          <button
+            key={criterionId}
+            type="button"
+            data-testid="evaluation-criterion"
+            data-criterion-id={criterionId}
+            aria-current={isCurrent ? "true" : undefined}
+            disabled={disabled}
+            className={cn(
+              "grid min-h-16 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-l-2 border-l-transparent px-3 py-2.5 text-left outline-none transition-colors",
+              "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+              row.subgroup && "pl-9",
+              isCurrent && "border-l-primary bg-primary/10"
+            )}
+            onClick={() => onSelectCriterion(criterionId)}
+          >
+            <span className="min-w-0">
+              <span className="block text-xs font-medium text-muted-foreground">
+                {row.criterion.criterionCode}
+              </span>
+              <span className="mt-1 block break-words text-sm font-medium leading-5">
+                {row.criterion.title ?? "Chưa có tiêu đề"}
+              </span>
+            </span>
+            <Badge
+              variant={TECHNICAL_CONFIGURATION_EVALUATION_STATUS_BADGE_VARIANTS[status]}
+              className="max-w-32 justify-center whitespace-normal text-center"
+            >
+              {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[status]}
+            </Badge>
+          </button>
+        )
+      })}
     </nav>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -24,6 +24,7 @@ import { buildTechnicalConfigurationEvaluationMatrixPresentation } from "./techn
 import { TechnicalConfigurationEvaluationFeedback } from "./TechnicalConfigurationEvaluationFeedback"
 import { TechnicalConfigurationEvaluationMatrixControls } from "./TechnicalConfigurationEvaluationMatrixControls"
 import { TechnicalConfigurationEvaluationMatrixToolbar } from "./TechnicalConfigurationEvaluationMatrixToolbar"
+import { TechnicalConfigurationEvaluationNavigatorPane } from "./TechnicalConfigurationEvaluationNavigatorPane"
 import { TechnicalConfigurationEvaluationPanel } from "./TechnicalConfigurationEvaluationPanel"
 import { TechnicalConfigurationProgressSummary } from "./TechnicalConfigurationProgressSummary"
 import { TechnicalConfigurationResultExportControl } from "./TechnicalConfigurationResultExportControl"
@@ -101,6 +102,7 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
       onDiscard: evaluation.discard,
     })
   const hasEvaluationReadError = comparisonSetQuery.isError || assessmentQuery.isError
+  const isEvaluationReadLoading = comparisonSetQuery.isLoading || assessmentQuery.isLoading
   const evaluationReadError = comparisonSetQuery.isError
     ? comparisonSetQuery.error
     : assessmentQuery.error
@@ -224,8 +226,41 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
 
       <TechnicalConfigurationProgressSummary
         progress={matrixPresentation.progress}
-        isLoading={comparisonSetQuery.isLoading || assessmentQuery.isLoading}
+        isLoading={isEvaluationReadLoading}
         isError={hasEvaluationReadError}
+      />
+
+      <TechnicalConfigurationEvaluationNavigatorPane
+        statusFilter={navigator.statusFilter}
+        onStatusFilterChange={handleFilterChange}
+        criteria={navigator.hierarchyRows}
+        progress={matrixPresentation.progress}
+        assessmentsByCriterionId={evaluation.assessmentsByCriterionId}
+        currentCriterionId={navigator.criterionId}
+        onSelectCriterion={(criterionId) => {
+          navigator.changeCriterion(criterionId, requestNavigation, () => {
+            evaluationReturnFocusRef.current =
+              document.activeElement instanceof HTMLElement ? document.activeElement : null
+          })
+        }}
+        listOnly
+        page={matrix.page}
+        pageSize={TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE}
+        total={navigator.projection.length}
+        onPageChange={handleMatrixPageChange}
+        disabled={isNavigationBlocked}
+        isLoading={
+          navigator.criteriaQuery.isLoading ||
+          navigator.isTransitionPending ||
+          isEvaluationReadLoading
+        }
+        isError={navigator.criteriaQuery.isError || hasEvaluationReadError}
+        error={hasEvaluationReadError ? evaluationReadError : navigator.criteriaQuery.error}
+        onRetry={handleRetryEvaluationData}
+        isCurrentCriterionFilteredOut={navigator.isCurrentCriterionFilteredOut}
+        hasNoMoreMatches={navigator.hasNoMoreMatches}
+        expandedRowIds={navigator.expandedRowIds}
+        onExpandedRowIdsChange={navigator.onExpandedRowIdsChange}
       />
 
       <TechnicalConfigurationMatrix

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationHierarchyStatusCounts.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationHierarchyStatusCounts.tsx
@@ -1,0 +1,29 @@
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+} from "@/lib/technical-configuration-evaluation"
+import type { TechnicalConfigurationDerivedStatusCounts } from "@/lib/technical-configuration-hierarchy-aggregate-status"
+
+type TechnicalConfigurationEvaluationHierarchyStatusCountsProps = {
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+  testId: string
+}
+
+/** Renders the canonical derived-status counts for one authoritative aggregate. */
+export function TechnicalConfigurationEvaluationHierarchyStatusCounts({
+  statusCounts,
+  testId,
+}: Readonly<TechnicalConfigurationEvaluationHierarchyStatusCountsProps>) {
+  return (
+    <span
+      className="flex flex-wrap justify-end gap-x-2 gap-y-0.5 text-[11px] font-normal leading-4 text-muted-foreground"
+      data-testid={testId}
+    >
+      {TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES.map((status) => (
+        <span key={status} className="whitespace-nowrap tabular-nums">
+          {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[status]}: {statusCounts[status]}
+        </span>
+      ))}
+    </span>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationLoadError.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationLoadError.tsx
@@ -9,7 +9,7 @@ type TechnicalConfigurationEvaluationLoadErrorProps = {
   title: string
   error: unknown
   fallback: string
-  onRetry: () => void
+  onRetry?: () => void
 }
 
 function toErrorMessage(error: unknown, fallback: string): string {
@@ -29,10 +29,12 @@ export function TechnicalConfigurationEvaluationLoadError({
       <AlertTitle>{title}</AlertTitle>
       <AlertDescription className="space-y-3">
         <p>{toErrorMessage(error, fallback)}</p>
-        <Button type="button" variant="outline" size="sm" onClick={onRetry}>
-          <RefreshCw className="size-4" aria-hidden="true" />
-          Thử lại
-        </Button>
+        {onRetry ? (
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        ) : null}
       </AlertDescription>
     </Alert>
   )

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx
@@ -74,18 +74,25 @@ export function TechnicalConfigurationEvaluationNavigatorPane({
           disabled={disabled}
         />
       )}
-      {!listOnly && isLoading ? (
-        <div className="flex min-h-24 items-center justify-center gap-2 text-sm text-muted-foreground">
+      {isLoading ? (
+        <div
+          className="flex min-h-24 items-center justify-center gap-2 text-sm text-muted-foreground"
+          role="status"
+        >
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-          Đang lọc tiêu chí...
+          {listOnly ? "Đang tải tiêu chí đánh giá..." : "Đang lọc tiêu chí..."}
         </div>
       ) : null}
-      {!listOnly && isError ? (
+      {isError ? (
         <TechnicalConfigurationEvaluationLoadError
-          title="Không thể lọc tiêu chí đánh giá"
+          title={listOnly ? "Không thể tải tiêu chí đánh giá" : "Không thể lọc tiêu chí đánh giá"}
           error={error}
-          fallback="Không thể tải danh sách tiêu chí đã lọc."
-          onRetry={onRetry}
+          fallback={
+            listOnly
+              ? "Không thể tải danh sách tiêu chí đánh giá."
+              : "Không thể tải danh sách tiêu chí đã lọc."
+          }
+          onRetry={listOnly ? undefined : onRetry}
         />
       ) : null}
       {!listOnly && !isLoading && !isError && total === 0 ? (

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationNavigatorPane.tsx
@@ -10,7 +10,9 @@ import type {
   TechnicalConfigurationEvaluationStatusFilter,
 } from "../../assessment-types"
 import { TechnicalConfigurationCriterionPagination } from "../comparison/TechnicalConfigurationCriterionPagination"
+import type { TechnicalConfigurationEvaluationHierarchyRow } from "./technical-configuration-evaluation-hierarchy"
 import type { TechnicalConfigurationEvaluationCriterionListItem } from "./technical-configuration-evaluation-navigation"
+import type { TechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
 import { TechnicalConfigurationCriterionList } from "./TechnicalConfigurationCriterionList"
 import { TechnicalConfigurationEvaluationFilters } from "./TechnicalConfigurationEvaluationFilters"
 import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
@@ -18,7 +20,8 @@ import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurat
 type TechnicalConfigurationEvaluationNavigatorPaneProps = {
   statusFilter: TechnicalConfigurationEvaluationStatusFilter
   onStatusFilterChange: (value: TechnicalConfigurationEvaluationStatusFilter) => void
-  criteria: readonly TechnicalConfigurationEvaluationCriterionListItem[]
+  criteria: readonly TechnicalConfigurationEvaluationHierarchyRow<TechnicalConfigurationEvaluationCriterionListItem>[]
+  progress: TechnicalConfigurationEvaluationProgress | null
   assessmentsByCriterionId: Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
   currentCriterionId: string | null
   onSelectCriterion: (criterionId: string) => void
@@ -33,13 +36,17 @@ type TechnicalConfigurationEvaluationNavigatorPaneProps = {
   onRetry: () => void
   isCurrentCriterionFilteredOut: boolean
   hasNoMoreMatches: boolean
+  listOnly?: boolean
+  expandedRowIds?: ReadonlySet<string>
+  onExpandedRowIdsChange?: (expandedRowIds: ReadonlySet<string>) => void
 }
 
-/** Renders P12B2 filters, filtered list, pagination and deterministic end states. */
+/** Renders the filtered hierarchy with optional standalone controls and status chrome. */
 export function TechnicalConfigurationEvaluationNavigatorPane({
   statusFilter,
   onStatusFilterChange,
   criteria,
+  progress,
   assessmentsByCriterionId,
   currentCriterionId,
   onSelectCriterion,
@@ -54,21 +61,26 @@ export function TechnicalConfigurationEvaluationNavigatorPane({
   onRetry,
   isCurrentCriterionFilteredOut,
   hasNoMoreMatches,
+  listOnly = false,
+  expandedRowIds,
+  onExpandedRowIdsChange,
 }: Readonly<TechnicalConfigurationEvaluationNavigatorPaneProps>) {
   return (
     <div className="space-y-3">
-      <TechnicalConfigurationEvaluationFilters
-        value={statusFilter}
-        onValueChange={onStatusFilterChange}
-        disabled={disabled}
-      />
-      {isLoading ? (
+      {listOnly ? null : (
+        <TechnicalConfigurationEvaluationFilters
+          value={statusFilter}
+          onValueChange={onStatusFilterChange}
+          disabled={disabled}
+        />
+      )}
+      {!listOnly && isLoading ? (
         <div className="flex min-h-24 items-center justify-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
           Đang lọc tiêu chí...
         </div>
       ) : null}
-      {isError ? (
+      {!listOnly && isError ? (
         <TechnicalConfigurationEvaluationLoadError
           title="Không thể lọc tiêu chí đánh giá"
           error={error}
@@ -76,7 +88,7 @@ export function TechnicalConfigurationEvaluationNavigatorPane({
           onRetry={onRetry}
         />
       ) : null}
-      {!isLoading && !isError && total === 0 ? (
+      {!listOnly && !isLoading && !isError && total === 0 ? (
         <Alert>
           <AlertTitle>Không có tiêu chí phù hợp</AlertTitle>
           <AlertDescription>
@@ -92,12 +104,12 @@ export function TechnicalConfigurationEvaluationNavigatorPane({
           </AlertDescription>
         </Alert>
       ) : null}
-      {isCurrentCriterionFilteredOut ? (
+      {!listOnly && isCurrentCriterionFilteredOut ? (
         <p className="text-sm text-muted-foreground" role="status">
           Tiêu chí đang mở không còn phù hợp với bộ lọc sau khi lưu.
         </p>
       ) : null}
-      {hasNoMoreMatches ? (
+      {!listOnly && hasNoMoreMatches ? (
         <p className="text-sm text-muted-foreground" role="status">
           Không còn tiêu chí phù hợp với bộ lọc.
         </p>
@@ -105,19 +117,24 @@ export function TechnicalConfigurationEvaluationNavigatorPane({
       {!isLoading && !isError && total > 0 ? (
         <>
           <TechnicalConfigurationCriterionList
-            criteria={criteria}
+            rows={criteria}
+            hierarchyProgress={progress?.hierarchy ?? null}
             assessmentsByCriterionId={assessmentsByCriterionId}
             currentCriterionId={currentCriterionId}
             onSelectCriterion={onSelectCriterion}
             disabled={disabled}
+            expandedRowIds={expandedRowIds}
+            onExpandedRowIdsChange={onExpandedRowIdsChange}
           />
-          <TechnicalConfigurationCriterionPagination
-            page={page}
-            pageSize={pageSize}
-            total={total}
-            onPageChange={onPageChange}
-            disabled={disabled}
-          />
+          {listOnly ? null : (
+            <TechnicalConfigurationCriterionPagination
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={onPageChange}
+              disabled={disabled}
+            />
+          )}
         </>
       ) : null}
     </div>

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
@@ -1,8 +1,11 @@
 import { Layers, ListChecks } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { StatCard } from "@/components/ui/stat-card"
+import { TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS } from "@/lib/technical-configuration-hierarchy-aggregate-status"
 
 import type { TechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
+import { TechnicalConfigurationEvaluationHierarchyStatusCounts } from "./TechnicalConfigurationEvaluationHierarchyStatusCounts"
 
 type TechnicalConfigurationProgressSummaryProps = {
   progress: TechnicalConfigurationEvaluationProgress
@@ -10,7 +13,7 @@ type TechnicalConfigurationProgressSummaryProps = {
   isError: boolean
 }
 
-/** Renders compact selected-option progress without scoring or status breakdowns. */
+/** Renders selected-option progress and authoritative hierarchy status breakdowns. */
 export function TechnicalConfigurationProgressSummary({
   progress,
   isLoading,
@@ -72,6 +75,58 @@ export function TechnicalConfigurationProgressSummary({
               value={`${group.evaluated} / ${group.total}`}
               icon={<ListChecks className="size-5" aria-hidden="true" />}
             />
+          </div>
+        ))}
+      </div>
+
+      <TechnicalConfigurationEvaluationHierarchyStatusCounts
+        statusCounts={progress.statusCounts}
+        testId="evaluation-progress-status-counts-overall"
+      />
+
+      <div className="divide-y border-y" aria-label="Tiến độ theo cấu trúc">
+        {progress.hierarchy.map((section) => (
+          <div key={section.id} data-testid={`evaluation-progress-section-${section.id}`}>
+            <div className="grid min-h-11 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-3 py-2">
+              <p className="min-w-0 break-words text-sm font-semibold">{section.name}</p>
+              <Badge variant="outline">
+                {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[section.status]}
+              </Badge>
+              <span className="text-sm tabular-nums text-muted-foreground">
+                {section.evaluated} / {section.total} tiêu chí
+              </span>
+            </div>
+            <div className="px-3 pb-2">
+              <TechnicalConfigurationEvaluationHierarchyStatusCounts
+                statusCounts={section.statusCounts}
+                testId={`evaluation-progress-section-status-counts-${section.id}`}
+              />
+            </div>
+            {section.subgroups.length > 0 ? (
+              <div className="divide-y border-t bg-muted/20">
+                {section.subgroups.map((subgroup) => (
+                  <div
+                    key={subgroup.id}
+                    data-testid={`evaluation-progress-subgroup-${subgroup.id}`}
+                    className="grid min-h-10 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 px-3 py-2 pl-8"
+                  >
+                    <p className="min-w-0 break-words text-sm">{subgroup.name}</p>
+                    <Badge variant="outline">
+                      {TECHNICAL_CONFIGURATION_AGGREGATE_STATUS_LABELS[subgroup.status]}
+                    </Badge>
+                    <span className="text-sm tabular-nums text-muted-foreground">
+                      {subgroup.evaluated} / {subgroup.total} tiêu chí
+                    </span>
+                    <span className="col-span-3">
+                      <TechnicalConfigurationEvaluationHierarchyStatusCounts
+                        statusCounts={subgroup.statusCounts}
+                        testId={`evaluation-progress-subgroup-status-counts-${subgroup.id}`}
+                      />
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
           </div>
         ))}
       </div>

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-hierarchy.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-hierarchy.ts
@@ -1,0 +1,254 @@
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+  TechnicalConfigurationBaselineSubgroupWire,
+} from "../../baseline-types"
+
+export type TechnicalConfigurationEvaluationHierarchyGroup = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+}>
+
+export type TechnicalConfigurationEvaluationHierarchySubgroup = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+}>
+
+export type TechnicalConfigurationEvaluationHierarchyCriterion = Readonly<{
+  id: string
+  criterionCode: string
+  title: string | null
+  sortOrder: number
+}>
+
+export type TechnicalConfigurationEvaluationHierarchyLeaf = Readonly<{
+  group: TechnicalConfigurationEvaluationHierarchyGroup
+  subgroup?: TechnicalConfigurationEvaluationHierarchySubgroup
+  criterion: TechnicalConfigurationEvaluationHierarchyCriterion
+  canonicalIndex: number
+}>
+
+export type TechnicalConfigurationEvaluationHierarchySubgroupSection = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+  criterionIds: readonly string[]
+}>
+
+export type TechnicalConfigurationEvaluationHierarchySection = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+  criterionIds: readonly string[]
+  subgroups: readonly TechnicalConfigurationEvaluationHierarchySubgroupSection[]
+}>
+
+export type TechnicalConfigurationEvaluationHierarchyRow<
+  TLeaf extends TechnicalConfigurationEvaluationHierarchyLeaf =
+    TechnicalConfigurationEvaluationHierarchyLeaf,
+> =
+  | Readonly<{
+      kind: "section"
+      id: string
+      name: string
+    }>
+  | Readonly<{
+      kind: "subgroup"
+      id: string
+      sectionId: string
+      name: string
+    }>
+  | Readonly<{
+      kind: "criterion"
+      row: TLeaf
+    }>
+
+type HierarchyLeafCandidate = Readonly<{
+  group: TechnicalConfigurationBaselineGroupWire
+  subgroup?: TechnicalConfigurationBaselineSubgroupWire
+  criterion: TechnicalConfigurationBaselineCriterionWire
+}>
+
+function compareNumber(left: number, right: number): number {
+  return left - right
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right)
+}
+
+function compareCandidates(left: HierarchyLeafCandidate, right: HierarchyLeafCandidate): number {
+  return (
+    compareNumber(left.group.sort_order, right.group.sort_order) ||
+    compareText(left.group.id, right.group.id) ||
+    compareNumber(left.subgroup ? 1 : 0, right.subgroup ? 1 : 0) ||
+    compareNumber(left.subgroup?.sort_order ?? 0, right.subgroup?.sort_order ?? 0) ||
+    compareText(left.subgroup?.id ?? "", right.subgroup?.id ?? "") ||
+    compareNumber(left.criterion.sort_order, right.criterion.sort_order) ||
+    compareText(left.criterion.id, right.criterion.id)
+  )
+}
+
+function toGroup(
+  group: TechnicalConfigurationBaselineGroupWire
+): TechnicalConfigurationEvaluationHierarchyGroup {
+  return {
+    id: group.id,
+    name: group.name,
+    sortOrder: group.sort_order,
+  }
+}
+
+function toSubgroup(
+  subgroup: TechnicalConfigurationBaselineSubgroupWire
+): TechnicalConfigurationEvaluationHierarchySubgroup {
+  return {
+    id: subgroup.id,
+    name: subgroup.name,
+    sortOrder: subgroup.sort_order,
+  }
+}
+
+function toCriterion(
+  criterion: TechnicalConfigurationBaselineCriterionWire
+): TechnicalConfigurationEvaluationHierarchyCriterion {
+  return {
+    id: criterion.id,
+    criterionCode: criterion.criterion_code,
+    title: criterion.title,
+    sortOrder: criterion.sort_order,
+  }
+}
+
+function collectCandidates(
+  groups: readonly TechnicalConfigurationBaselineGroupWire[]
+): HierarchyLeafCandidate[] {
+  const candidates: HierarchyLeafCandidate[] = []
+
+  for (const group of groups) {
+    for (const criterion of group.criteria) {
+      if (criterion.group_id !== group.id || criterion.subgroup_id != null) continue
+      candidates.push({ group, criterion })
+    }
+
+    for (const subgroup of group.subgroups ?? []) {
+      if (subgroup.group_id !== group.id) continue
+      for (const criterion of subgroup.criteria) {
+        if (criterion.group_id !== group.id || criterion.subgroup_id !== subgroup.id) {
+          continue
+        }
+        candidates.push({ group, subgroup, criterion })
+      }
+    }
+  }
+
+  return candidates
+}
+
+/** Flattens one baseline into the immutable canonical evaluation leaf sequence. */
+export function flattenTechnicalConfigurationEvaluationLeaves(
+  groups: readonly TechnicalConfigurationBaselineGroupWire[]
+): TechnicalConfigurationEvaluationHierarchyLeaf[] {
+  const emittedCriterionIds = new Set<string>()
+  const leaves: TechnicalConfigurationEvaluationHierarchyLeaf[] = []
+
+  for (const candidate of collectCandidates(groups).sort(compareCandidates)) {
+    if (emittedCriterionIds.has(candidate.criterion.id)) continue
+    emittedCriterionIds.add(candidate.criterion.id)
+    leaves.push({
+      group: toGroup(candidate.group),
+      ...(candidate.subgroup ? { subgroup: toSubgroup(candidate.subgroup) } : {}),
+      criterion: toCriterion(candidate.criterion),
+      canonicalIndex: leaves.length + 1,
+    })
+  }
+
+  return leaves
+}
+
+/** Builds structural inputs for full-universe section and subgroup aggregates. */
+export function buildTechnicalConfigurationEvaluationHierarchySections(
+  groups: readonly TechnicalConfigurationBaselineGroupWire[],
+  leaves: readonly TechnicalConfigurationEvaluationHierarchyLeaf[]
+): TechnicalConfigurationEvaluationHierarchySection[] {
+  const directCriterionIdsByGroupId = new Map<string, string[]>()
+  const criterionIdsBySubgroupId = new Map<string, string[]>()
+
+  for (const leaf of leaves) {
+    const groupId = leaf.group.id
+    const criterionId = leaf.criterion.id
+    const subgroupId = leaf.subgroup?.id
+    const criterionIdsByOwner = subgroupId ? criterionIdsBySubgroupId : directCriterionIdsByGroupId
+    const ownerId = subgroupId ?? groupId
+    const criterionIds = criterionIdsByOwner.get(ownerId)
+    if (criterionIds) criterionIds.push(criterionId)
+    else criterionIdsByOwner.set(ownerId, [criterionId])
+  }
+
+  const sortedGroups = [...groups].sort(
+    (left, right) =>
+      compareNumber(left.sort_order, right.sort_order) || compareText(left.id, right.id)
+  )
+
+  return sortedGroups.map((group) => {
+    const validSubgroups = (group.subgroups ?? [])
+      .filter((subgroup) => subgroup.group_id === group.id)
+      .sort(
+        (left, right) =>
+          compareNumber(left.sort_order, right.sort_order) || compareText(left.id, right.id)
+      )
+
+    return {
+      id: group.id,
+      name: group.name,
+      sortOrder: group.sort_order,
+      criterionIds: directCriterionIdsByGroupId.get(group.id) ?? [],
+      subgroups: validSubgroups.map((subgroup) => ({
+        id: subgroup.id,
+        name: subgroup.name,
+        sortOrder: subgroup.sort_order,
+        criterionIds: criterionIdsBySubgroupId.get(subgroup.id) ?? [],
+      })),
+    }
+  })
+}
+
+/** Wraps supplied page leaves with only their page-local ancestor headings. */
+export function buildTechnicalConfigurationEvaluationHierarchyRows<
+  TLeaf extends TechnicalConfigurationEvaluationHierarchyLeaf,
+>(leaves: readonly TLeaf[]): TechnicalConfigurationEvaluationHierarchyRow<TLeaf>[] {
+  const rows: TechnicalConfigurationEvaluationHierarchyRow<TLeaf>[] = []
+  let currentSectionId: string | null = null
+  let currentSubgroupId: string | null = null
+
+  for (const leaf of leaves) {
+    const { group, subgroup } = leaf
+    if (group.id !== currentSectionId) {
+      currentSectionId = group.id
+      currentSubgroupId = null
+      rows.push({
+        kind: "section",
+        id: group.id,
+        name: group.name,
+      })
+    }
+
+    if (subgroup && subgroup.id !== currentSubgroupId) {
+      currentSubgroupId = subgroup.id
+      rows.push({
+        kind: "subgroup",
+        id: subgroup.id,
+        sectionId: group.id,
+        name: subgroup.name,
+      })
+    } else if (!subgroup) {
+      currentSubgroupId = null
+    }
+
+    rows.push({ kind: "criterion", row: leaf })
+  }
+
+  return rows
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-navigation.ts
@@ -1,69 +1,39 @@
-import type {
-  TechnicalConfigurationBaselineCriterionWire,
-  TechnicalConfigurationBaselineGroupWire,
-} from "../../baseline-types"
 import type { TechnicalConfigurationEvaluationCriterionWire } from "../../assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+import {
+  flattenTechnicalConfigurationEvaluationLeaves,
+  type TechnicalConfigurationEvaluationHierarchyLeaf,
+} from "./technical-configuration-evaluation-hierarchy"
 
-export type TechnicalConfigurationEvaluationCriterionListItem = {
-  group: {
-    id: string
-    name: string
-    sortOrder: number
+export type TechnicalConfigurationEvaluationCriterionListItem =
+  TechnicalConfigurationEvaluationHierarchyLeaf & {
+    canonicalIndex: number
+    canonicalPage: number
   }
-  criterion: {
-    id: string
-    criterionCode: string
-    title: string | null
-    sortOrder: number
-  }
-  canonicalIndex: number
-  canonicalPage: number
-}
 
 function toProjectionItem({
-  group,
-  criterion,
+  leaf,
   canonicalIndex,
   canonicalPage,
 }: {
-  group: TechnicalConfigurationBaselineGroupWire
-  criterion: TechnicalConfigurationBaselineCriterionWire
+  leaf: Omit<TechnicalConfigurationEvaluationHierarchyLeaf, "canonicalIndex">
   canonicalIndex: number
   canonicalPage: number
 }): TechnicalConfigurationEvaluationCriterionListItem {
   return {
-    group: {
-      id: group.id,
-      name: group.name,
-      sortOrder: group.sort_order,
-    },
-    criterion: {
-      id: criterion.id,
-      criterionCode: criterion.criterion_code,
-      title: criterion.title,
-      sortOrder: criterion.sort_order,
-    },
+    ...leaf,
     canonicalIndex,
     canonicalPage,
   }
 }
 
-function buildBaselineCriterionIndex(groups: readonly TechnicalConfigurationBaselineGroupWire[]) {
-  const criteria = new Map<
-    string,
-    {
-      group: TechnicalConfigurationBaselineGroupWire
-      criterion: TechnicalConfigurationBaselineCriterionWire
-    }
-  >()
-
-  for (const group of groups) {
-    for (const criterion of group.criteria) {
-      criteria.set(criterion.id, { group, criterion })
-    }
-  }
-
-  return criteria
+function buildProjectionLeafIndex(groups: readonly TechnicalConfigurationBaselineGroupWire[]) {
+  return new Map(
+    flattenTechnicalConfigurationEvaluationLeaves(groups).map((leaf) => {
+      const { canonicalIndex: _canonicalIndex, ...projectionLeaf } = leaf
+      return [leaf.criterion.id, projectionLeaf] as const
+    })
+  )
 }
 
 /** Maps exact server-filtered IDs to baseline display rows without re-filtering locally. */
@@ -74,14 +44,14 @@ export function buildTechnicalConfigurationEvaluationProjection({
   groups: readonly TechnicalConfigurationBaselineGroupWire[]
   entries: readonly TechnicalConfigurationEvaluationCriterionWire[]
 }): TechnicalConfigurationEvaluationCriterionListItem[] {
-  const criteriaById = buildBaselineCriterionIndex(groups)
+  const leavesById = buildProjectionLeafIndex(groups)
 
   return entries.flatMap((entry) => {
-    const baselineCriterion = criteriaById.get(entry.criterion_id)
-    return baselineCriterion
+    const leaf = leavesById.get(entry.criterion_id)
+    return leaf
       ? [
           toProjectionItem({
-            ...baselineCriterion,
+            leaf,
             canonicalIndex: entry.canonical_index,
             canonicalPage: entry.canonical_page,
           }),
@@ -127,20 +97,15 @@ export function findTechnicalConfigurationEvaluationCriterion({
 }): TechnicalConfigurationEvaluationCriterionListItem | null {
   if (!criterionId) return null
 
-  let canonicalIndex = 0
-  for (const group of groups) {
-    for (const criterion of group.criteria) {
-      canonicalIndex += 1
-      if (criterion.id === criterionId) {
-        return toProjectionItem({
-          group,
-          criterion,
-          canonicalIndex,
-          canonicalPage: Math.ceil(canonicalIndex / pageSize),
-        })
-      }
-    }
-  }
+  const leaf = flattenTechnicalConfigurationEvaluationLeaves(groups).find(
+    (item) => item.criterion.id === criterionId
+  )
+  if (!leaf) return null
 
-  return null
+  const { canonicalIndex, ...projectionLeaf } = leaf
+  return toProjectionItem({
+    leaf: projectionLeaf,
+    canonicalIndex,
+    canonicalPage: Math.ceil(canonicalIndex / pageSize),
+  })
 }

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
@@ -2,9 +2,18 @@ import {
   deriveTechnicalConfigurationEvaluationStatus,
   type TechnicalConfigurationDerivedStatus,
 } from "@/lib/technical-configuration-evaluation"
+import {
+  buildTechnicalConfigurationHierarchyAggregateStatus,
+  type TechnicalConfigurationAggregateStatus,
+  type TechnicalConfigurationDerivedStatusCounts,
+} from "@/lib/technical-configuration-hierarchy-aggregate-status"
 
 import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
 import type { TechnicalConfigurationBaselineGroupWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  buildTechnicalConfigurationEvaluationHierarchySections,
+  flattenTechnicalConfigurationEvaluationLeaves,
+} from "./technical-configuration-evaluation-hierarchy"
 
 /** Compact progress for one canonical baseline group. */
 export type TechnicalConfigurationEvaluationGroupProgress = Readonly<{
@@ -14,12 +23,34 @@ export type TechnicalConfigurationEvaluationGroupProgress = Readonly<{
   evaluated: number
 }>
 
+export type TechnicalConfigurationEvaluationSubgroupAggregateProgress = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+  total: number
+  evaluated: number
+  status: TechnicalConfigurationAggregateStatus
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+}>
+
+export type TechnicalConfigurationEvaluationSectionAggregateProgress = Readonly<{
+  id: string
+  name: string
+  sortOrder: number
+  total: number
+  evaluated: number
+  status: TechnicalConfigurationAggregateStatus
+  statusCounts: TechnicalConfigurationDerivedStatusCounts
+  subgroups: readonly TechnicalConfigurationEvaluationSubgroupAggregateProgress[]
+}>
+
 /** Full-universe progress for the currently selected option. */
 export type TechnicalConfigurationEvaluationProgress = Readonly<{
   total: number
   evaluated: number
   statusCounts: Readonly<Record<TechnicalConfigurationDerivedStatus, number>>
   groups: readonly TechnicalConfigurationEvaluationGroupProgress[]
+  hierarchy: readonly TechnicalConfigurationEvaluationSectionAggregateProgress[]
 }>
 
 type BuildTechnicalConfigurationEvaluationProgressInput = Readonly<{
@@ -27,16 +58,10 @@ type BuildTechnicalConfigurationEvaluationProgressInput = Readonly<{
   assessments: readonly TechnicalConfigurationAssessmentWire[]
 }>
 
-function createEmptyStatusCounts(): Record<TechnicalConfigurationDerivedStatus, number> {
-  return {
-    not_evaluated: 0,
-    not_applicable: 0,
-    fails: 0,
-    unclear: 0,
-    insufficient_evidence: 0,
-    exceeds: 0,
-    meets: 0,
-  }
+function countEvaluated(statusCounts: TechnicalConfigurationDerivedStatusCounts): number {
+  return (
+    Object.values(statusCounts).reduce((sum, count) => sum + count, 0) - statusCounts.not_evaluated
+  )
 }
 
 /** Reconciles complete assessments by criterion ID against one locked baseline universe. */
@@ -44,43 +69,71 @@ export function buildTechnicalConfigurationEvaluationProgress({
   groups,
   assessments,
 }: BuildTechnicalConfigurationEvaluationProgressInput): TechnicalConfigurationEvaluationProgress {
+  const leaves = flattenTechnicalConfigurationEvaluationLeaves(groups)
+  const hierarchySections = buildTechnicalConfigurationEvaluationHierarchySections(groups, leaves)
   const assessmentsByCriterionId = new Map(
-    assessments.map((assessment) => [assessment.criterion_id, assessment])
+    assessments.map((assessment) => [assessment.criterion_id, assessment] as const)
   )
-  let statusCounts = createEmptyStatusCounts()
-  let evaluated = 0
-
-  const groupProgress = groups.map((group) => {
-    let groupEvaluated = 0
-
-    for (const criterion of group.criteria) {
-      const assessment = assessmentsByCriterionId.get(criterion.id)
-      const status = deriveTechnicalConfigurationEvaluationStatus(
-        assessment?.technical_axis,
-        assessment?.evidence_axis
-      )
-      statusCounts = {
-        ...statusCounts,
-        [status]: statusCounts[status] + 1,
-      }
-      if (status !== "not_evaluated") {
-        evaluated += 1
-        groupEvaluated += 1
-      }
-    }
+  const statusByCriterionId = new Map(
+    leaves.map((leaf) => {
+      const assessment = assessmentsByCriterionId.get(leaf.criterion.id)
+      return [
+        leaf.criterion.id,
+        deriveTechnicalConfigurationEvaluationStatus(
+          assessment?.technical_axis,
+          assessment?.evidence_axis
+        ),
+      ] as const
+    })
+  )
+  const aggregate = buildTechnicalConfigurationHierarchyAggregateStatus({
+    sections: hierarchySections,
+    statusByCriterionId,
+  })
+  const sectionById = new Map(aggregate.sections.map((section) => [section.id, section]))
+  const hierarchy = hierarchySections.map((section) => {
+    const sectionAggregate = sectionById.get(section.id)
+    if (!sectionAggregate) throw new Error(`Missing aggregate section ${section.id}`)
+    const subgroupById = new Map(
+      sectionAggregate.subgroups.map((subgroup) => [subgroup.id, subgroup])
+    )
 
     return {
-      id: group.id,
-      name: group.name,
-      total: group.criteria.length,
-      evaluated: groupEvaluated,
+      id: section.id,
+      name: section.name,
+      sortOrder: section.sortOrder,
+      total: sectionAggregate.descendantCount,
+      evaluated: countEvaluated(sectionAggregate.statusCounts),
+      status: sectionAggregate.status,
+      statusCounts: sectionAggregate.statusCounts,
+      subgroups: section.subgroups.map((subgroup) => {
+        const subgroupAggregate = subgroupById.get(subgroup.id)
+        if (!subgroupAggregate) {
+          throw new Error(`Missing aggregate subgroup ${subgroup.id}`)
+        }
+        return {
+          id: subgroup.id,
+          name: subgroup.name,
+          sortOrder: subgroup.sortOrder,
+          total: subgroupAggregate.descendantCount,
+          evaluated: countEvaluated(subgroupAggregate.statusCounts),
+          status: subgroupAggregate.status,
+          statusCounts: subgroupAggregate.statusCounts,
+        }
+      }),
     }
   })
 
   return {
-    total: groupProgress.reduce((sum, group) => sum + group.total, 0),
-    evaluated,
-    statusCounts,
-    groups: groupProgress,
+    total: aggregate.criterionIds.length,
+    evaluated: countEvaluated(aggregate.statusCounts),
+    statusCounts: aggregate.statusCounts,
+    groups: hierarchy.map((section) => ({
+      id: section.id,
+      name: section.name,
+      total: section.total,
+      evaluated: section.evaluated,
+    })),
+    hierarchy,
   }
 }

--- a/src/app/(app)/technical-configurations/_hooks/TechnicalConfigurationAssessmentCompleteCache.ts
+++ b/src/app/(app)/technical-configurations/_hooks/TechnicalConfigurationAssessmentCompleteCache.ts
@@ -1,0 +1,95 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+import type {
+  TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentWire,
+} from "../assessment-types"
+import { listTechnicalConfigurationAssessments } from "../technical-configuration-assessment-rpc"
+import { technicalConfigurationAssessmentsQueryKeyPrefix } from "../technical-configuration-query-keys"
+import { collectStableTechnicalConfigurationPages } from "../technical-configuration-pagination"
+
+/** Page size used to collect authoritative complete assessment snapshots. */
+export const ASSESSMENT_COLLECTION_PAGE_SIZE = 100
+
+const ASSESSMENT_PAGINATION_SNAPSHOT_ERROR = "Assessment pagination snapshot changed during load."
+
+export type TechnicalConfigurationCompleteAssessmentMap = Readonly<
+  Record<string, TechnicalConfigurationAssessmentWire>
+>
+
+/** Collects a stable complete assessment snapshot keyed by criterion ID. */
+export async function collectTechnicalConfigurationAssessments(
+  comparisonSetId: string,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationCompleteAssessmentMap> {
+  const { items } = await collectStableTechnicalConfigurationPages<
+    TechnicalConfigurationAssessmentWire,
+    TechnicalConfigurationAssessmentListWireResponse
+  >({
+    loadPage: async (page) => {
+      const response = await listTechnicalConfigurationAssessments(
+        {
+          p_comparison_set_id: comparisonSetId,
+          p_page: page,
+          p_page_size: ASSESSMENT_COLLECTION_PAGE_SIZE,
+        },
+        signal
+      )
+      if (response.page !== page || response.page_size !== ASSESSMENT_COLLECTION_PAGE_SIZE) {
+        throw new Error(ASSESSMENT_PAGINATION_SNAPSHOT_ERROR)
+      }
+      return response
+    },
+    snapshotError: ASSESSMENT_PAGINATION_SNAPSHOT_ERROR,
+    getItemKey: (item) => item.criterion_id,
+  })
+
+  return Object.fromEntries(items.map((item) => [item.criterion_id, item]))
+}
+
+/** Updates an existing authoritative complete cache with a saved assessment. */
+export function adoptCompleteAssessment(
+  queryClient: QueryClient,
+  comparisonSetId: string,
+  assessment: TechnicalConfigurationAssessmentWire
+): void {
+  const completeQueryKey = [
+    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    "complete",
+  ] as const
+  queryClient.setQueryData<TechnicalConfigurationCompleteAssessmentMap>(
+    completeQueryKey,
+    (current) =>
+      current !== undefined
+        ? {
+            ...current,
+            [assessment.criterion_id]: assessment,
+          }
+        : undefined
+  )
+}
+
+/** Ensures a complete cache is available and reports whether loading succeeded. */
+export async function loadKnownAbsentCompleteAssessments(
+  queryClient: QueryClient,
+  comparisonSetId: string
+): Promise<boolean> {
+  const completeQueryKey = [
+    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    "complete",
+  ] as const
+  if (queryClient.getQueryData(completeQueryKey) !== undefined) return true
+
+  try {
+    await queryClient.fetchQuery({
+      queryKey: completeQueryKey,
+      queryFn: ({ signal }) => collectTechnicalConfigurationAssessments(comparisonSetId, signal),
+      staleTime: 30_000,
+      retry: false,
+    })
+    return true
+  } catch {
+    // Persistence may continue, but a failed snapshot is never promoted to authoritative.
+    return false
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/TechnicalConfigurationAssessmentCompleteCache.ts
+++ b/src/app/(app)/technical-configurations/_hooks/TechnicalConfigurationAssessmentCompleteCache.ts
@@ -17,6 +17,28 @@ export type TechnicalConfigurationCompleteAssessmentMap = Readonly<
   Record<string, TechnicalConfigurationAssessmentWire>
 >
 
+/** Preserves assessments that are newer than an incoming complete snapshot. */
+export function selectNewestCompleteAssessmentSnapshot(
+  current: TechnicalConfigurationCompleteAssessmentMap | undefined,
+  incoming: TechnicalConfigurationCompleteAssessmentMap
+): TechnicalConfigurationCompleteAssessmentMap {
+  if (current === undefined) return incoming
+
+  return Object.values(current).reduce<TechnicalConfigurationCompleteAssessmentMap>(
+    (merged, assessment) => {
+      const incomingAssessment = incoming[assessment.criterion_id]
+      if (!incomingAssessment || assessment.revision > incomingAssessment.revision) {
+        return {
+          ...merged,
+          [assessment.criterion_id]: assessment,
+        }
+      }
+      return merged
+    },
+    incoming
+  )
+}
+
 /** Collects a stable complete assessment snapshot keyed by criterion ID. */
 export async function collectTechnicalConfigurationAssessments(
   comparisonSetId: string,
@@ -59,13 +81,16 @@ export function adoptCompleteAssessment(
   ] as const
   queryClient.setQueryData<TechnicalConfigurationCompleteAssessmentMap>(
     completeQueryKey,
-    (current) =>
-      current !== undefined
-        ? {
-            ...current,
-            [assessment.criterion_id]: assessment,
-          }
-        : undefined
+    (current) => {
+      if (current === undefined) return undefined
+      const cachedAssessment = current[assessment.criterion_id]
+      if (cachedAssessment && cachedAssessment.revision > assessment.revision) return current
+
+      return {
+        ...current,
+        [assessment.criterion_id]: assessment,
+      }
+    }
   )
 }
 
@@ -81,11 +106,16 @@ export async function loadKnownAbsentCompleteAssessments(
   if (queryClient.getQueryData(completeQueryKey) !== undefined) return true
 
   try {
-    await queryClient.fetchQuery({
+    await queryClient.fetchQuery<TechnicalConfigurationCompleteAssessmentMap>({
       queryKey: completeQueryKey,
       queryFn: ({ signal }) => collectTechnicalConfigurationAssessments(comparisonSetId, signal),
       staleTime: 30_000,
       retry: false,
+      structuralSharing: (current, incoming) =>
+        selectNewestCompleteAssessmentSnapshot(
+          current as TechnicalConfigurationCompleteAssessmentMap | undefined,
+          incoming as TechnicalConfigurationCompleteAssessmentMap
+        ),
     })
     return true
   } catch {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -2,12 +2,18 @@
 
 import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
+import {
+  adoptCompleteAssessment,
+  ASSESSMENT_COLLECTION_PAGE_SIZE,
+  collectTechnicalConfigurationAssessments,
+  loadKnownAbsentCompleteAssessments,
+  type TechnicalConfigurationCompleteAssessmentMap,
+} from "./TechnicalConfigurationAssessmentCompleteCache"
 import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
 import type {
   TechnicalConfigurationAssessmentListWireResponse,
   TechnicalConfigurationAssessmentSaveResult,
   TechnicalConfigurationAssessmentUpsertInput,
-  TechnicalConfigurationAssessmentWire,
 } from "../assessment-types"
 import {
   listTechnicalConfigurationAssessments,
@@ -20,11 +26,7 @@ import {
   technicalConfigurationEvaluationCriteriaQueryKeyPrefix,
   technicalConfigurationReferenceRankingQueryKey,
 } from "../technical-configuration-query-keys"
-import { collectStableTechnicalConfigurationPages } from "../technical-configuration-pagination"
 import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
-
-const ASSESSMENT_COLLECTION_PAGE_SIZE = 100
-const ASSESSMENT_PAGINATION_SNAPSHOT_ERROR = "Assessment pagination snapshot changed during load."
 
 interface TechnicalConfigurationAssessmentContext {
   optionId: string
@@ -57,35 +59,6 @@ function isValidAssessmentPage(page: number, pageSize: number): boolean {
     pageSize >= 1 &&
     pageSize <= 100
   )
-}
-
-async function collectTechnicalConfigurationAssessments(
-  comparisonSetId: string,
-  signal?: AbortSignal
-): Promise<Readonly<Record<string, TechnicalConfigurationAssessmentWire>>> {
-  const { items } = await collectStableTechnicalConfigurationPages<
-    TechnicalConfigurationAssessmentWire,
-    TechnicalConfigurationAssessmentListWireResponse
-  >({
-    loadPage: async (page) => {
-      const response = await listTechnicalConfigurationAssessments(
-        {
-          p_comparison_set_id: comparisonSetId,
-          p_page: page,
-          p_page_size: ASSESSMENT_COLLECTION_PAGE_SIZE,
-        },
-        signal
-      )
-      if (response.page !== page || response.page_size !== ASSESSMENT_COLLECTION_PAGE_SIZE) {
-        throw new Error(ASSESSMENT_PAGINATION_SNAPSHOT_ERROR)
-      }
-      return response
-    },
-    snapshotError: ASSESSMENT_PAGINATION_SNAPSHOT_ERROR,
-    getItemKey: (item) => item.criterion_id,
-  })
-
-  return Object.fromEntries(items.map((item) => [item.criterion_id, item]))
 }
 
 function acquireAssessmentComparisonSet({
@@ -142,27 +115,6 @@ function acquireAssessmentComparisonSet({
   return acquisition
 }
 
-function adoptCompleteAssessment(
-  queryClient: QueryClient,
-  comparisonSetId: string,
-  assessment: TechnicalConfigurationAssessmentWire
-): void {
-  const completeQueryKey = [
-    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
-    "complete",
-  ] as const
-  queryClient.setQueryData<Readonly<Record<string, TechnicalConfigurationAssessmentWire>>>(
-    completeQueryKey,
-    (current) =>
-      current
-        ? {
-            ...current,
-            [assessment.criterion_id]: assessment,
-          }
-        : current
-  )
-}
-
 /** Exposes the dormant P11C assessment data contract without mounting assessment UI. */
 export function useTechnicalConfigurationAssessments(
   input: UseTechnicalConfigurationAssessmentsInput
@@ -212,9 +164,7 @@ export function useTechnicalConfigurationAssessments(
     retry: false,
     refetchOnWindowFocus: false,
   })
-  const completeAssessmentsQuery = useQuery<
-    Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
-  >({
+  const completeAssessmentsQuery = useQuery<TechnicalConfigurationCompleteAssessmentMap>({
     queryKey: completeQueryKey,
     queryFn: ({ signal }) => {
       if (!completeQueryEnabled) {
@@ -240,10 +190,13 @@ export function useTechnicalConfigurationAssessments(
         throw new Error("technical_configuration_assessment_context_unavailable")
       }
 
-      const cachedComparisonSet =
-        queryClient.getQueryData<TechnicalConfigurationComparisonSetWire | null>(
+      const comparisonSetState =
+        queryClient.getQueryState<TechnicalConfigurationComparisonSetWire | null>(
           comparisonSetQueryKey
         )
+      const cachedComparisonSet = comparisonSetState?.data
+      const comparisonSetWasKnownAbsent =
+        comparisonSetState?.status === "success" && cachedComparisonSet === null
       const comparisonSet = await acquireAssessmentComparisonSet({
         queryClient,
         comparisonSetQueryKey,
@@ -254,6 +207,9 @@ export function useTechnicalConfigurationAssessments(
       if (!cachedComparisonSet) {
         onComparisonSetReady?.(comparisonSet)
       }
+      const knownAbsentSnapshot = comparisonSetWasKnownAbsent
+        ? loadKnownAbsentCompleteAssessments(queryClient, comparisonSet.id)
+        : null
 
       const response = await upsertTechnicalConfigurationAssessment({
         p_comparison_set_id: comparisonSet.id,
@@ -264,33 +220,43 @@ export function useTechnicalConfigurationAssessments(
         p_expected_revision: input.expectedRevision,
       })
 
+      if (knownAbsentSnapshot) {
+        void knownAbsentSnapshot
+          .then((isAuthoritative) => {
+            if (isAuthoritative) {
+              adoptCompleteAssessment(queryClient, comparisonSet.id, response.data)
+            }
+            return queryClient.invalidateQueries({
+              queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
+            })
+          })
+          .catch(() => undefined)
+      } else {
+        adoptCompleteAssessment(queryClient, comparisonSet.id, response.data)
+        void queryClient
+          .invalidateQueries({
+            queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
+          })
+          .catch(() => undefined)
+      }
       return { comparisonSet, assessment: response.data }
     },
-    onSuccess: async ({ comparisonSet, assessment }) => {
-      adoptCompleteAssessment(queryClient, comparisonSet.id, assessment)
-      const invalidations = [
-        queryClient.invalidateQueries({
-          queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
-        }),
-      ]
+    onSuccess: async ({ comparisonSet }) => {
       let rankingQueryKey: ReturnType<
         typeof technicalConfigurationReferenceRankingQueryKey
       > | null = null
       if (baselineVersionId) {
-        invalidations.push(
-          queryClient.invalidateQueries({
-            queryKey: technicalConfigurationEvaluationCriteriaQueryKeyPrefix(
-              optionId,
-              baselineVersionId
-            ),
-          })
-        )
+        await queryClient.invalidateQueries({
+          queryKey: technicalConfigurationEvaluationCriteriaQueryKeyPrefix(
+            optionId,
+            baselineVersionId
+          ),
+        })
         rankingQueryKey = technicalConfigurationReferenceRankingQueryKey({
           dossierId: comparisonSet.dossier_id,
           baselineVersionId,
         })
       }
-      await Promise.all(invalidations)
       if (rankingQueryKey) {
         void queryClient
           .resetQueries({

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -7,6 +7,7 @@ import {
   ASSESSMENT_COLLECTION_PAGE_SIZE,
   collectTechnicalConfigurationAssessments,
   loadKnownAbsentCompleteAssessments,
+  selectNewestCompleteAssessmentSnapshot,
   type TechnicalConfigurationCompleteAssessmentMap,
 } from "./TechnicalConfigurationAssessmentCompleteCache"
 import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
@@ -179,6 +180,11 @@ export function useTechnicalConfigurationAssessments(
     staleTime: 30_000,
     retry: false,
     refetchOnWindowFocus: false,
+    structuralSharing: (current, incoming) =>
+      selectNewestCompleteAssessmentSnapshot(
+        current as TechnicalConfigurationCompleteAssessmentMap | undefined,
+        incoming as TechnicalConfigurationCompleteAssessmentMap
+      ),
   })
   const upsertAssessment = useMutation<
     TechnicalConfigurationAssessmentSaveResult,
@@ -221,14 +227,13 @@ export function useTechnicalConfigurationAssessments(
       })
 
       if (knownAbsentSnapshot) {
-        void knownAbsentSnapshot
-          .then((isAuthoritative) => {
-            if (isAuthoritative) {
-              adoptCompleteAssessment(queryClient, comparisonSet.id, response.data)
-            }
-            return queryClient.invalidateQueries({
-              queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
-            })
+        const isAuthoritative = await knownAbsentSnapshot
+        if (isAuthoritative) {
+          adoptCompleteAssessment(queryClient, comparisonSet.id, response.data)
+        }
+        await queryClient
+          .invalidateQueries({
+            queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
           })
           .catch(() => undefined)
       } else {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationHierarchyPresentation.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationHierarchyPresentation.ts
@@ -1,0 +1,127 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  buildTechnicalConfigurationEvaluationHierarchyRows,
+  type TechnicalConfigurationEvaluationHierarchyLeaf,
+} from "../_components/evaluation/technical-configuration-evaluation-hierarchy"
+import {
+  findTechnicalConfigurationEvaluationCriterion,
+  type TechnicalConfigurationEvaluationCriterionListItem,
+} from "../_components/evaluation/technical-configuration-evaluation-navigation"
+import type { TechnicalConfigurationBaselineGroupWire } from "../baseline-types"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+type PageLeaf = TechnicalConfigurationEvaluationHierarchyLeaf & {
+  canonicalPage: number
+}
+
+export type TechnicalConfigurationEvaluationRequestNavigation = (navigate: () => void) => void
+
+export type TechnicalConfigurationEvaluationCriterionCommit = (
+  criterion: TechnicalConfigurationEvaluationCriterionListItem | null
+) => void
+
+export type UseTechnicalConfigurationEvaluationNavigatorInput = {
+  options: readonly TechnicalConfigurationOptionWire[]
+  baselineGroups: readonly TechnicalConfigurationBaselineGroupWire[]
+  baselineVersionId: string
+  pageSize: number
+}
+
+/** Resolves the selected leaf within the active projection and canonical page context. */
+export function resolveTechnicalConfigurationEvaluationContextCriterion<TLeaf extends PageLeaf>(
+  projection: readonly TLeaf[],
+  criterionId: string | null,
+  canonicalPage: number
+): TLeaf | null {
+  return (
+    (criterionId ? projection.find((item) => item.criterion.id === criterionId) : undefined) ??
+    projection.find((item) => item.canonicalPage === canonicalPage) ??
+    (criterionId ? projection[0] : undefined) ??
+    null
+  )
+}
+
+/** Resolves a selected leaf from the projection or its canonical baseline fallback. */
+export function resolveTechnicalConfigurationEvaluationTargetCriterion(
+  projection: readonly TechnicalConfigurationEvaluationCriterionListItem[],
+  groups: readonly TechnicalConfigurationBaselineGroupWire[],
+  criterionId: string | null,
+  pageSize: number
+) {
+  return (
+    projection.find((item) => item.criterion.id === criterionId) ??
+    findTechnicalConfigurationEvaluationCriterion({ groups, criterionId, pageSize })
+  )
+}
+
+function getStructuralRowIds(
+  rows: ReturnType<typeof buildTechnicalConfigurationEvaluationHierarchyRows>
+) {
+  return rows.flatMap((row) => (row.kind === "criterion" ? [] : [row.id]))
+}
+
+function getAncestorRowIds(leaf: TechnicalConfigurationEvaluationHierarchyLeaf) {
+  return leaf.subgroup ? [leaf.group.id, leaf.subgroup.id] : [leaf.group.id]
+}
+
+/** Owns page-local hierarchy rows and controlled structural expansion state. */
+export function useTechnicalConfigurationEvaluationHierarchyPresentation<TLeaf extends PageLeaf>(
+  projection: readonly TLeaf[],
+  canonicalPage: number
+) {
+  const hierarchyRows = React.useMemo(
+    () =>
+      buildTechnicalConfigurationEvaluationHierarchyRows(
+        projection.filter((leaf) => leaf.canonicalPage === canonicalPage)
+      ),
+    [canonicalPage, projection]
+  )
+  const structuralRowIds = React.useMemo(() => getStructuralRowIds(hierarchyRows), [hierarchyRows])
+  const pageKey = `${canonicalPage}:${structuralRowIds.join(":")}`
+  const [expansion, setExpansion] = React.useState(() => ({
+    pageKey,
+    rowIds: new Set(structuralRowIds) as ReadonlySet<string>,
+  }))
+  const expandedRowIds = React.useMemo(
+    () => (expansion.pageKey === pageKey ? expansion.rowIds : new Set(structuralRowIds)),
+    [expansion, pageKey, structuralRowIds]
+  )
+  const onExpandedRowIdsChange = React.useCallback(
+    (rowIds: ReadonlySet<string>) => {
+      const allowedRowIds = new Set(structuralRowIds)
+      setExpansion({
+        pageKey,
+        rowIds: new Set([...rowIds].filter((rowId) => allowedRowIds.has(rowId))),
+      })
+    },
+    [pageKey, structuralRowIds]
+  )
+  const expandCriterionAncestors = React.useCallback(
+    (leaf: TechnicalConfigurationEvaluationHierarchyLeaf | null) => {
+      if (!leaf) return
+
+      const ancestorRowIds = getAncestorRowIds(leaf)
+      setExpansion((current) => {
+        const currentRowIds =
+          current.pageKey === pageKey ? current.rowIds : new Set(structuralRowIds)
+        if (ancestorRowIds.every((rowId) => currentRowIds.has(rowId))) return current
+
+        return {
+          pageKey,
+          rowIds: new Set([...currentRowIds, ...ancestorRowIds]),
+        }
+      })
+    },
+    [pageKey, structuralRowIds]
+  )
+
+  return {
+    hierarchyRows,
+    expandedRowIds,
+    onExpandedRowIdsChange,
+    expandCriterionAncestors,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
@@ -59,11 +59,15 @@ export function useTechnicalConfigurationEvaluationNavigator({
     requestedCriterionId ??
     projection.find((item) => item.canonicalPage === canonicalPage)?.criterion.id ??
     null
-  const currentCriterion = resolveTechnicalConfigurationEvaluationTargetCriterion(
-    projection,
-    baselineGroups,
-    criterionId,
-    pageSize
+  const currentCriterion = React.useMemo(
+    () =>
+      resolveTechnicalConfigurationEvaluationTargetCriterion(
+        projection,
+        baselineGroups,
+        criterionId,
+        pageSize
+      ),
+    [baselineGroups, criterionId, pageSize, projection]
   )
   const isCurrentCriterionFilteredOut =
     criterionId !== null &&

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationNavigator.ts
@@ -6,43 +6,22 @@ import type {
   TechnicalConfigurationEvaluationCriterionWire,
   TechnicalConfigurationEvaluationStatusFilter,
 } from "../assessment-types"
-import type { TechnicalConfigurationBaselineGroupWire } from "../baseline-types"
-import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 import {
   buildTechnicalConfigurationEvaluationProjection,
   findNextTechnicalConfigurationEvaluationCriterion,
-  findTechnicalConfigurationEvaluationCriterion,
 } from "../_components/evaluation/technical-configuration-evaluation-navigation"
 import { useTechnicalConfigurationEvaluationCriteria } from "./useTechnicalConfigurationEvaluationCriteria"
+import {
+  resolveTechnicalConfigurationEvaluationContextCriterion,
+  resolveTechnicalConfigurationEvaluationTargetCriterion,
+  type TechnicalConfigurationEvaluationCriterionCommit,
+  type TechnicalConfigurationEvaluationRequestNavigation,
+  type UseTechnicalConfigurationEvaluationNavigatorInput,
+  useTechnicalConfigurationEvaluationHierarchyPresentation,
+} from "./useTechnicalConfigurationEvaluationHierarchyPresentation"
 import { useTechnicalConfigurationEvaluationTransition } from "./useTechnicalConfigurationEvaluationTransition"
 
-type RequestNavigation = (navigate: () => void) => void
-type EvaluationProjectionItem = ReturnType<
-  typeof buildTechnicalConfigurationEvaluationProjection
->[number]
-type OnCriterionCommit = (criterion: EvaluationProjectionItem | null) => void
-
-function resolveContextCriterion(
-  projection: readonly EvaluationProjectionItem[],
-  criterionId: string | null,
-  canonicalPage: number
-) {
-  return (
-    (criterionId ? projection.find((item) => item.criterion.id === criterionId) : undefined) ??
-    projection.find((item) => item.canonicalPage === canonicalPage) ??
-    (criterionId ? projection[0] : undefined) ??
-    null
-  )
-}
-
-type UseTechnicalConfigurationEvaluationNavigatorInput = {
-  options: readonly TechnicalConfigurationOptionWire[]
-  baselineGroups: readonly TechnicalConfigurationBaselineGroupWire[]
-  baselineVersionId: string
-  pageSize: number
-}
-
-/** Owns P12B2 option, filter, canonical page, selection and no-more-match state. */
+/** Coordinates filtered leaf selection, canonical paging, and guarded evaluation navigation. */
 export function useTechnicalConfigurationEvaluationNavigator({
   options,
   baselineGroups,
@@ -74,17 +53,18 @@ export function useTechnicalConfigurationEvaluationNavigator({
       }),
     [baselineGroups, criteriaQuery.data]
   )
+  const { hierarchyRows, expandedRowIds, onExpandedRowIdsChange, expandCriterionAncestors } =
+    useTechnicalConfigurationEvaluationHierarchyPresentation(projection, canonicalPage)
   const criterionId =
     requestedCriterionId ??
     projection.find((item) => item.canonicalPage === canonicalPage)?.criterion.id ??
     null
-  const currentCriterion =
-    projection.find((item) => item.criterion.id === criterionId) ??
-    findTechnicalConfigurationEvaluationCriterion({
-      groups: baselineGroups,
-      criterionId,
-      pageSize,
-    })
+  const currentCriterion = resolveTechnicalConfigurationEvaluationTargetCriterion(
+    projection,
+    baselineGroups,
+    criterionId,
+    pageSize
+  )
   const isCurrentCriterionFilteredOut =
     criterionId !== null &&
     !criteriaQuery.isLoading &&
@@ -94,8 +74,8 @@ export function useTechnicalConfigurationEvaluationNavigator({
   const changeFilter = React.useCallback(
     (
       nextFilter: TechnicalConfigurationEvaluationStatusFilter,
-      requestNavigation: RequestNavigation,
-      onCriterionCommit?: OnCriterionCommit
+      requestNavigation: TechnicalConfigurationEvaluationRequestNavigation,
+      onCriterionCommit?: TechnicalConfigurationEvaluationCriterionCommit
     ) => {
       if (nextFilter === statusFilter || !activeSelectedOptionId || transitionPendingRef.current) {
         return
@@ -113,9 +93,14 @@ export function useTechnicalConfigurationEvaluationNavigator({
         })
         const currentRemainsVisible =
           criterionId !== null && nextProjection.some((item) => item.criterion.id === criterionId)
-        const nextCriterion = resolveContextCriterion(nextProjection, criterionId, canonicalPage)
+        const nextCriterion = resolveTechnicalConfigurationEvaluationContextCriterion(
+          nextProjection,
+          criterionId,
+          canonicalPage
+        )
         const nextCriterionId = nextCriterion?.criterion.id ?? null
         const commit = () => {
+          expandCriterionAncestors(nextCriterion)
           setStatusFilter(nextFilter)
           if (nextCriterion) setCanonicalPage(nextCriterion.canonicalPage)
           setRequestedCriterionId(nextCriterionId)
@@ -138,6 +123,7 @@ export function useTechnicalConfigurationEvaluationNavigator({
       canonicalPage,
       criterionId,
       loadCriteria,
+      expandCriterionAncestors,
       startTransition,
       statusFilter,
       transitionPendingRef,
@@ -147,8 +133,8 @@ export function useTechnicalConfigurationEvaluationNavigator({
   const changeOption = React.useCallback(
     (
       nextOptionId: string,
-      requestNavigation: RequestNavigation,
-      onCriterionCommit?: OnCriterionCommit
+      requestNavigation: TechnicalConfigurationEvaluationRequestNavigation,
+      onCriterionCommit?: TechnicalConfigurationEvaluationCriterionCommit
     ) => {
       if (nextOptionId === activeSelectedOptionId || transitionPendingRef.current) return
 
@@ -163,9 +149,14 @@ export function useTechnicalConfigurationEvaluationNavigator({
             groups: baselineGroups,
             entries,
           })
-          const nextCriterion = resolveContextCriterion(nextProjection, criterionId, canonicalPage)
+          const nextCriterion = resolveTechnicalConfigurationEvaluationContextCriterion(
+            nextProjection,
+            criterionId,
+            canonicalPage
+          )
           const nextCriterionId = nextCriterion?.criterion.id ?? null
 
+          expandCriterionAncestors(nextCriterion)
           setSelectedOptionId(nextOptionId)
           if (nextCriterion) setCanonicalPage(nextCriterion.canonicalPage)
           setRequestedCriterionId(nextCriterionId)
@@ -182,6 +173,7 @@ export function useTechnicalConfigurationEvaluationNavigator({
       canonicalPage,
       criterionId,
       loadCriteria,
+      expandCriterionAncestors,
       startTransition,
       statusFilter,
       transitionPendingRef,
@@ -189,7 +181,11 @@ export function useTechnicalConfigurationEvaluationNavigator({
   )
 
   const changePage = React.useCallback(
-    (nextPage: number, requestNavigation: RequestNavigation, onCommit?: () => void) => {
+    (
+      nextPage: number,
+      requestNavigation: TechnicalConfigurationEvaluationRequestNavigation,
+      onCommit?: () => void
+    ) => {
       requestNavigation(() => {
         setCanonicalPage(nextPage)
         setRequestedCriterionId(null)
@@ -202,8 +198,20 @@ export function useTechnicalConfigurationEvaluationNavigator({
   )
 
   const changeCriterion = React.useCallback(
-    (nextCriterionId: string, requestNavigation: RequestNavigation, beforeOpen?: () => void) => {
+    (
+      nextCriterionId: string,
+      requestNavigation: TechnicalConfigurationEvaluationRequestNavigation,
+      beforeOpen?: () => void
+    ) => {
       const navigate = () => {
+        expandCriterionAncestors(
+          resolveTechnicalConfigurationEvaluationTargetCriterion(
+            projection,
+            baselineGroups,
+            nextCriterionId,
+            pageSize
+          )
+        )
         beforeOpen?.()
         setRequestedCriterionId(nextCriterionId)
         setIsPanelOpen(true)
@@ -215,14 +223,14 @@ export function useTechnicalConfigurationEvaluationNavigator({
       }
       requestNavigation(navigate)
     },
-    [criterionId]
+    [baselineGroups, criterionId, expandCriterionAncestors, pageSize, projection]
   )
 
   const changeTarget = React.useCallback(
     (
       nextOptionId: string,
       nextCriterionId: string,
-      requestNavigation: RequestNavigation,
+      requestNavigation: TechnicalConfigurationEvaluationRequestNavigation,
       beforeOpen?: () => void
     ) => {
       if (transitionPendingRef.current) return
@@ -239,6 +247,14 @@ export function useTechnicalConfigurationEvaluationNavigator({
             statusFilter,
           })
 
+          expandCriterionAncestors(
+            resolveTechnicalConfigurationEvaluationTargetCriterion(
+              projection,
+              baselineGroups,
+              nextCriterionId,
+              pageSize
+            )
+          )
           beforeOpen?.()
           setSelectedOptionId(nextOptionId)
           setRequestedCriterionId(nextCriterionId)
@@ -251,7 +267,11 @@ export function useTechnicalConfigurationEvaluationNavigator({
       activeSelectedOptionId,
       baselineVersionId,
       changeCriterion,
+      baselineGroups,
+      expandCriterionAncestors,
       loadCriteria,
+      pageSize,
+      projection,
       startTransition,
       statusFilter,
       transitionPendingRef,
@@ -283,6 +303,7 @@ export function useTechnicalConfigurationEvaluationNavigator({
         return
       }
 
+      expandCriterionAncestors(transitionResult.nextCriterion)
       setCanonicalPage(transitionResult.nextCriterion.canonicalPage)
       setRequestedCriterionId(transitionResult.nextCriterion.criterion.id)
       setIsPanelOpen(true)
@@ -294,6 +315,7 @@ export function useTechnicalConfigurationEvaluationNavigator({
     baselineGroups,
     baselineVersionId,
     currentCriterion,
+    expandCriterionAncestors,
     loadCriteria,
     startTransition,
     statusFilter,
@@ -304,6 +326,9 @@ export function useTechnicalConfigurationEvaluationNavigator({
     activeSelectedOptionId,
     statusFilter,
     projection,
+    hierarchyRows,
+    expandedRowIds,
+    onExpandedRowIdsChange,
     criterionId,
     currentCriterion,
     isPanelOpen,

--- a/src/app/api/rpc/__tests__/technical-configuration-evaluation-hierarchy-order-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-evaluation-hierarchy-order-migration.test.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATION_FILE = "20260812140500_technical_configuration_evaluation_hierarchy_order.sql"
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "supabase/migrations")
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATES_DIR = path.resolve(process.cwd(), "supabase/tests")
+const BEHAVIOR_PHASE_GATE_FILE = "technical_configuration_evaluation_hierarchy_order_phase_gate.sql"
+const PHASE_GATE_FILES = [
+  BEHAVIOR_PHASE_GATE_FILE,
+  "technical_configuration_evaluation_hierarchy_order_security_phase_gate.sql",
+] as const
+const EVALUATION_LIST_DEFINITION =
+  /CREATE OR REPLACE FUNCTION public\.technical_configuration_evaluation_criteria_list\s*\(/
+
+function compactSql(source: string): string {
+  return source.replace(/\s+/g, " ").trim()
+}
+
+function getMigrationSource(): string {
+  expect(existsSync(MIGRATION_PATH), `${MIGRATION_FILE} must exist`).toBe(true)
+  return readFileSync(MIGRATION_PATH, "utf8")
+}
+
+function getEvaluationListRedefinitionFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(".sql"))
+    .filter((file) =>
+      EVALUATION_LIST_DEFINITION.test(readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"))
+    )
+    .sort()
+}
+
+function getFunctionBlock(source: string): string {
+  const start = source.indexOf(
+    "CREATE OR REPLACE FUNCTION public.technical_configuration_evaluation_criteria_list("
+  )
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const end = source.indexOf("\n$$;", start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end + 4)
+}
+
+describe("technical configuration evaluation P5C0 hierarchy order migration", () => {
+  it("keeps both rollback-only phase gates discoverable and below the hard ceiling", () => {
+    const discoveredPhaseGates = readdirSync(PHASE_GATES_DIR)
+      .filter(
+        (file) =>
+          file.startsWith("technical_configuration_evaluation_hierarchy_order") &&
+          file.endsWith("_phase_gate.sql")
+      )
+      .sort()
+
+    expect(discoveredPhaseGates).toEqual([...PHASE_GATE_FILES])
+
+    for (const file of PHASE_GATE_FILES) {
+      const source = readFileSync(path.join(PHASE_GATES_DIR, file), "utf8")
+      expect(source.split("\n").length).toBeLessThanOrEqual(450)
+      expect(source).toMatch(/\bBEGIN;/)
+      expect(source).toMatch(/\bROLLBACK;\s*$/)
+    }
+  })
+
+  it("uses an interleaved fixture that cannot pass through legacy flat ordering", () => {
+    const source = compactSql(
+      readFileSync(path.join(PHASE_GATES_DIR, BEHAVIOR_PHASE_GATE_FILE), "utf8")
+    )
+
+    expect(source).toContain(
+      "CASE WHEN series = 101 THEN NULL WHEN series % 2 = 1 THEN v_subgroup_1_id ELSE v_subgroup_2_id END"
+    )
+    expect(source).toContain("P5C0 criterion ' || series, series, v_user_id")
+    expect(source).toContain("subgroup_id IS NULL AND sort_order = 101")
+    expect(source).toContain("subgroup_id = v_subgroup_1_id AND sort_order = 97")
+    expect(source).toContain("subgroup_id = v_subgroup_1_id AND sort_order = 99")
+    expect(source).toContain("subgroup_id = v_subgroup_2_id AND sort_order = 98")
+    expect(source).toContain("subgroup_id = v_subgroup_2_id AND sort_order = 100")
+  })
+
+  it("ships after the latest local redefinition and only replaces the evaluation list RPC", () => {
+    const source = getMigrationSource()
+    const redefinitionFiles = getEvaluationListRedefinitionFiles()
+    const priorRedefinitionFiles = redefinitionFiles.filter((file) => file !== MIGRATION_FILE)
+    const latestPriorRedefinition = priorRedefinitionFiles.at(-1)
+    const redefinedFunctions = [
+      ...source.matchAll(/CREATE OR REPLACE FUNCTION public\.([a-z0-9_]+)\s*\(/g),
+    ].map((match) => match[1])
+
+    expect(latestPriorRedefinition).toBeDefined()
+    expect(redefinitionFiles.at(-1)).toBe(MIGRATION_FILE)
+    expect(MIGRATION_FILE > (latestPriorRedefinition ?? "")).toBe(true)
+    expect(redefinedFunctions).toEqual(["technical_configuration_evaluation_criteria_list"])
+    expect(source).not.toMatch(
+      /\b(?:CREATE TABLE|ALTER TABLE|CREATE INDEX|INSERT INTO|UPDATE public\.|DELETE FROM)\b/
+    )
+    expect(source).not.toMatch(
+      /CREATE OR REPLACE FUNCTION public\.technical_configuration_(?:comparison|result_export)[a-z0-9_]*/
+    )
+    expect(source).toContain("Rollback (forward-compatible; never edit applied history)")
+  })
+
+  it("preserves the public contract, authorization, validation, and least-privilege grants", () => {
+    const source = getMigrationSource()
+    const block = getFunctionBlock(source)
+    const compactBlock = compactSql(block)
+    const compact = compactSql(source)
+    const headerEnd = compactBlock.indexOf(" LANGUAGE plpgsql")
+
+    expect(compactBlock.slice(0, headerEnd)).toBe(
+      "CREATE OR REPLACE FUNCTION public.technical_configuration_evaluation_criteria_list( p_option_id UUID, p_baseline_version_id UUID, p_status_filter TEXT, p_page INTEGER, p_page_size INTEGER ) RETURNS JSONB"
+    )
+    expect(block).toContain("LANGUAGE plpgsql")
+    expect(block).toContain("SECURITY DEFINER")
+    expect(block).toContain("SET search_path = public, pg_temp")
+    expect(block).toContain("PERFORM public._technical_configuration_require_global_user()")
+    expect(block).toContain("v_comparison_page_size CONSTANT INTEGER := 50")
+    expect(block).toContain("p_page_size > 100")
+    expect(block).toContain(
+      "p_status_filter NOT IN ('all', 'not_evaluated', 'fails', 'insufficient_evidence')"
+    )
+    expect(block).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
+    expect(block).toContain("RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404'")
+
+    expect(compact).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_evaluation_criteria_list( UUID, UUID, TEXT, INTEGER, INTEGER ) FROM PUBLIC, anon, authenticated, service_role"
+    )
+    expect(compact).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_evaluation_criteria_list( UUID, UUID, TEXT, INTEGER, INTEGER ) TO authenticated, service_role"
+    )
+  })
+
+  it("computes the hierarchy-aware canonical index before filtering", () => {
+    const block = compactSql(getFunctionBlock(getMigrationSource()))
+    const canonicalStart = block.indexOf("canonical_criteria AS MATERIALIZED")
+    const filteredStart = block.indexOf("filtered_criteria AS MATERIALIZED")
+    const pagedStart = block.indexOf("paged_criteria AS")
+    const statusFilter = block.indexOf("WHERE p_status_filter = 'all'", filteredStart)
+
+    expect(canonicalStart).toBeGreaterThanOrEqual(0)
+    expect(filteredStart).toBeGreaterThan(canonicalStart)
+    expect(pagedStart).toBeGreaterThan(filteredStart)
+    expect(statusFilter).toBeGreaterThan(filteredStart)
+    expect(statusFilter).toBeLessThan(pagedStart)
+
+    expect(block).toContain(
+      "LEFT JOIN public.technical_configuration_baseline_subgroups subgroup_row ON subgroup_row.id = criterion.subgroup_id AND subgroup_row.group_id = criterion.group_id AND subgroup_row.baseline_version_id = criterion.baseline_version_id"
+    )
+    expect(block).toContain(
+      "ORDER BY group_row.sort_order, group_row.id, CASE WHEN criterion.subgroup_id IS NULL THEN 0 ELSE 1 END, CASE WHEN criterion.subgroup_id IS NULL THEN 0 ELSE COALESCE(subgroup_row.sort_order, 2147483647) END, CASE WHEN criterion.subgroup_id IS NULL THEN '00000000-0000-0000-0000-000000000000'::UUID ELSE COALESCE( subgroup_row.id, 'ffffffff-ffff-ffff-ffff-ffffffffffff'::UUID ) END, criterion.sort_order, criterion.id"
+    )
+    expect(block).toContain(
+      "row_number() OVER ( ORDER BY group_row.sort_order, group_row.id, CASE WHEN criterion.subgroup_id IS NULL THEN 0 ELSE 1 END"
+    )
+    expect(block).toContain(
+      "((canonical.canonical_index - 1) / v_comparison_page_size) + 1 AS canonical_page"
+    )
+  })
+
+  it("orders transport pagination and JSON aggregation by canonical index", () => {
+    const block = compactSql(getFunctionBlock(getMigrationSource()))
+    const pagedStart = block.indexOf("paged_criteria AS")
+    const transportOrder = block.indexOf("ORDER BY filtered.canonical_index", pagedStart)
+    const limit = block.indexOf("LIMIT p_page_size", pagedStart)
+    const offset = block.indexOf("OFFSET (p_page - 1)::BIGINT * p_page_size", pagedStart)
+    const jsonOrder = block.indexOf("ORDER BY paged.canonical_index", offset)
+
+    expect(transportOrder).toBeGreaterThan(pagedStart)
+    expect(limit).toBeGreaterThan(transportOrder)
+    expect(offset).toBeGreaterThan(limit)
+    expect(jsonOrder).toBeGreaterThan(offset)
+  })
+
+  it("preserves assessment derivation and the response JSON shape", () => {
+    const block = compactSql(getFunctionBlock(getMigrationSource()))
+
+    expect(block).toContain(
+      "LEFT JOIN public.technical_configuration_comparison_sets comparison_set ON comparison_set.option_id = p_option_id AND comparison_set.baseline_version_id = p_baseline_version_id"
+    )
+    expect(block).toContain(
+      "LEFT JOIN public.technical_configuration_manual_assessments assessment ON assessment.comparison_set_id = comparison_set.id AND assessment.baseline_version_id = criterion.baseline_version_id AND assessment.criterion_id = criterion.id"
+    )
+    expect(block).toContain("WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'")
+    expect(block).toContain(
+      "WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'"
+    )
+    expect(block).toContain("WHEN assessment.technical_axis = 'fails' THEN 'fails'")
+    expect(block).toContain("WHEN assessment.technical_axis = 'unclear' THEN 'unclear'")
+    expect(block).toContain(
+      "WHEN assessment.evidence_axis IN ('partial', 'missing') THEN 'insufficient_evidence'"
+    )
+    expect(block).toContain(
+      "jsonb_build_object( 'criterion_id', paged.criterion_id, 'canonical_index', paged.canonical_index, 'canonical_page', paged.canonical_page )"
+    )
+    expect(block).toContain(
+      "RETURN jsonb_build_object( 'data', v_data, 'total', v_total, 'page', p_page, 'page_size', p_page_size )"
+    )
+  })
+})

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
@@ -8,15 +9,13 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        muted:
-          "border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
+        muted: "border-transparent bg-muted text-muted-foreground hover:bg-muted/80",
       },
     },
     defaultVariants: {
@@ -26,15 +25,14 @@ const badgeVariants = cva(
 )
 
 interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
-
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {
+  asChild?: boolean
 }
 
-export {
-  Badge
+/** Renders a styled badge, optionally delegating its element through Radix Slot. */
+function Badge({ className, variant, asChild = false, ...props }: BadgeProps) {
+  const Component = asChild ? Slot : "div"
+  return <Component className={cn(badgeVariants({ variant }), className)} {...props} />
 }
+
+export { Badge }

--- a/supabase/migrations/20260812140500_technical_configuration_evaluation_hierarchy_order.sql
+++ b/supabase/migrations/20260812140500_technical_configuration_evaluation_hierarchy_order.sql
@@ -1,0 +1,151 @@
+-- P5C0: make evaluation leaf navigation follow the baseline hierarchy.
+-- Rollback (forward-compatible; never edit applied history): ship a later migration
+-- that restores the prior flat ordering while preserving this function signature.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_evaluation_criteria_list(
+  p_option_id UUID,
+  p_baseline_version_id UUID,
+  p_status_filter TEXT,
+  p_page INTEGER,
+  p_page_size INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_comparison_page_size CONSTANT INTEGER := 50;
+  v_dossier_id UUID;
+  v_total BIGINT;
+  v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_option_id IS NULL
+     OR p_baseline_version_id IS NULL
+     OR p_status_filter IS NULL
+     OR p_status_filter NOT IN ('all', 'not_evaluated', 'fails', 'insufficient_evidence')
+     OR p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT version.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_baseline_versions version
+  WHERE version.id = p_baseline_version_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_options option_row
+    WHERE option_row.id = p_option_id
+      AND option_row.dossier_id = v_dossier_id
+  ) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  WITH canonical_criteria AS MATERIALIZED (
+    SELECT
+      criterion.id AS criterion_id,
+      row_number() OVER (
+        ORDER BY
+          group_row.sort_order,
+          group_row.id,
+          CASE WHEN criterion.subgroup_id IS NULL THEN 0 ELSE 1 END,
+          CASE
+            WHEN criterion.subgroup_id IS NULL THEN 0
+            ELSE COALESCE(subgroup_row.sort_order, 2147483647)
+          END,
+          CASE
+            WHEN criterion.subgroup_id IS NULL
+              THEN '00000000-0000-0000-0000-000000000000'::UUID
+            ELSE COALESCE(
+              subgroup_row.id,
+              'ffffffff-ffff-ffff-ffff-ffffffffffff'::UUID
+            )
+          END,
+          criterion.sort_order,
+          criterion.id
+      ) AS canonical_index,
+      CASE
+        WHEN assessment.technical_axis IS NULL THEN 'not_evaluated'
+        WHEN assessment.technical_axis = 'not_applicable' THEN 'not_applicable'
+        WHEN assessment.technical_axis = 'fails' THEN 'fails'
+        WHEN assessment.technical_axis = 'unclear' THEN 'unclear'
+        WHEN assessment.evidence_axis IS NULL THEN 'not_evaluated'
+        WHEN assessment.evidence_axis IN ('partial', 'missing')
+          THEN 'insufficient_evidence'
+        ELSE assessment.technical_axis
+      END AS derived_status
+    FROM public.technical_configuration_baseline_criteria criterion
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+    LEFT JOIN public.technical_configuration_baseline_subgroups subgroup_row
+      ON subgroup_row.id = criterion.subgroup_id
+     AND subgroup_row.group_id = criterion.group_id
+     AND subgroup_row.baseline_version_id = criterion.baseline_version_id
+    LEFT JOIN public.technical_configuration_comparison_sets comparison_set
+      ON comparison_set.option_id = p_option_id
+     AND comparison_set.baseline_version_id = p_baseline_version_id
+    LEFT JOIN public.technical_configuration_manual_assessments assessment
+      ON assessment.comparison_set_id = comparison_set.id
+     AND assessment.baseline_version_id = criterion.baseline_version_id
+     AND assessment.criterion_id = criterion.id
+    WHERE criterion.baseline_version_id = p_baseline_version_id
+  ),
+  filtered_criteria AS MATERIALIZED (
+    SELECT
+      canonical.criterion_id,
+      canonical.canonical_index,
+      ((canonical.canonical_index - 1) / v_comparison_page_size) + 1 AS canonical_page
+    FROM canonical_criteria canonical
+    WHERE p_status_filter = 'all'
+       OR canonical.derived_status = p_status_filter
+  ),
+  paged_criteria AS (
+    SELECT *
+    FROM filtered_criteria filtered
+    ORDER BY filtered.canonical_index
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT
+    (SELECT count(*) FROM filtered_criteria),
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'criterion_id', paged.criterion_id,
+          'canonical_index', paged.canonical_index,
+          'canonical_page', paged.canonical_page
+        )
+        ORDER BY paged.canonical_index
+      ),
+      '[]'::JSONB
+    )
+  INTO v_total, v_data
+  FROM paged_criteria paged;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_evaluation_criteria_list(
+  UUID, UUID, TEXT, INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_evaluation_criteria_list(
+  UUID, UUID, TEXT, INTEGER, INTEGER
+) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_evaluation_hierarchy_order_phase_gate.sql
+++ b/supabase/tests/technical_configuration_evaluation_hierarchy_order_phase_gate.sql
@@ -1,0 +1,434 @@
+-- P5C0 rollback-only hierarchy-aware evaluation ordering and behavior gate.
+BEGIN;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_label;
+  END IF;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_supplier_id UUID := gen_random_uuid();
+  v_option_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_group_id UUID := gen_random_uuid();
+  v_subgroup_1_id UUID := gen_random_uuid();
+  v_subgroup_2_id UUID := gen_random_uuid();
+  v_set_id UUID := gen_random_uuid();
+  v_direct_101 UUID;
+  v_subgroup_1_1 UUID;
+  v_subgroup_1_97 UUID;
+  v_subgroup_1_99 UUID;
+  v_subgroup_2_2 UUID;
+  v_subgroup_2_98 UUID;
+  v_subgroup_2_100 UUID;
+  v_assessment_count BIGINT;
+  v_criterion_count BIGINT;
+  v_subgroup_count BIGINT;
+  v_assessment_snapshot JSONB;
+  v_criterion_snapshot JSONB;
+  v_subgroup_snapshot JSONB;
+  v_result JSONB;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_evaluation_hierarchy_order_phase_gate')
+  );
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P5C0 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id,
+    device_type_name,
+    name,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_dossier_id,
+    'P5C0 device ' || v_suffix,
+    'P5C0 dossier ' || v_suffix,
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_suppliers (
+    id,
+    dossier_id,
+    name,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_supplier_id,
+    v_dossier_id,
+    'P5C0 Supplier',
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_options (
+    id,
+    dossier_id,
+    supplier_id,
+    option_name,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_option_id,
+    v_dossier_id,
+    v_supplier_id,
+    'P5C0 Option',
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id,
+    dossier_id,
+    version_number,
+    status,
+    next_criterion_number,
+    revision,
+    locked_at,
+    locked_by,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_version_id,
+    v_dossier_id,
+    1,
+    'locked',
+    102,
+    1,
+    now(),
+    v_user_id,
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id,
+    baseline_version_id,
+    name,
+    sort_order,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_group_id,
+    v_version_id,
+    'P5C0 Group',
+    1,
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_baseline_subgroups (
+    id,
+    baseline_version_id,
+    group_id,
+    name,
+    sort_order,
+    created_by,
+    updated_by
+  ) VALUES
+    (
+      v_subgroup_1_id,
+      v_version_id,
+      v_group_id,
+      'P5C0 Subgroup 1',
+      1,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_subgroup_2_id,
+      v_version_id,
+      v_group_id,
+      'P5C0 Subgroup 2',
+      2,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id,
+    baseline_version_id,
+    group_id,
+    subgroup_id,
+    criterion_code,
+    requirement_text,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  SELECT
+    gen_random_uuid(),
+    v_version_id,
+    v_group_id,
+    CASE
+      WHEN series = 101 THEN NULL
+      WHEN series % 2 = 1 THEN v_subgroup_1_id
+      ELSE v_subgroup_2_id
+    END,
+    'TC-' || lpad(series::TEXT, 4, '0'),
+    'P5C0 criterion ' || series,
+    series,
+    v_user_id,
+    v_user_id
+  FROM generate_series(1, 101) AS series;
+
+  SELECT id INTO v_direct_101
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id IS NULL
+    AND sort_order = 101;
+  SELECT id INTO v_subgroup_1_1
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_1_id
+    AND sort_order = 1;
+  SELECT id INTO v_subgroup_1_97
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_1_id
+    AND sort_order = 97;
+  SELECT id INTO v_subgroup_1_99
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_1_id
+    AND sort_order = 99;
+  SELECT id INTO v_subgroup_2_2
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_2_id
+    AND sort_order = 2;
+  SELECT id INTO v_subgroup_2_98
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_2_id
+    AND sort_order = 98;
+  SELECT id INTO v_subgroup_2_100
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+    AND subgroup_id = v_subgroup_2_id
+    AND sort_order = 100;
+
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id,
+    dossier_id,
+    option_id,
+    baseline_version_id,
+    created_by,
+    updated_by
+  ) VALUES (
+    v_set_id,
+    v_dossier_id,
+    v_option_id,
+    v_version_id,
+    v_user_id,
+    v_user_id
+  );
+
+  INSERT INTO public.technical_configuration_manual_assessments (
+    comparison_set_id,
+    baseline_version_id,
+    criterion_id,
+    technical_axis,
+    evidence_axis,
+    created_by,
+    updated_by
+  ) VALUES
+    (v_set_id, v_version_id, v_direct_101, 'fails', 'complete', v_user_id, v_user_id),
+    (v_set_id, v_version_id, v_subgroup_1_97, 'meets', 'partial', v_user_id, v_user_id),
+    (v_set_id, v_version_id, v_subgroup_1_99, 'fails', 'complete', v_user_id, v_user_id),
+    (v_set_id, v_version_id, v_subgroup_2_98, 'meets', 'missing', v_user_id, v_user_id),
+    (v_set_id, v_version_id, v_subgroup_2_100, 'fails', 'missing', v_user_id, v_user_id);
+
+  SELECT count(*) INTO v_assessment_count
+  FROM public.technical_configuration_manual_assessments
+  WHERE comparison_set_id = v_set_id;
+  SELECT count(*) INTO v_criterion_count
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id;
+  SELECT count(*) INTO v_subgroup_count
+  FROM public.technical_configuration_baseline_subgroups
+  WHERE baseline_version_id = v_version_id;
+  SELECT COALESCE(
+    jsonb_agg(to_jsonb(assessment_row) ORDER BY assessment_row.criterion_id),
+    '[]'::JSONB
+  ) INTO v_assessment_snapshot
+  FROM public.technical_configuration_manual_assessments assessment_row
+  WHERE assessment_row.comparison_set_id = v_set_id;
+  SELECT COALESCE(
+    jsonb_agg(to_jsonb(criterion_row) ORDER BY criterion_row.id),
+    '[]'::JSONB
+  ) INTO v_criterion_snapshot
+  FROM public.technical_configuration_baseline_criteria criterion_row
+  WHERE criterion_row.baseline_version_id = v_version_id;
+  SELECT COALESCE(
+    jsonb_agg(to_jsonb(subgroup_row) ORDER BY subgroup_row.id),
+    '[]'::JSONB
+  ) INTO v_subgroup_snapshot
+  FROM public.technical_configuration_baseline_subgroups subgroup_row
+  WHERE subgroup_row.baseline_version_id = v_version_id;
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  SELECT public.technical_configuration_evaluation_criteria_list(
+    v_option_id,
+    v_version_id,
+    'all',
+    1,
+    100
+  ) INTO v_result;
+  PERFORM pg_temp.assert_true(
+    'hierarchy overrides interleaved flat order at boundaries 50/51 and 100/101',
+    (v_result->>'total')::BIGINT = 101
+    AND jsonb_array_length(v_result->'data') = 100
+    AND (v_result->'data'->0->>'criterion_id')::UUID = v_direct_101
+    AND (v_result->'data'->0->>'canonical_index')::BIGINT = 1
+    AND (v_result->'data'->0->>'canonical_page')::BIGINT = 1
+    AND (v_result->'data'->1->>'criterion_id')::UUID = v_subgroup_1_1
+    AND (v_result->'data'->49->>'criterion_id')::UUID = v_subgroup_1_97
+    AND (v_result->'data'->49->>'canonical_index')::BIGINT = 50
+    AND (v_result->'data'->49->>'canonical_page')::BIGINT = 1
+    AND (v_result->'data'->50->>'criterion_id')::UUID = v_subgroup_1_99
+    AND (v_result->'data'->50->>'canonical_index')::BIGINT = 51
+    AND (v_result->'data'->50->>'canonical_page')::BIGINT = 2
+    AND (v_result->'data'->51->>'criterion_id')::UUID = v_subgroup_2_2
+    AND (v_result->'data'->99->>'criterion_id')::UUID = v_subgroup_2_98
+    AND (v_result->'data'->99->>'canonical_index')::BIGINT = 100
+    AND (v_result->'data'->99->>'canonical_page')::BIGINT = 2
+  );
+
+  SELECT public.technical_configuration_evaluation_criteria_list(
+    v_option_id,
+    v_version_id,
+    'all',
+    2,
+    100
+  ) INTO v_result;
+  PERFORM pg_temp.assert_true(
+    'transport page two retains canonical boundary 100/101 without wrapping',
+    (v_result->>'total')::BIGINT = 101
+    AND jsonb_array_length(v_result->'data') = 1
+    AND (v_result->'data'->0->>'criterion_id')::UUID = v_subgroup_2_100
+    AND (v_result->'data'->0->>'canonical_index')::BIGINT = 101
+    AND (v_result->'data'->0->>'canonical_page')::BIGINT = 3
+  );
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  SELECT public.technical_configuration_evaluation_criteria_list(
+    v_option_id,
+    v_version_id,
+    'fails',
+    1,
+    100
+  ) INTO v_result;
+  PERFORM pg_temp.assert_true(
+    'filter keeps sparse canonical indexes and pages from the full hierarchy',
+    (v_result->>'total')::BIGINT = 3
+    AND jsonb_array_length(v_result->'data') = 3
+    AND (v_result->'data'->0->>'criterion_id')::UUID = v_direct_101
+    AND (v_result->'data'->0->>'canonical_index')::BIGINT = 1
+    AND (v_result->'data'->0->>'canonical_page')::BIGINT = 1
+    AND (v_result->'data'->1->>'criterion_id')::UUID = v_subgroup_1_99
+    AND (v_result->'data'->1->>'canonical_index')::BIGINT = 51
+    AND (v_result->'data'->1->>'canonical_page')::BIGINT = 2
+    AND (v_result->'data'->2->>'criterion_id')::UUID = v_subgroup_2_100
+    AND (v_result->'data'->2->>'canonical_index')::BIGINT = 101
+    AND (v_result->'data'->2->>'canonical_page')::BIGINT = 3
+  );
+
+  SELECT public.technical_configuration_evaluation_criteria_list(
+    v_option_id,
+    v_version_id,
+    'insufficient_evidence',
+    1,
+    100
+  ) INTO v_result;
+  PERFORM pg_temp.assert_true(
+    'evidence filter preserves hierarchy order across comparison pages',
+    (v_result->>'total')::BIGINT = 2
+    AND (v_result->'data'->0->>'criterion_id')::UUID = v_subgroup_1_97
+    AND (v_result->'data'->0->>'canonical_index')::BIGINT = 50
+    AND (v_result->'data'->1->>'criterion_id')::UUID = v_subgroup_2_98
+    AND (v_result->'data'->1->>'canonical_index')::BIGINT = 100
+  );
+
+  PERFORM pg_temp.assert_true(
+    'evaluation hierarchy reads do not mutate phase-gate data',
+    (
+      SELECT count(*) = v_assessment_count
+      FROM public.technical_configuration_manual_assessments
+      WHERE comparison_set_id = v_set_id
+    )
+    AND (
+      SELECT count(*) = v_criterion_count
+      FROM public.technical_configuration_baseline_criteria
+      WHERE baseline_version_id = v_version_id
+    )
+    AND (
+      SELECT count(*) = v_subgroup_count
+      FROM public.technical_configuration_baseline_subgroups
+      WHERE baseline_version_id = v_version_id
+    )
+    AND (
+      SELECT COALESCE(
+        jsonb_agg(to_jsonb(assessment_row) ORDER BY assessment_row.criterion_id),
+        '[]'::JSONB
+      ) = v_assessment_snapshot
+      FROM public.technical_configuration_manual_assessments assessment_row
+      WHERE assessment_row.comparison_set_id = v_set_id
+    )
+    AND (
+      SELECT COALESCE(
+        jsonb_agg(to_jsonb(criterion_row) ORDER BY criterion_row.id),
+        '[]'::JSONB
+      ) = v_criterion_snapshot
+      FROM public.technical_configuration_baseline_criteria criterion_row
+      WHERE criterion_row.baseline_version_id = v_version_id
+    )
+    AND (
+      SELECT COALESCE(
+        jsonb_agg(to_jsonb(subgroup_row) ORDER BY subgroup_row.id),
+        '[]'::JSONB
+      ) = v_subgroup_snapshot
+      FROM public.technical_configuration_baseline_subgroups subgroup_row
+      WHERE subgroup_row.baseline_version_id = v_version_id
+    )
+  );
+
+END;
+$gate$;
+
+ROLLBACK;

--- a/supabase/tests/technical_configuration_evaluation_hierarchy_order_security_phase_gate.sql
+++ b/supabase/tests/technical_configuration_evaluation_hierarchy_order_security_phase_gate.sql
@@ -1,0 +1,153 @@
+-- P5C0 rollback-only evaluation hierarchy authorization and privilege gate.
+BEGIN;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_label;
+  END IF;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+      v_state = RETURNED_SQLSTATE,
+      v_message = MESSAGE_TEXT;
+    IF v_state IS DISTINCT FROM p_expected_state
+       OR v_message IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION '%: expected [%] %, got [%] %',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_user_id BIGINT;
+  v_option_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_function_signature TEXT :=
+    'public.technical_configuration_evaluation_criteria_list(uuid,uuid,text,integer,integer)';
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_evaluation_hierarchy_order_security_phase_gate')
+  );
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P5C0 security phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_evaluation_criteria_list(%L::UUID, %L::UUID, %L, 1, 100)',
+      v_option_id,
+      v_version_id,
+      'all'
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role rejected',
+    format(
+      'SELECT public.technical_configuration_evaluation_criteria_list(%L::UUID, %L::UUID, %L, 1, 100)',
+      v_option_id,
+      v_version_id,
+      'all'
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'invalid filter rejected before lookup',
+    format(
+      'SELECT public.technical_configuration_evaluation_criteria_list(%L::UUID, %L::UUID, %L, 1, 100)',
+      v_option_id,
+      v_version_id,
+      'meets'
+    ),
+    'PT422',
+    'validation_error'
+  );
+  PERFORM pg_temp.expect_error(
+    'oversized page rejected before lookup',
+    format(
+      'SELECT public.technical_configuration_evaluation_criteria_list(%L::UUID, %L::UUID, %L, 1, 101)',
+      v_option_id,
+      v_version_id,
+      'all'
+    ),
+    'PT422',
+    'validation_error'
+  );
+
+  PERFORM pg_temp.assert_true(
+    'function remains security definer with hardened search path',
+    (
+      SELECT procedure.prosecdef
+        AND procedure.proconfig @> ARRAY['search_path=public, pg_temp']
+      FROM pg_proc procedure
+      WHERE procedure.oid = v_function_signature::regprocedure
+    )
+  );
+  PERFORM pg_temp.assert_true(
+    'authenticated executes hierarchy-aware criteria rpc',
+    has_function_privilege('authenticated', v_function_signature, 'EXECUTE')
+  );
+  PERFORM pg_temp.assert_true(
+    'service role executes hierarchy-aware criteria rpc',
+    has_function_privilege('service_role', v_function_signature, 'EXECUTE')
+  );
+  PERFORM pg_temp.assert_true(
+    'anon cannot execute hierarchy-aware criteria rpc',
+    NOT has_function_privilege('anon', v_function_signature, 'EXECUTE')
+  );
+END;
+$gate$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- amend the OpenSpec P5C contract and TDD plan for hierarchy-aware evaluation ordering
- add canonical three-level evaluation RPC ordering plus source and executable phase-gate contracts
- add the shared hierarchy flattener, structural navigator rows, full-universe progress, collapse/auto-expand, and canonical page navigation
- preserve authoritative complete-assessment cache semantics across load, failure, first-save, and save-next flows
- keep production comparison, result export, assessment persistence, and the legacy 21-case workspace test file unchanged

## Verification
- format, TypeScript docstrings, no-explicit-any, diff-only dedupe, and typecheck: pass
- focused affected suite: 13 files, 95 tests passed
- legacy workspace regression: 21/21 passed; file is byte-identical to `main@c6d3d6b9` and absent from the final diff
- React Doctor changed scan: 98/100, zero issues
- OpenSpec strict: valid
- broad technical-configuration suite: 134/136 files and 1177/1179 tests pass; the only failures are the two unchanged Issue #903 phase-gate assertions
- broad suite excluding the two Issue #903 files: 134 files, 1159 tests passed
- production scope, canonical traversal, diff integrity, and file-size guards: pass
- independent final review: Zero findings

## Pre-land status
- final commit: `cf1550c8`
- no live Supabase write or migration application was performed
- P5C.7 remains open only for the two executable SQL phase gates after the migration is applied to an authorized target environment
- browser E2E was not run; focused workspace/UI regressions and React Doctor are green

Refs #904
Related: #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hierarchy-aware technical configuration evaluation with groups, subgroups, collapsible navigation, canonical ordering, filtering, and pagination.
  * Added section and subgroup progress summaries with status counts and aggregate totals.
  * Improved criterion navigation, selection, and post-save advancement across hierarchy levels.
  * Added reliable assessment caching to preserve complete evaluation progress and support retry handling.
  * Continued support for legacy two-level configurations.

* **Bug Fixes**
  * Prevented presentation filters, pagination, expansion, or unsaved changes from affecting aggregate evaluation totals.
  * Added validation for invalid hierarchy references and duplicate criteria.

* **Tests**
  * Expanded coverage for hierarchy rendering, navigation, progress, caching, ordering, security, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->