### PR TITLE
feat(technical-config): activate P6A hierarchy server contracts

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6a-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6a-tdd-plan.md
@@ -1,0 +1,180 @@
+# P6A Cross-Surface Regression And Server Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if
+> subagents are available) or superpowers:executing-plans to implement this plan. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** #894
+
+**Base:** `main@67fd7fecc604eba047543bd713c59792f996c940` after PR #907
+
+**Branch:** `feat/894-p6a-hierarchy-server-activation`
+
+**Goal:** Prove every production technical-configuration reader is hierarchy-aware, then
+activate the already-deployed hierarchy authoring and XLSX v2 apply server contracts
+without mounting the P6B production controls.
+
+## Discovery And Scope
+
+- AgentMemory confirms P2B deliberately left
+  `technical_configuration_baseline_import_apply_v2` fail-closed with
+  `PT409 hierarchical_import_apply_not_activated`.
+- Code Review Graph narrows the change to the baseline RPC manifests, RPC proxy
+  allowlist, activation migration/source contracts, dormant import/authoring harnesses,
+  and hierarchy-aware evaluation/comparison/result-export readers.
+- GitNexus was stale, so it was reindexed at `67fd7fec`; `AGENTS.md` and `CLAUDE.md`
+  were restored immediately afterward.
+- Live Supabase read-only inspection confirms:
+  - the public v2 apply wrapper is executable by `authenticated` but still raises the
+    P2B not-activated error;
+  - all seven hierarchy authoring RPCs are deployed but ungranted;
+  - the hierarchy-aware evaluation read migration is deployed.
+- Issue #903 is in scope because its two stale assertions inspect the exact P6A
+  activation contracts. Reconcile the assertions without changing historical
+  migrations merely to satisfy stale text.
+- Issue #892 remains open only for authorized executable SQL phase gates. Its merged
+  code and migration are present on `main` and live Supabase, but the live gates still
+  require explicit permission.
+
+## Activation Contract
+
+- Add one superseding migration ordered after
+  `20260812140500_technical_configuration_evaluation_hierarchy_order.sql`.
+- Replace only the public v2 apply wrapper so it delegates to
+  `_technical_configuration_baseline_import_apply_v2`.
+- Keep the internal apply function ungranted.
+- Grant `EXECUTE` to `authenticated` only for:
+  - `technical_configuration_baseline_subgroup_create`
+  - `technical_configuration_baseline_subgroup_update`
+  - `technical_configuration_baseline_subgroup_delete`
+  - `technical_configuration_baseline_subgroups_reorder`
+  - `technical_configuration_baseline_hierarchy_criterion_create`
+  - `technical_configuration_baseline_hierarchy_criterion_move`
+  - `technical_configuration_baseline_hierarchy_criteria_reorder`
+- Allowlist the same seven functions in the RPC proxy. The P4C hierarchy save path uses
+  all seven, so activating only the four subgroup functions would leave P6B authoring
+  partially callable.
+- Keep legacy import apply byte/function contracts unchanged.
+- Keep both XLSX v2 download actions, hierarchy import, and subgroup authoring absent
+  from the production baseline tab until P6B.
+
+## Chunk 1: RED Server Activation Contracts
+
+### RED 1 - Proxy And Migration Contract
+
+- [x] Add the focused failing activation test at
+      `src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts`.
+- [x] Assert all seven hierarchy authoring RPCs are in `ALLOWED_FUNCTIONS` and absent
+      from `SERVICE_ROLE_RPC_FUNCTIONS`.
+- [x] Assert the new migration sorts after the latest hierarchy-aware reader migration.
+- [x] Assert the public v2 apply wrapper delegates to the internal atomic apply function
+      and no longer contains the P2B not-activated error.
+- [x] Assert the internal apply stays ungranted and the public wrapper plus seven
+      authoring RPCs grant only `authenticated`.
+- [x] Run the focused test and record the expected RED failure.
+
+Run:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  src/app/\(app\)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
+```
+
+### GREEN 1 - Minimal Server Activation
+
+- [x] Move the seven-RPC manifest to the shared baseline RPC owner and preserve the
+      existing app-level export for current consumers.
+- [x] Add the seven names to the production RPC proxy allowlist.
+- [x] Add the superseding P6A migration with explicit revoke/grant statements and a
+      secured public v2 apply wrapper.
+- [x] Add a rollback-only activation security phase gate that verifies function
+      existence, privileges, wrapper delegation, and internal-function isolation.
+- [x] Run the focused activation and RPC whitelist tests until green.
+
+## Chunk 2: RED/GREEN Stale Phase Contracts
+
+- [x] Update the P2B apply source-contract test to preserve historical P2B guarantees
+      while recognizing that the current client hook now contains the dormant v2 apply
+      path.
+- [x] Update the P1E subgroup mutation phase assertion to recognize completed P2B and
+      completed local P6A verification.
+- [x] Run both Issue #903 reproduction files and verify they pass for the canonical
+      current phase contract.
+
+Run:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  src/app/api/rpc/__tests__/technical-configuration-baseline-hierarchy-apply-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-baseline-subgroup-mutations-migration.test.ts
+```
+
+## Chunk 3: Cross-Surface And Browser Regressions
+
+- [x] Exercise both XLSX v2 downloads and assert current-data versus blank-template
+      structure, hidden identity, and example-only instructions.
+- [x] Exercise small, example-sized, and configured safety-bound workbooks without
+      hard-coded business row counts.
+- [x] Exercise parse/preview/apply round trips, invalid hierarchy rejection, revision
+      retry, and explicit destructive replacement confirmation using the dormant
+      hierarchy import harness.
+- [x] Exercise subgroup authoring, direct/subgroup criterion movement, ordering, save
+      resume, and rollback-safe failure behavior using the dormant authoring harness.
+- [x] Exercise aggregate evaluation, hierarchy-aware comparison, and hierarchy-aware
+      result export with mixed direct/subgroup criteria.
+- [x] Keep production-isolation assertions green for both downloads, hierarchy import,
+      and subgroup authoring.
+- [ ] Run browser-level narrow and wide viewport checks against the dormant harness or
+      the nearest existing browser-capable test surface. Check keyboard operation,
+      accessible names, long Vietnamese text, overflow/overlap, and console errors.
+- [x] Do not add a production route, feature flag, or mount point solely for testing.
+
+Browser execution note (2026-08-13): the browser-level item above was explicitly skipped
+by user instruction. Component and library regressions remain the recorded non-browser
+evidence.
+
+## Chunk 4: Local Verification
+
+- [x] Run SQL migration source contracts and rollback-only SQL gate source contracts.
+- [x] Run all focused XLSX v2, destructive replacement, hierarchy authoring, aggregate,
+      evaluation, comparison, and result-export regressions.
+- [x] Run the full technical-configuration app/lib/API regression set.
+- [x] Run required TypeScript/React gates in repository order.
+- [x] Run React Doctor changed scan.
+- [x] Run strict OpenSpec validation.
+- [x] Run Code Review Graph changed-file review and GitNexus changed-symbol impact.
+- [x] Request independent review and iterate until zero actionable findings.
+
+Required gate order:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+# focused and broad Vitest commands
+node scripts/npm-run.js run react-doctor
+openspec validate revise-technical-configuration-baseline-hierarchy --strict
+```
+
+## Chunk 5: Authorized Live Supabase Checkpoint
+
+- [x] Stop and request explicit permission before any live write.
+- [x] After permission, apply only the P6A migration through Supabase MCP.
+- [x] Run the authorized P5C and P6A executable SQL phase gates through Supabase MCP.
+- [x] Verify live privileges, public v2 delegation, internal isolation, and unchanged
+      legacy apply contracts.
+- [x] Run Supabase security and performance advisors.
+- [x] Do not use Supabase CLI.
+
+## Chunk 6: Closeout
+
+- [x] Mark P6A tasks complete only after local regressions, the documented user-directed
+      browser omission, and authorized server activation evidence are complete.
+- [x] Resolve Issue #903 if both stale assertions are fully covered by this PR.
+- [x] Update Issue #892 only if its authorized executable phase gates are completed.
+- [ ] Commit with Lefthook enabled, pull with rebase, push the branch, and verify it is
+      up to date with origin.
+- [ ] Open a PR to `main` that closes #894 and, if fully resolved, #903.
+- [ ] Report verification, live DB actions, residual risks, and review status before
+      merge. Do not merge without the user's next instruction.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6a-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6a-tdd-plan.md
@@ -173,8 +173,8 @@ openspec validate revise-technical-configuration-baseline-hierarchy --strict
       browser omission, and authorized server activation evidence are complete.
 - [x] Resolve Issue #903 if both stale assertions are fully covered by this PR.
 - [x] Update Issue #892 only if its authorized executable phase gates are completed.
-- [ ] Commit with Lefthook enabled, pull with rebase, push the branch, and verify it is
+- [x] Commit with Lefthook enabled, pull with rebase, push the branch, and verify it is
       up to date with origin.
-- [ ] Open a PR to `main` that closes #894 and, if fully resolved, #903.
-- [ ] Report verification, live DB actions, residual risks, and review status before
+- [x] Open a PR to `main` that closes #894 and, if fully resolved, #903.
+- [x] Report verification, live DB actions, residual risks, and review status before
       merge. Do not merge without the user's next instruction.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -380,18 +380,33 @@ Depends on: P3D, P4C, P5B, P5C, P5D.
 Deploy boundary: subgroup mutation RPCs and XLSX v2 apply become callable only after
 all readers are hierarchy-aware; production UI controls remain unmounted.
 
-- [ ] P6A.1 Run strict OpenSpec validation, formatting, `verify:no-explicit-any`,
+- [x] P6A.1 Run strict OpenSpec validation, formatting, `verify:no-explicit-any`,
       `verify:dedupe`, typecheck, focused tests, full technical-configuration regressions,
       and React Doctor.
 - [ ] P6A.2 Browser-test both downloads, round-trip import, invalid hierarchy,
       destructive replacement, hierarchy authoring, aggregate evaluation, comparison, and
       result export while activation remains off.
-- [ ] P6A.3 Exercise representative small, example-sized, and safety-bound XLSX files
+- [x] P6A.3 Exercise representative small, example-sized, and safety-bound XLSX files
       without hard-coded business row counts.
-- [ ] P6A.4 After explicit authorization, grant/allowlist subgroup mutations and enable
+- [x] P6A.4 After explicit authorization, grant/allowlist subgroup mutations and enable
       XLSX v2 apply, then prove no production reader can observe unsupported hierarchy.
 - [ ] P6A.5 Verify accessibility, narrow/wide layouts, long Vietnamese text, console
       errors, and non-overlapping controls.
+
+Browser execution note (2026-08-13): P6A.2 and the browser-dependent portions of P6A.5
+were explicitly skipped by user instruction. Production-isolation component tests still
+prove the two XLSX v2 downloads and hierarchy import remain unmounted.
+
+P6A.4 status: complete. Local migration `20260813105912` was applied through Supabase
+MCP as live migration `20260813132516`; the P6A activation gate and both pending P5C
+rollback-only gates passed. Live inspection confirmed authenticated-only execution for
+the public apply wrapper and seven hierarchy authoring RPCs, no direct execution for the
+internal apply worker, hardened search paths, and reviewed advisor output. The activation
+gate also exercised all seven authoring RPCs as database role `authenticated`: missing
+claims and non-global claims returned `42501`, while raw `admin` claims reached the
+target `PT404` guard. The activation-related authenticated `SECURITY DEFINER` warnings
+are expected for guarded RPCs; the remaining notices are existing baseline items outside
+P6A scope.
 
 ## Phase P6B - Production UI Activation
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
@@ -24,7 +24,11 @@ describe("technical configuration hierarchy import production isolation", () => 
     renderTab()
 
     expect(await screen.findByRole("button", { name: "Tải template Excel" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Tải cấu hình hiện tại" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Tải mẫu trống" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Nhập cấu hình phân cấp" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("combobox", { name: /Chuyển tiêu chí/i })).not.toBeInTheDocument()
     expect(
       screen.queryByRole("dialog", { name: "Nhập cấu hình phân cấp từ Excel" })
     ).not.toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
@@ -28,7 +28,6 @@ describe("technical configuration hierarchy import production isolation", () => 
     expect(screen.queryByRole("button", { name: "Tải mẫu trống" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Nhập cấu hình phân cấp" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole("combobox", { name: /Chuyển tiêu chí/i })).not.toBeInTheDocument()
     expect(
       screen.queryByRole("dialog", { name: "Nhập cấu hình phân cấp từ Excel" })
     ).not.toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "@/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs"
+import { BASELINE_RPC_FUNCTIONS } from "@/lib/technical-configuration-baseline-rpcs"
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "supabase/migrations")
+const ACTIVATION_SUFFIX = "_technical_configuration_baseline_hierarchy_server_activation.sql"
+const ACTIVATION_GATE_PATH = path.resolve(
+  process.cwd(),
+  "supabase/tests/technical_configuration_baseline_hierarchy_server_activation_security_gate.sql"
+)
+const LATEST_READER_MIGRATION =
+  "20260812140500_technical_configuration_evaluation_hierarchy_order.sql"
+const INTERNAL_APPLY_FUNCTION = "_technical_configuration_baseline_import_apply_v2"
+const PUBLIC_APPLY_FUNCTION = "technical_configuration_baseline_import_apply_v2"
+const APPLY_SIGNATURE = "(UUID, JSONB, JSONB, BIGINT)"
+
+function readActivationMigration() {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(ACTIVATION_SUFFIX))
+    .sort()
+
+  expect(files).toHaveLength(1)
+  const file = files[0]
+  if (!file) {
+    throw new Error("P6A activation migration is missing")
+  }
+
+  return {
+    file,
+    source: readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"),
+  }
+}
+
+describe("technical configuration P6A hierarchy server activation", () => {
+  it("allowlists the complete seven-RPC hierarchy authoring manifest for authenticated use", () => {
+    const authoringFunctions = Object.values(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS
+    )
+
+    expect(authoringFunctions).toHaveLength(7)
+    for (const fn of authoringFunctions) {
+      expect(ALLOWED_FUNCTIONS.has(fn)).toBe(true)
+      expect(SERVICE_ROLE_RPC_FUNCTIONS.has(fn)).toBe(false)
+    }
+  })
+
+  it("ships a superseding migration that activates v2 apply without exposing its internal worker", () => {
+    const activation = readActivationMigration()
+
+    expect(activation.file.localeCompare(LATEST_READER_MIGRATION)).toBeGreaterThan(0)
+    expect(activation.source).toContain(
+      `CREATE OR REPLACE FUNCTION public.${PUBLIC_APPLY_FUNCTION}(`
+    )
+    expect(activation.source).toContain(`RETURN public.${INTERNAL_APPLY_FUNCTION}(`)
+    expect(activation.source).not.toContain("hierarchical_import_apply_not_activated")
+    expect(activation.source).toContain(
+      `REVOKE ALL ON FUNCTION public.${INTERNAL_APPLY_FUNCTION}${APPLY_SIGNATURE} FROM PUBLIC, anon, authenticated, service_role;`
+    )
+    expect(activation.source).not.toContain(
+      `GRANT EXECUTE ON FUNCTION public.${INTERNAL_APPLY_FUNCTION}${APPLY_SIGNATURE}`
+    )
+    expect(activation.source).toContain(
+      `GRANT EXECUTE ON FUNCTION public.${PUBLIC_APPLY_FUNCTION}${APPLY_SIGNATURE} TO authenticated;`
+    )
+    expect(BASELINE_RPC_FUNCTIONS.applyHierarchyImport).toBe(PUBLIC_APPLY_FUNCTION)
+  })
+
+  it("grants every hierarchy authoring RPC only to authenticated", () => {
+    const activation = readActivationMigration().source
+
+    for (const fn of Object.values(TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS)) {
+      expect(activation).toContain(`REVOKE ALL ON FUNCTION public.${fn}`)
+      expect(activation).toMatch(
+        new RegExp(
+          `GRANT EXECUTE ON FUNCTION public\\.${fn.replaceAll("_", "\\_")}\\([^;]+\\) TO authenticated;`
+        )
+      )
+    }
+  })
+
+  it("ships a rollback-only security gate for the activated server contracts", () => {
+    const gate = readFileSync(ACTIVATION_GATE_PATH, "utf8")
+
+    expect(gate).toContain("BEGIN;")
+    expect(gate).toContain("ROLLBACK;")
+    expect(gate).toContain("public v2 apply delegation contract mismatch")
+    expect(gate).toContain("internal v2 apply privilege contract mismatch")
+    expect(gate).toContain("hierarchy authoring privilege contract mismatch")
+    expect(gate).toContain("public v2 apply missing claims rejected")
+    expect(gate).toContain("public v2 apply delegates to editable version guard")
+    expect(gate).toContain("SET LOCAL ROLE authenticated;")
+    expect(gate).toContain("hierarchy authoring missing claims rejected")
+    expect(gate).toContain("hierarchy authoring non-global role rejected")
+    expect(gate).toContain("hierarchy authoring admin reaches target guard")
+    expect(gate).toContain("'42501'")
+    expect(gate).toContain("'PT404'")
+    for (const fn of Object.values(TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS)) {
+      expect(gate).toContain(fn)
+    }
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
@@ -13,11 +13,44 @@ const ACTIVATION_GATE_PATH = path.resolve(
   process.cwd(),
   "supabase/tests/technical_configuration_baseline_hierarchy_server_activation_security_gate.sql"
 )
-const LATEST_READER_MIGRATION =
-  "20260812140500_technical_configuration_evaluation_hierarchy_order.sql"
+const FUNCTION_DEFINITION_PATTERN = /CREATE OR REPLACE FUNCTION public\.([a-z0-9_]+)\s*\(/gi
 const INTERNAL_APPLY_FUNCTION = "_technical_configuration_baseline_import_apply_v2"
 const PUBLIC_APPLY_FUNCTION = "technical_configuration_baseline_import_apply_v2"
 const APPLY_SIGNATURE = "(UUID, JSONB, JSONB, BIGINT)"
+
+function isHierarchyDependentReader(fn: string) {
+  return (
+    fn === "_technical_configuration_baseline_snapshot" ||
+    /^technical_configuration_baseline(?:_.+)?_(?:get|list)$/.test(fn) ||
+    /^technical_configuration_comparison(?:_.+)?_(?:get|list)$/.test(fn) ||
+    /^technical_configuration_(?:assessments?|evaluation)(?:_.+)?_(?:get|list)$/.test(fn) ||
+    /^technical_configuration_result_export(?:_.+)?_(?:get|list)$/.test(fn)
+  )
+}
+
+function containsHierarchyDependentReader(source: string) {
+  return Array.from(source.matchAll(FUNCTION_DEFINITION_PATTERN), ([, fn]) => fn).some(
+    (fn) => fn !== undefined && isHierarchyDependentReader(fn)
+  )
+}
+
+function findLatestHierarchyReaderMigration() {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith(".sql") && !file.endsWith(ACTIVATION_SUFFIX))
+    .filter((file) => {
+      const source = readFileSync(path.join(MIGRATIONS_DIR, file), "utf8")
+
+      return containsHierarchyDependentReader(source)
+    })
+    .sort()
+  const file = files.at(-1)
+
+  if (!file) {
+    throw new Error("Hierarchy-aware reader migration is missing")
+  }
+
+  return file
+}
 
 function readActivationMigration() {
   const files = readdirSync(MIGRATIONS_DIR)
@@ -37,6 +70,26 @@ function readActivationMigration() {
 }
 
 describe("technical configuration P6A hierarchy server activation", () => {
+  it("tracks migrations for every hierarchy-dependent production reader surface", () => {
+    const readerFunctions = [
+      "_technical_configuration_baseline_snapshot",
+      "technical_configuration_baseline_versions_list",
+      "technical_configuration_comparison_get",
+      "technical_configuration_assessments_list",
+      "technical_configuration_evaluation_criteria_list",
+      "technical_configuration_result_export_manifest_get",
+      "technical_configuration_result_export_matrix_list",
+    ]
+
+    for (const fn of readerFunctions) {
+      expect(isHierarchyDependentReader(fn)).toBe(true)
+    }
+    expect(isHierarchyDependentReader(PUBLIC_APPLY_FUNCTION)).toBe(false)
+    expect(isHierarchyDependentReader("technical_configuration_baseline_subgroup_create")).toBe(
+      false
+    )
+  })
+
   it("allowlists the complete seven-RPC hierarchy authoring manifest for authenticated use", () => {
     const authoringFunctions = Object.values(
       TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS
@@ -51,8 +104,9 @@ describe("technical configuration P6A hierarchy server activation", () => {
 
   it("ships a superseding migration that activates v2 apply without exposing its internal worker", () => {
     const activation = readActivationMigration()
+    const latestReaderMigration = findLatestHierarchyReaderMigration()
 
-    expect(activation.file.localeCompare(LATEST_READER_MIGRATION)).toBeGreaterThan(0)
+    expect(activation.file.localeCompare(latestReaderMigration)).toBeGreaterThan(0)
     expect(activation.source).toContain(
       `CREATE OR REPLACE FUNCTION public.${PUBLIC_APPLY_FUNCTION}(`
     )

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-hierarchy-activation.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from "vitest"
 
 import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "@/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs"
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
 import { BASELINE_RPC_FUNCTIONS } from "@/lib/technical-configuration-baseline-rpcs"
+import { COMPARISON_READ_RPC_FUNCTIONS } from "@/lib/technical-configuration-comparison-rpcs"
+import { DOCUMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-document-rpcs"
+import { RESULT_EXPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-result-export-rpcs"
 
 const MIGRATIONS_DIR = path.resolve(process.cwd(), "supabase/migrations")
 const ACTIVATION_SUFFIX = "_technical_configuration_baseline_hierarchy_server_activation.sql"
@@ -13,24 +17,24 @@ const ACTIVATION_GATE_PATH = path.resolve(
   process.cwd(),
   "supabase/tests/technical_configuration_baseline_hierarchy_server_activation_security_gate.sql"
 )
-const FUNCTION_DEFINITION_PATTERN = /CREATE OR REPLACE FUNCTION public\.([a-z0-9_]+)\s*\(/gi
+const FUNCTION_DEFINITION_PATTERN = /CREATE(?: OR REPLACE)? FUNCTION public\.([a-z0-9_]+)\s*\(/gi
 const INTERNAL_APPLY_FUNCTION = "_technical_configuration_baseline_import_apply_v2"
 const PUBLIC_APPLY_FUNCTION = "technical_configuration_baseline_import_apply_v2"
 const APPLY_SIGNATURE = "(UUID, JSONB, JSONB, BIGINT)"
-
-function isHierarchyDependentReader(fn: string) {
-  return (
-    fn === "_technical_configuration_baseline_snapshot" ||
-    /^technical_configuration_baseline(?:_.+)?_(?:get|list)$/.test(fn) ||
-    /^technical_configuration_comparison(?:_.+)?_(?:get|list)$/.test(fn) ||
-    /^technical_configuration_(?:assessments?|evaluation)(?:_.+)?_(?:get|list)$/.test(fn) ||
-    /^technical_configuration_result_export(?:_.+)?_(?:get|list)$/.test(fn)
-  )
-}
+const HIERARCHY_DEPENDENT_READER_FUNCTIONS = new Set([
+  "_technical_configuration_baseline_snapshot",
+  BASELINE_RPC_FUNCTIONS.getDraft,
+  BASELINE_RPC_FUNCTIONS.listVersions,
+  DOCUMENT_RPC_FUNCTIONS.listBaselineDocuments,
+  COMPARISON_READ_RPC_FUNCTIONS.getComparison,
+  ASSESSMENT_RPC_FUNCTIONS.listAssessments,
+  ASSESSMENT_RPC_FUNCTIONS.listEvaluationCriteria,
+  ...Object.values(RESULT_EXPORT_RPC_FUNCTIONS),
+])
 
 function containsHierarchyDependentReader(source: string) {
   return Array.from(source.matchAll(FUNCTION_DEFINITION_PATTERN), ([, fn]) => fn).some(
-    (fn) => fn !== undefined && isHierarchyDependentReader(fn)
+    (fn) => fn !== undefined && HIERARCHY_DEPENDENT_READER_FUNCTIONS.has(fn)
   )
 }
 
@@ -70,23 +74,19 @@ function readActivationMigration() {
 }
 
 describe("technical configuration P6A hierarchy server activation", () => {
-  it("tracks migrations for every hierarchy-dependent production reader surface", () => {
-    const readerFunctions = [
-      "_technical_configuration_baseline_snapshot",
-      "technical_configuration_baseline_versions_list",
-      "technical_configuration_comparison_get",
-      "technical_configuration_assessments_list",
-      "technical_configuration_evaluation_criteria_list",
-      "technical_configuration_result_export_manifest_get",
-      "technical_configuration_result_export_matrix_list",
-    ]
-
-    for (const fn of readerFunctions) {
-      expect(isHierarchyDependentReader(fn)).toBe(true)
+  it("tracks the canonical hierarchy-dependent production reader manifest", () => {
+    expect(HIERARCHY_DEPENDENT_READER_FUNCTIONS).toContain(
+      COMPARISON_READ_RPC_FUNCTIONS.getComparison
+    )
+    expect(HIERARCHY_DEPENDENT_READER_FUNCTIONS).toContain(
+      ASSESSMENT_RPC_FUNCTIONS.listEvaluationCriteria
+    )
+    for (const fn of Object.values(RESULT_EXPORT_RPC_FUNCTIONS)) {
+      expect(HIERARCHY_DEPENDENT_READER_FUNCTIONS).toContain(fn)
     }
-    expect(isHierarchyDependentReader(PUBLIC_APPLY_FUNCTION)).toBe(false)
-    expect(isHierarchyDependentReader("technical_configuration_baseline_subgroup_create")).toBe(
-      false
+    expect(HIERARCHY_DEPENDENT_READER_FUNCTIONS).not.toContain(PUBLIC_APPLY_FUNCTION)
+    expect(HIERARCHY_DEPENDENT_READER_FUNCTIONS).not.toContain(
+      TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS.createSubgroup
     )
   })
 

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs.ts
@@ -1,10 +1,1 @@
-/** Dormant P1E mutation names. Do not add these to the production proxy allowlist before P6A. */
-export const TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS = {
-  createSubgroup: "technical_configuration_baseline_subgroup_create",
-  updateSubgroup: "technical_configuration_baseline_subgroup_update",
-  deleteSubgroup: "technical_configuration_baseline_subgroup_delete",
-  reorderSubgroups: "technical_configuration_baseline_subgroups_reorder",
-  createCriterion: "technical_configuration_baseline_hierarchy_criterion_create",
-  moveCriterion: "technical_configuration_baseline_hierarchy_criterion_move",
-  reorderCriteria: "technical_configuration_baseline_hierarchy_criteria_reorder",
-} as const
+export { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "@/lib/technical-configuration-baseline-rpcs"

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -1,5 +1,8 @@
 import { ASSESSMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-assessment-rpcs"
-import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
+import {
+  BASELINE_RPC_FUNCTION_NAMES,
+  TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPC_NAMES,
+} from "@/lib/technical-configuration-baseline-rpcs"
 import { COMPARISON_READ_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-comparison-rpcs"
 import { DOSSIER_DELETE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-dossier-rpcs"
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
@@ -109,6 +112,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   "technical_configuration_dossiers_archive",
   ...DOSSIER_DELETE_RPC_FUNCTION_NAMES,
   ...BASELINE_RPC_FUNCTION_NAMES,
+  ...TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPC_NAMES,
   ...REFERENCE_PRODUCT_RPC_FUNCTION_NAMES,
   ...DOCUMENT_RPC_FUNCTION_NAMES,
   ...SUPPLIER_RPC_FUNCTION_NAMES,

--- a/src/app/api/rpc/__tests__/technical-configuration-baseline-hierarchy-apply-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-baseline-hierarchy-apply-migration.test.ts
@@ -198,7 +198,7 @@ describe("technical configuration baseline P2B hierarchy apply migration", () =>
     )
   })
 
-  it("locks internal/public privileges and registers only the guarded v2 RPC", () => {
+  it("locks historical P2B privileges while the dormant client path remains registered", () => {
     const migration = readSingleMigration(APPLY_SUFFIX).source
     const signature = "(UUID, JSONB, JSONB, BIGINT)"
 
@@ -216,7 +216,7 @@ describe("technical configuration baseline P2B hierarchy apply migration", () =>
     )
     expect(BASELINE_RPC_FUNCTIONS.applyImport).toBe(LEGACY_APPLY_FUNCTION)
     expect(BASELINE_RPC_FUNCTIONS.applyHierarchyImport).toBe(PUBLIC_APPLY_FUNCTION)
-    expect(readFileSync(BASELINE_HOOK_PATH, "utf8")).not.toContain("applyHierarchyImport")
+    expect(readFileSync(BASELINE_HOOK_PATH, "utf8")).toContain("applyHierarchyImport")
   })
 
   it("ships rollback-only functional and security phase gates for every P2B failure mode", () => {

--- a/src/app/api/rpc/__tests__/technical-configuration-baseline-subgroup-mutations-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-baseline-subgroup-mutations-migration.test.ts
@@ -241,7 +241,7 @@ describe("technical configuration baseline P1E hierarchy mutation migration", ()
       }
     })
 
-    it("keeps every new contract unavailable until the P6A activation leaf", () => {
+    it("keeps the P1E migration ungranted and registers every contract for P6A activation", () => {
       const allowlistSource = readFileSync(ALLOWLIST_PATH, "utf8")
 
       for (const [name, signature] of NEW_RPC_SIGNATURES) {
@@ -256,7 +256,7 @@ describe("technical configuration baseline P1E hierarchy mutation migration", ()
         expect(p1eMigrationSource).not.toContain(
           `GRANT EXECUTE ON FUNCTION public.${name}(${sqlSignature})`
         )
-        expect(allowlistSource).not.toContain(name)
+        expect(allowlistSource).toContain(name)
       }
     })
 
@@ -283,13 +283,27 @@ describe("technical configuration baseline P1E hierarchy mutation migration", ()
       expect(phaseGateSource).toContain("SET CONSTRAINTS ALL IMMEDIATE;")
     })
 
-    it("keeps completed hierarchy phases aligned without advancing P2B", () => {
+    it("keeps completed hierarchy phases aligned through P6A verification", () => {
       const tasksSource = readFileSync(TASKS_PATH, "utf8")
 
-      for (const task of ["P1E.1", "P1E.2", "P1E.3", "P1E.4", "P2A.1", "P2A.2", "P2A.3", "P2A.4"]) {
+      for (const task of [
+        "P1E.1",
+        "P1E.2",
+        "P1E.3",
+        "P1E.4",
+        "P2A.1",
+        "P2A.2",
+        "P2A.3",
+        "P2A.4",
+        "P2B.1",
+        "P2B.2",
+        "P2B.3",
+        "P2B.4",
+        "P2B.5",
+        "P6A.1",
+      ]) {
         expect(tasksSource).toContain(`- [x] ${task}`)
       }
-      expect(tasksSource).toContain("- [ ] P2B.1")
     })
   })
 })

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it, vi } from "vitest"
 vi.mock("server-only", () => ({}))
 
 import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
-import { TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS } from "@/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-rpcs"
 import { POST } from "@/app/api/rpc/[fn]/route"
-import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
+import {
+  BASELINE_RPC_FUNCTION_NAMES,
+  TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPC_NAMES,
+  TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS,
+} from "@/lib/technical-configuration-baseline-rpcs"
 import {
   COMPARISON_READ_RPC_FUNCTION_NAMES,
   COMPARISON_READ_RPC_FUNCTIONS,
@@ -56,6 +59,7 @@ const P7A1_REFERENCE_RPC_FUNCTIONS = [
 
 const BASELINE_RPC_FUNCTIONS = [
   ...BASELINE_RPC_FUNCTION_NAMES,
+  ...TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPC_NAMES,
   ...BASELINE_DOCUMENT_RPC_FUNCTIONS,
 ] as const
 
@@ -111,7 +115,7 @@ describe("technical configuration baseline RPC whitelist", () => {
     ])
   })
 
-  it("allowlists exactly the existing baseline RPCs plus six P7B1 baseline names", () => {
+  it("allowlists exactly the activated baseline RPCs plus six P7B1 baseline names", () => {
     expect(
       [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_baseline_"))
     ).toEqual(BASELINE_RPC_FUNCTIONS)
@@ -124,9 +128,9 @@ describe("technical configuration baseline RPC whitelist", () => {
     await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
   })
 
-  it("keeps P1E hierarchy authoring mutations dormant until P6A", () => {
+  it("allows P6A hierarchy authoring mutations through the authenticated proxy only", () => {
     for (const fn of Object.values(TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS)) {
-      expect(ALLOWED_FUNCTIONS.has(fn)).toBe(false)
+      expect(ALLOWED_FUNCTIONS.has(fn)).toBe(true)
       expect(SERVICE_ROLE_RPC_FUNCTIONS.has(fn)).toBe(false)
     }
   })

--- a/src/lib/technical-configuration-baseline-rpcs.ts
+++ b/src/lib/technical-configuration-baseline-rpcs.ts
@@ -22,3 +22,19 @@ export const BASELINE_RPC_FUNCTIONS = {
 
 /** Ordered baseline RPC names for allowlists and contract iteration. */
 export const BASELINE_RPC_FUNCTION_NAMES = Object.values(BASELINE_RPC_FUNCTIONS)
+
+/** Hierarchy authoring RPCs activated on the server in P6A. */
+export const TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS = {
+  createSubgroup: "technical_configuration_baseline_subgroup_create",
+  updateSubgroup: "technical_configuration_baseline_subgroup_update",
+  deleteSubgroup: "technical_configuration_baseline_subgroup_delete",
+  reorderSubgroups: "technical_configuration_baseline_subgroups_reorder",
+  createCriterion: "technical_configuration_baseline_hierarchy_criterion_create",
+  moveCriterion: "technical_configuration_baseline_hierarchy_criterion_move",
+  reorderCriteria: "technical_configuration_baseline_hierarchy_criteria_reorder",
+} as const
+
+/** Ordered hierarchy authoring RPC names for the production proxy allowlist. */
+export const TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPC_NAMES = Object.values(
+  TECHNICAL_CONFIGURATION_BASELINE_HIERARCHY_AUTHORING_RPCS
+)

--- a/supabase/migrations/20260813105912_technical_configuration_baseline_hierarchy_server_activation.sql
+++ b/supabase/migrations/20260813105912_technical_configuration_baseline_hierarchy_server_activation.sql
@@ -1,0 +1,45 @@
+-- P6A server activation after every production hierarchy reader is compatible.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_import_apply_v2(
+  p_baseline_version_id UUID,
+  p_template_metadata JSONB,
+  p_rows JSONB,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN public._technical_configuration_baseline_import_apply_v2(
+    p_baseline_version_id,
+    p_template_metadata,
+    p_rows,
+    p_expected_revision
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_baseline_import_apply_v2(UUID, JSONB, JSONB, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_import_apply_v2(UUID, JSONB, JSONB, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_import_apply_v2(UUID, JSONB, JSONB, BIGINT) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_subgroup_create(UUID, TEXT, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_subgroup_update(UUID, TEXT, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_subgroup_delete(UUID, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_subgroups_reorder(UUID, UUID[], BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_hierarchy_criterion_create(UUID, UUID, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_hierarchy_criterion_move(UUID, UUID, UUID, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_hierarchy_criteria_reorder(UUID, UUID, UUID[], BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_subgroup_create(UUID, TEXT, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_subgroup_update(UUID, TEXT, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_subgroup_delete(UUID, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_subgroups_reorder(UUID, UUID[], BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_hierarchy_criterion_create(UUID, UUID, TEXT, TEXT, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_hierarchy_criterion_move(UUID, UUID, UUID, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_hierarchy_criteria_reorder(UUID, UUID, UUID[], BIGINT) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_baseline_hierarchy_server_activation_security_gate.sql
+++ b/supabase/tests/technical_configuration_baseline_hierarchy_server_activation_security_gate.sql
@@ -1,0 +1,230 @@
+-- P6A hierarchy server activation security gate. All work rolls back.
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state = p_expected_state AND v_message = p_expected_message THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION '%: expected %/%, got %/%',
+        p_label,
+        p_expected_state,
+        p_expected_message,
+        v_state,
+        v_message;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_internal REGPROCEDURE := to_regprocedure(
+    'public._technical_configuration_baseline_import_apply_v2(uuid,jsonb,jsonb,bigint)'
+  );
+  v_public REGPROCEDURE := to_regprocedure(
+    'public.technical_configuration_baseline_import_apply_v2(uuid,jsonb,jsonb,bigint)'
+  );
+  v_definition TEXT;
+  v_authoring_signature TEXT;
+  v_authoring_statement TEXT;
+  v_authoring_statements TEXT[];
+  v_authoring REGPROCEDURE;
+  v_user_id BIGINT;
+BEGIN
+  IF v_internal IS NULL OR v_public IS NULL THEN
+    RAISE EXCEPTION 'P6A apply function contract is incomplete';
+  END IF;
+
+  SELECT pg_get_functiondef(v_public)
+  INTO v_definition;
+  IF v_definition NOT LIKE '%_technical_configuration_baseline_import_apply_v2(%'
+     OR v_definition LIKE '%hierarchical_import_apply_not_activated%' THEN
+    RAISE EXCEPTION 'public v2 apply delegation contract mismatch';
+  END IF;
+
+  IF has_function_privilege('public', v_internal, 'EXECUTE')
+     OR has_function_privilege('anon', v_internal, 'EXECUTE')
+     OR has_function_privilege('authenticated', v_internal, 'EXECUTE')
+     OR has_function_privilege('service_role', v_internal, 'EXECUTE') THEN
+    RAISE EXCEPTION 'internal v2 apply privilege contract mismatch';
+  END IF;
+
+  IF has_function_privilege('public', v_public, 'EXECUTE')
+     OR has_function_privilege('anon', v_public, 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', v_public, 'EXECUTE')
+     OR has_function_privilege('service_role', v_public, 'EXECUTE') THEN
+    RAISE EXCEPTION 'public v2 apply privilege contract mismatch';
+  END IF;
+
+  FOREACH v_authoring_signature IN ARRAY ARRAY[
+    'public.technical_configuration_baseline_subgroup_create(uuid,text,bigint)',
+    'public.technical_configuration_baseline_subgroup_update(uuid,text,bigint)',
+    'public.technical_configuration_baseline_subgroup_delete(uuid,bigint)',
+    'public.technical_configuration_baseline_subgroups_reorder(uuid,uuid[],bigint)',
+    'public.technical_configuration_baseline_hierarchy_criterion_create(uuid,uuid,text,text,bigint)',
+    'public.technical_configuration_baseline_hierarchy_criterion_move(uuid,uuid,uuid,bigint)',
+    'public.technical_configuration_baseline_hierarchy_criteria_reorder(uuid,uuid,uuid[],bigint)'
+  ]
+  LOOP
+    v_authoring := to_regprocedure(v_authoring_signature);
+    IF v_authoring IS NULL
+       OR has_function_privilege('public', v_authoring, 'EXECUTE')
+       OR has_function_privilege('anon', v_authoring, 'EXECUTE')
+       OR NOT has_function_privilege('authenticated', v_authoring, 'EXECUTE')
+       OR has_function_privilege('service_role', v_authoring, 'EXECUTE') THEN
+      RAISE EXCEPTION 'hierarchy authoring privilege contract mismatch: %',
+        v_authoring_signature;
+    END IF;
+  END LOOP;
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P6A activation gate requires one active public.nhan_vien row';
+  END IF;
+
+  SET LOCAL ROLE authenticated;
+  IF current_user <> 'authenticated' THEN
+    RAISE EXCEPTION 'P6A activation gate failed to assume authenticated role';
+  END IF;
+
+  v_authoring_statements := ARRAY[
+    format(
+      'SELECT public.technical_configuration_baseline_subgroup_create(%L::UUID, %L, 1)',
+      gen_random_uuid(),
+      'P6A subgroup'
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_subgroup_update(%L::UUID, %L, 1)',
+      gen_random_uuid(),
+      'P6A subgroup'
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_subgroup_delete(%L::UUID, 1)',
+      gen_random_uuid()
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_subgroups_reorder(%L::UUID, %L::UUID[], 1)',
+      gen_random_uuid(),
+      '{}'
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_hierarchy_criterion_create(%L::UUID, NULL::UUID, %L, %L, 1)',
+      gen_random_uuid(),
+      'P6A criterion',
+      'P6A requirement'
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_hierarchy_criterion_move(%L::UUID, %L::UUID, NULL::UUID, 1)',
+      gen_random_uuid(),
+      gen_random_uuid()
+    ),
+    format(
+      'SELECT public.technical_configuration_baseline_hierarchy_criteria_reorder(%L::UUID, NULL::UUID, %L::UUID[], 1)',
+      gen_random_uuid(),
+      '{}'
+    )
+  ];
+
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'public v2 apply missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_baseline_import_apply_v2(%L::UUID, %L::JSONB, %L::JSONB, 1)',
+      gen_random_uuid(),
+      '{}'::JSONB::TEXT,
+      '[]'::JSONB::TEXT
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  FOREACH v_authoring_statement IN ARRAY v_authoring_statements
+  LOOP
+    PERFORM pg_temp.expect_error(
+      'hierarchy authoring missing claims rejected',
+      v_authoring_statement,
+      '42501',
+      'permission_denied'
+    );
+  END LOOP;
+
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  FOREACH v_authoring_statement IN ARRAY v_authoring_statements
+  LOOP
+    PERFORM pg_temp.expect_error(
+      'hierarchy authoring non-global role rejected',
+      v_authoring_statement,
+      '42501',
+      'permission_denied'
+    );
+  END LOOP;
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'public v2 apply delegates to editable version guard',
+    format(
+      'SELECT public.technical_configuration_baseline_import_apply_v2(%L::UUID, %L::JSONB, %L::JSONB, 1)',
+      gen_random_uuid(),
+      '{}'::JSONB::TEXT,
+      '[]'::JSONB::TEXT
+    ),
+    'PT404',
+    'not_found'
+  );
+
+  FOREACH v_authoring_statement IN ARRAY v_authoring_statements
+  LOOP
+    PERFORM pg_temp.expect_error(
+      'hierarchy authoring admin reaches target guard',
+      v_authoring_statement,
+      'PT404',
+      'not_found'
+    );
+  END LOOP;
+END;
+$gate$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- activate the public XLSX v2 apply wrapper and all seven hierarchy-authoring RPCs for authenticated proxy calls
- keep the internal apply worker ungranted and keep all production XLSX v2/hierarchy authoring UI controls unmounted
- reconcile stale P2B/P1E phase contracts, add rollback-only activation security coverage, and record the authorized live checkpoint

## Live Supabase checkpoint

- Applied local migration `20260813105912_technical_configuration_baseline_hierarchy_server_activation.sql` through Supabase MCP; live version: `20260813132516`
- P6A activation gate passed and rolled back
- Both deferred P5C gates passed and rolled back
- Live ACLs: public apply wrapper plus seven authoring RPCs are `authenticated`-only; `PUBLIC`, `anon`, and `service_role` are revoked
- Internal apply worker remains ungranted to all exposed roles
- Runtime gate assumes database role `authenticated` and exercises every authoring RPC:
  - empty claims: `42501/permission_denied`
  - `to_qltb`: `42501/permission_denied`
  - raw `admin`: reaches `PT404/not_found`
- Security and performance advisors reviewed; activation-related authenticated `SECURITY DEFINER` notices are expected for guarded RPCs, remaining notices are existing baseline items outside P6A

## Verification

- format check: pass
- no explicit any: pass
- diff-only dedupe: pass
- typecheck: pass
- focused P6A: `5 files`, `103/103`
- broad technical-configuration: `154 files`, `1366/1366`
- React Doctor: `100/100`
- OpenSpec strict: valid
- production build: pass
- `git diff --check`: pass
- independent review: Zero actionable findings

## Browser and UI boundary

Browser testing was explicitly skipped by user instruction. Component/source regressions still cover small, example-sized, and safety-bound XLSX v2 download/import, destructive replacement, hierarchy authoring, aggregate evaluation, comparison, result export, and production isolation. P6A does not mount production UI; P6B remains the UI activation phase.

Closes #894
Closes #903

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates P6A hierarchy server contracts so hierarchy authoring and XLSX v2 apply are callable through the authenticated proxy while production UI remains unmounted. Previously the public v2 apply wrapper failed closed with PT409; now it delegates to the internal worker, which remains ungranted.

- Grants only authenticated to the public v2 apply wrapper and all seven hierarchy-authoring RPCs; revokes PUBLIC, anon, and service_role; updates the RPC proxy allowlist to include the seven authoring functions.
- Adds a superseding migration that replaces the public v2 apply wrapper to delegate to the internal function and applies explicit REVOKE/GRANTs, plus a rollback-only security gate that verifies delegation, privileges, and JWT claim handling (missing/non-global claims → 42501; admin reaches PT404). Legacy apply contracts are unchanged.
- Centralizes the hierarchy authoring RPC manifest in shared libs and updates tests to use the canonical hierarchy-dependent reader manifest for migration ordering and proxy coverage; tightens production-isolation checks so downloads/import/authoring controls stay unmounted. Aligns with #894; reconciles stale assertions from #903.
- Migration action: apply Supabase migration 20260813105912 to activate server contracts.

<sup>Written for commit aeee0fb077dc359a6d3f5b254747fefe1a7729f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

