### PR TITLE
feat(technical-configurations): activate P6B hierarchy UI

### DIFF
--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
@@ -82,16 +82,16 @@ UI, Vitest, Testing Library, OpenSpec.
 
 ### Task 1: Draft And Locked Visibility
 
-- [ ] Update the production-isolation regression first.
-- [ ] Render the production baseline tab with a clean draft and assert:
+- [x] Update the production-isolation regression first.
+- [x] Render the production baseline tab with a clean draft and assert:
   - `Tải cấu hình hiện tại` is visible and enabled;
   - `Tải mẫu trống` is visible and enabled;
   - the legacy import command remains visible;
   - `Nhập cấu hình phân cấp` is visible;
   - subgroup authoring controls are reachable through the existing editor.
-- [ ] Render a locked version and assert all draft-only download/import/authoring
+- [x] Render a locked version and assert all draft-only download/import/authoring
       controls are absent while the locked read surface remains.
-- [ ] Run the focused test and confirm RED because P6B controls are not mounted.
+- [x] Run the focused test and confirm RED because P6B controls are not mounted.
 
 Run:
 
@@ -104,46 +104,46 @@ Expected: FAIL only on new production-activation assertions.
 
 ### Task 2: Coexistence, Blocking, Accessibility, And Responsive Layout
 
-- [ ] Add RED assertions that the legacy and XLSX v2 import commands open different
+- [x] Add RED assertions that the legacy and XLSX v2 import commands open different
       labelled dialogs and remain independently discoverable by role/name.
-- [ ] Assert an unresolved workflow from either dialog blocks version adoption,
+- [x] Assert an unresolved workflow from either dialog blocks version adoption,
       reload, copy, lock, and navigation until reset or successful completion.
-- [ ] Assert the XLSX v2 dialog keeps the existing explicit replacement checkbox;
+- [x] Assert the XLSX v2 dialog keeps the existing explicit replacement checkbox;
       apply remains disabled before confirmation, for invalid previews, and for stale
       previews.
-- [ ] Assert accessible action grouping, non-duplicated control names, visible busy
+- [x] Assert accessible action grouping, non-duplicated control names, visible busy
       status/error announcements, and keyboard-focusable commands.
-- [ ] Assert the production action container wraps on narrow widths and does not
+- [x] Assert the production action container wraps on narrow widths and does not
       rely on fixed-width buttons or clipped overflow.
-- [ ] Run the focused tests and confirm RED for missing production composition.
+- [x] Run the focused tests and confirm RED for missing production composition.
 
 ## Chunk 2: GREEN Minimal Production Wiring
 
 ### Task 3: Compose Existing Import Workflows
 
-- [ ] Implement
+- [x] Implement
       `useTechnicalConfigurationBaselineImportWorkflows.ts`.
-- [ ] Instantiate `useTechnicalConfigurationBaselineImport` unchanged for legacy
+- [x] Instantiate `useTechnicalConfigurationBaselineImport` unchanged for legacy
       compatibility.
-- [ ] Instantiate `useTechnicalConfigurationBaselineHierarchyImport` unchanged for
+- [x] Instantiate `useTechnicalConfigurationBaselineHierarchyImport` unchanged for
       XLSX v2 preview/apply.
-- [ ] Track legacy and hierarchy unresolved states independently; derive one
+- [x] Track legacy and hierarchy unresolved states independently; derive one
       `hasUnresolvedImportState` boolean so one workflow closing cannot clear the
       other's blocking state.
-- [ ] Return only both workflows and the aggregate guard needed by the tab.
-- [ ] Run the focused RED tests and make only this composition slice GREEN.
+- [x] Return only both workflows and the aggregate guard needed by the tab.
+- [x] Run the focused RED tests and make only this composition slice GREEN.
 
 ### Task 4: Mount Production Actions And Dialogs
 
-- [ ] Implement
+- [x] Implement
       `TechnicalConfigurationBaselineProductionActions.tsx`.
-- [ ] Reuse `TechnicalConfigurationBaselineDownloadActions` for both download
+- [x] Reuse `TechnicalConfigurationBaselineDownloadActions` for both download
       intents; do not duplicate workbook generation or download state.
-- [ ] Add one hierarchy import button with a Lucide icon, descriptive accessible
+- [x] Add one hierarchy import button with a Lucide icon, descriptive accessible
       name, and a responsive wrapping layout. Do not duplicate or relocate the legacy
       `Tải template Excel` / import commands already rendered by
       `TechnicalConfigurationVersionBar`.
-- [ ] In `TechnicalConfigurationBaselineTab.tsx`:
+- [x] In `TechnicalConfigurationBaselineTab.tsx`:
   - replace the single legacy import hook with the dual-import workflow hook;
   - include aggregate unresolved state in external-draft replacement,
     `isUnsafeToLeave`, reload, copy, lock, and navigation guards;
@@ -151,21 +151,21 @@ Expected: FAIL only on new production-activation assertions.
   - pass the existing `inlineEditor.hierarchyAuthoring` to
     `TechnicalConfigurationBaselineEditor`;
   - keep focus mode, summary, Save, scroll ownership, and version behavior intact.
-- [ ] Keep the tab below the 350-line extraction threshold.
-- [ ] Run the focused production activation tests and confirm GREEN.
+- [x] Keep the tab below the 350-line extraction threshold.
+- [x] Run the focused production activation tests and confirm GREEN.
 
 ### Task 5: Preserve Dormant Contract Regressions
 
-- [ ] Run the existing P3C download tests and prove current-data/blank-template
+- [x] Run the existing P3C download tests and prove current-data/blank-template
       identity, dirty/conflict guards, duplicate-download prevention, and locked
       visibility remain unchanged.
-- [ ] Run the existing P3D hierarchy import tests and prove legacy parsing,
+- [x] Run the existing P3D hierarchy import tests and prove legacy parsing,
       authoritative preview, destructive confirmation, stale evidence, recovery,
       pagination, and apply lifecycle remain unchanged.
-- [ ] Run the existing P4C authoring tests and prove subgroup CRUD/reorder,
+- [x] Run the existing P4C authoring tests and prove subgroup CRUD/reorder,
       criterion movement, owner-scoped entry, focus, responsive controls, save/resume,
       conflict, and lock guards remain unchanged.
-- [ ] Run baseline legacy import tests to prove the compatibility path remains
+- [x] Run baseline legacy import tests to prove the compatibility path remains
       callable from production.
 
 Focused command:
@@ -188,11 +188,11 @@ node scripts/npm-run.js exec vitest run \
 
 ### Task 6: Cross-Surface Regression
 
-- [ ] Run the complete technical-configuration test directory.
-- [ ] Explicitly inspect failures for evaluation hierarchy/progress, comparison
+- [x] Run the complete technical-configuration test directory.
+- [x] Explicitly inspect failures for evaluation hierarchy/progress, comparison
       hierarchy, result export, version navigation, focus mode, inline editing, copy,
       lock, and reload behavior.
-- [ ] Do not change those surfaces merely to make unrelated assertions pass; prove
+- [x] Do not change those surfaces merely to make unrelated assertions pass; prove
       any baseline failure against `32e2937c` and file a follow-up issue if needed.
 
 Run:
@@ -204,7 +204,9 @@ node scripts/npm-run.js exec vitest run \
 
 ### Task 7: Required Gates
 
-- [ ] Run the repository verification chain in the mandated order through one
+- [x] Invoke `react-best-practices` before running the TypeScript/React verification
+      chain.
+- [x] Run the repository verification chain in the mandated order through one
       `ctx_batch_execute` call:
 
 ```bash
@@ -220,22 +222,25 @@ openspec validate revise-technical-configuration-baseline-hierarchy --strict
 git diff --check
 ```
 
-- [ ] Run the `code-deduplication` semantic check before commit because P6B creates
+- [x] Run the `code-deduplication` semantic check before commit because P6B creates
       a composition hook/component.
-- [ ] Use Code Review Graph change detection and GitNexus `detect_changes`; inspect
+- [x] Before symbol edits, use Code Review Graph for broad discovery, then GitNexus
+      impact analysis; inspect and report every HIGH or CRITICAL risk result. Repeat
+      change detection after implementation.
+- [x] Use Code Review Graph change detection and GitNexus `detect_changes`; inspect
       every high-risk symbol/process.
-- [ ] Record browser testing as skipped, not passed.
+- [x] Record browser testing as skipped, not passed.
 
 ### Task 8: Review, OpenSpec Status, Commit, Push, And PR
 
-- [ ] Request independent specification review, then code-quality review.
-- [ ] Fix and re-review until both report zero actionable findings.
-- [ ] Mark P6B.1 and P6B.3 complete in `tasks.md`; leave P6B.2 unchecked with the
+- [x] Request independent specification review, then code-quality review.
+- [x] Fix and re-review until both report zero actionable findings.
+- [x] Mark P6B.1 and P6B.3 complete in `tasks.md`; leave P6B.2 unchecked with the
       explicit credential/user-instruction note.
 - [ ] Commit through enabled Lefthook hooks.
 - [ ] Run `git pull --rebase`, push the branch, and verify it is up to date with
       origin.
-- [ ] Open a PR into `main` that links and closes #909, lists verification counts,
+- [x] Open a PR into `main` that links and closes #909, lists verification counts,
       states that browser tests were skipped, and confirms no live DB write occurred.
 - [ ] Stop before merge and report the PR for user review.
 

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
@@ -237,8 +237,8 @@ git diff --check
 - [x] Fix and re-review until both report zero actionable findings.
 - [x] Mark P6B.1 and P6B.3 complete in `tasks.md`; leave P6B.2 unchecked with the
       explicit credential/user-instruction note.
-- [ ] Commit through enabled Lefthook hooks.
-- [ ] Run `git pull --rebase`, push the branch, and verify it is up to date with
+- [x] Commit through enabled Lefthook hooks.
+- [x] Run `git pull --rebase`, push the branch, and verify it is up to date with
       origin.
 - [x] Open a PR into `main` that links and closes #909, lists verification counts,
       states that browser tests were skipped, and confirms no live DB write occurred.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/p6b-tdd-plan.md
@@ -1,0 +1,249 @@
+# P6B Production UI Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development
+> (if subagents are available) or superpowers:executing-plans to implement this
+> plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** #909
+
+**Branch:** `feat/909-p6b-production-ui-activation`
+
+**Base:** clean `main` at `32e2937ceaba9822c8c5f55ee9733aeb7c619910`
+
+**Goal:** Mount the already-tested XLSX v2 download/import and hierarchy-authoring
+capabilities on the production baseline screen while preserving legacy import,
+destructive replacement safeguards, accessibility, responsive layout, and every
+existing evaluation/comparison/result-export contract.
+
+**Architecture:** Keep P6B UI-only. Reuse the P3C download component, P3D hierarchy
+import hook/dialog, and the P4C `inlineEditor.hierarchyAuthoring` capability without
+changing their server contracts. Extract only the dual-import workflow composition
+from the 328-line `TechnicalConfigurationBaselineTab` so the owner remains below the
+350-line extraction threshold and both import workflows contribute independently to
+dirty, reload, navigation, copy, lock, and version-change blocking.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, TanStack Query, shadcn/Radix
+UI, Vitest, Testing Library, OpenSpec.
+
+---
+
+## Scope And Constraints
+
+- P6A is deployed through PR #908. Do not add or change SQL, RPC signatures,
+  allowlists, grants, policies, or migrations.
+- Do not perform any live database write. A newly discovered live-write need is a
+  blocker that requires explicit user permission and Supabase MCP.
+- Keep the legacy baseline workbook import workflow mounted for the compatibility
+  window.
+- New XLSX v2 downloads and hierarchy import are draft-only. Locked baselines stay
+  read-only.
+- Reuse the existing authoritative preview, replacement checkbox, deletion counts,
+  stale-revision evidence, and atomic apply lifecycle. Do not duplicate those rules
+  in the production owner.
+- Browser testing is intentionally skipped because credentials are unavailable per
+  user instruction. Replace it with production-component integration coverage and
+  record the skip in the PR.
+- Do not alter evaluation, comparison, or result-export production components.
+- Keep every source file below 450 lines and extract around 350 lines.
+
+## Planned File Ownership
+
+- Create
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx`
+  to render the two XLSX v2 downloads plus the hierarchy import command in a
+  wrapping, keyboard-accessible action group. The existing legacy download/import
+  commands remain owned by `TechnicalConfigurationVersionBar`.
+- Create
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows.ts`
+  to compose only the legacy and hierarchy import workflows while retaining
+  independent unresolved-state flags.
+- Modify
+  `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx`
+  only to consume the extracted workflow/action composition, pass hierarchy
+  authoring to the editor, aggregate navigation/reload/lock guards, and mount both
+  dialogs.
+- Replace the stale absence contract in
+  `technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx`
+  with focused production activation coverage. This is the only existing
+  hierarchy production-isolation file; it already owns download, import, and
+  subgroup-control absence assertions.
+- Update the stale production-absence assertion at the end of
+  `technical-configuration-baseline-download-actions.test.tsx` to assert that the
+  existing download component is mounted by the production baseline screen.
+- Add a separate focused production workflow test only if activation visibility,
+  dual-import blocking, and destructive-state assertions cannot remain clear in
+  that file without approaching the extraction threshold.
+- Modify
+  `openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md`
+  only after verification, marking P6B.1 and P6B.3 complete. Leave P6B.2 unchecked
+  with a note that browser testing was skipped by explicit user instruction.
+
+## Chunk 1: RED Production Activation Contract
+
+### Task 1: Draft And Locked Visibility
+
+- [ ] Update the production-isolation regression first.
+- [ ] Render the production baseline tab with a clean draft and assert:
+  - `Tải cấu hình hiện tại` is visible and enabled;
+  - `Tải mẫu trống` is visible and enabled;
+  - the legacy import command remains visible;
+  - `Nhập cấu hình phân cấp` is visible;
+  - subgroup authoring controls are reachable through the existing editor.
+- [ ] Render a locked version and assert all draft-only download/import/authoring
+      controls are absent while the locked read surface remains.
+- [ ] Run the focused test and confirm RED because P6B controls are not mounted.
+
+Run:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx"
+```
+
+Expected: FAIL only on new production-activation assertions.
+
+### Task 2: Coexistence, Blocking, Accessibility, And Responsive Layout
+
+- [ ] Add RED assertions that the legacy and XLSX v2 import commands open different
+      labelled dialogs and remain independently discoverable by role/name.
+- [ ] Assert an unresolved workflow from either dialog blocks version adoption,
+      reload, copy, lock, and navigation until reset or successful completion.
+- [ ] Assert the XLSX v2 dialog keeps the existing explicit replacement checkbox;
+      apply remains disabled before confirmation, for invalid previews, and for stale
+      previews.
+- [ ] Assert accessible action grouping, non-duplicated control names, visible busy
+      status/error announcements, and keyboard-focusable commands.
+- [ ] Assert the production action container wraps on narrow widths and does not
+      rely on fixed-width buttons or clipped overflow.
+- [ ] Run the focused tests and confirm RED for missing production composition.
+
+## Chunk 2: GREEN Minimal Production Wiring
+
+### Task 3: Compose Existing Import Workflows
+
+- [ ] Implement
+      `useTechnicalConfigurationBaselineImportWorkflows.ts`.
+- [ ] Instantiate `useTechnicalConfigurationBaselineImport` unchanged for legacy
+      compatibility.
+- [ ] Instantiate `useTechnicalConfigurationBaselineHierarchyImport` unchanged for
+      XLSX v2 preview/apply.
+- [ ] Track legacy and hierarchy unresolved states independently; derive one
+      `hasUnresolvedImportState` boolean so one workflow closing cannot clear the
+      other's blocking state.
+- [ ] Return only both workflows and the aggregate guard needed by the tab.
+- [ ] Run the focused RED tests and make only this composition slice GREEN.
+
+### Task 4: Mount Production Actions And Dialogs
+
+- [ ] Implement
+      `TechnicalConfigurationBaselineProductionActions.tsx`.
+- [ ] Reuse `TechnicalConfigurationBaselineDownloadActions` for both download
+      intents; do not duplicate workbook generation or download state.
+- [ ] Add one hierarchy import button with a Lucide icon, descriptive accessible
+      name, and a responsive wrapping layout. Do not duplicate or relocate the legacy
+      `Tải template Excel` / import commands already rendered by
+      `TechnicalConfigurationVersionBar`.
+- [ ] In `TechnicalConfigurationBaselineTab.tsx`:
+  - replace the single legacy import hook with the dual-import workflow hook;
+  - include aggregate unresolved state in external-draft replacement,
+    `isUnsafeToLeave`, reload, copy, lock, and navigation guards;
+  - mount both import dialogs;
+  - pass the existing `inlineEditor.hierarchyAuthoring` to
+    `TechnicalConfigurationBaselineEditor`;
+  - keep focus mode, summary, Save, scroll ownership, and version behavior intact.
+- [ ] Keep the tab below the 350-line extraction threshold.
+- [ ] Run the focused production activation tests and confirm GREEN.
+
+### Task 5: Preserve Dormant Contract Regressions
+
+- [ ] Run the existing P3C download tests and prove current-data/blank-template
+      identity, dirty/conflict guards, duplicate-download prevention, and locked
+      visibility remain unchanged.
+- [ ] Run the existing P3D hierarchy import tests and prove legacy parsing,
+      authoritative preview, destructive confirmation, stale evidence, recovery,
+      pagination, and apply lifecycle remain unchanged.
+- [ ] Run the existing P4C authoring tests and prove subgroup CRUD/reorder,
+      criterion movement, owner-scoped entry, focus, responsive controls, save/resume,
+      conflict, and lock guards remain unchanged.
+- [ ] Run baseline legacy import tests to prove the compatibility path remains
+      callable from production.
+
+Focused command:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-lifecycle.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-large-preview.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-entry.test.ts" \
+  "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-workflow.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/baseline-import-dialog.test.tsx" \
+  "src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-import.test.tsx"
+```
+
+## Chunk 3: Broad Regression And Closeout
+
+### Task 6: Cross-Surface Regression
+
+- [ ] Run the complete technical-configuration test directory.
+- [ ] Explicitly inspect failures for evaluation hierarchy/progress, comparison
+      hierarchy, result export, version navigation, focus mode, inline editing, copy,
+      lock, and reload behavior.
+- [ ] Do not change those surfaces merely to make unrelated assertions pass; prove
+      any baseline failure against `32e2937c` and file a follow-up issue if needed.
+
+Run:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  "src/app/(app)/technical-configurations/__tests__"
+```
+
+### Task 7: Required Gates
+
+- [ ] Run the repository verification chain in the mandated order through one
+      `ctx_batch_execute` call:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js exec vitest run \
+  "src/app/(app)/technical-configurations/__tests__"
+node scripts/npm-run.js run react-doctor
+node scripts/npm-run.js run build
+openspec validate revise-technical-configuration-baseline-hierarchy --strict
+git diff --check
+```
+
+- [ ] Run the `code-deduplication` semantic check before commit because P6B creates
+      a composition hook/component.
+- [ ] Use Code Review Graph change detection and GitNexus `detect_changes`; inspect
+      every high-risk symbol/process.
+- [ ] Record browser testing as skipped, not passed.
+
+### Task 8: Review, OpenSpec Status, Commit, Push, And PR
+
+- [ ] Request independent specification review, then code-quality review.
+- [ ] Fix and re-review until both report zero actionable findings.
+- [ ] Mark P6B.1 and P6B.3 complete in `tasks.md`; leave P6B.2 unchecked with the
+      explicit credential/user-instruction note.
+- [ ] Commit through enabled Lefthook hooks.
+- [ ] Run `git pull --rebase`, push the branch, and verify it is up to date with
+      origin.
+- [ ] Open a PR into `main` that links and closes #909, lists verification counts,
+      states that browser tests were skipped, and confirms no live DB write occurred.
+- [ ] Stop before merge and report the PR for user review.
+
+## Completion Boundary
+
+P6B is ready for review only when production component tests prove both workbook
+paths coexist, XLSX v2 replacement remains explicitly destructive, hierarchy
+authoring is mounted for drafts, locked versions remain read-only, broad
+evaluation/comparison/export regressions pass, all required gates pass, independent
+review reaches zero findings, and the pushed PR is open against `main`. Merge,
+live acceptance, issue closure, and OpenSpec archival remain P6C/user-owned.

--- a/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
+++ b/openspec/changes/revise-technical-configuration-baseline-hierarchy/tasks.md
@@ -415,12 +415,16 @@ Depends on: P6A.
 Deploy boundary: UI-only activation mounts both XLSX v2 download/import and subgroup
 authoring after the server activation is already deployed.
 
-- [ ] P6B.1 Mount `Tải cấu hình hiện tại`, `Tải mẫu trống`, XLSX v2 import, and subgroup
+- [x] P6B.1 Mount `Tải cấu hình hiện tại`, `Tải mẫu trống`, XLSX v2 import, and subgroup
       authoring controls in the production baseline screen.
 - [ ] P6B.2 Browser-test the complete production route with direct-only, subgroup-only,
       and mixed sections plus failure rollback and stale-revision recovery.
-- [ ] P6B.3 Verify the previous legacy workbook import path remains available during
+- [x] P6B.3 Verify the previous legacy workbook import path remains available during
       the compatibility window.
+
+Browser execution note (2026-08-13): P6B.2 remains incomplete because browser testing
+was explicitly skipped due to unavailable production credentials. Production component
+integration coverage and the complete technical-configuration regression suite passed.
 
 ## Phase P6C - Authorized Live Acceptance And Closeout
 

--- a/src/app/(app)/technical-configurations/TechnicalConfigurationBaselineLockReason.ts
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationBaselineLockReason.ts
@@ -1,0 +1,49 @@
+import type {
+  TechnicalConfigurationBaselineEditorDraft,
+  TechnicalConfigurationBaselineEditorValidation,
+} from "./technical-configuration-baseline-editor"
+
+type TechnicalConfigurationBaselineLockReasonOptions = Readonly<{
+  draft: TechnicalConfigurationBaselineEditorDraft | null
+  isSelectedDraft: boolean
+  isConflict: boolean
+  isDirty: boolean
+  hasPendingBulkInput: boolean
+  hasUnresolvedImportState: boolean
+  validation: TechnicalConfigurationBaselineEditorValidation
+}>
+
+/** Returns the highest-priority reason the selected baseline cannot be locked. */
+export function getTechnicalConfigurationBaselineLockBlockedReason({
+  draft,
+  isSelectedDraft,
+  isConflict,
+  isDirty,
+  hasPendingBulkInput,
+  hasUnresolvedImportState,
+  validation,
+}: TechnicalConfigurationBaselineLockReasonOptions): string | null {
+  if (!draft || !isSelectedDraft) return null
+  if (isConflict) return "Tải lại dữ liệu từ máy chủ trước khi khóa phiên bản."
+  if (isDirty) return "Lưu thay đổi trước khi khóa phiên bản."
+  if (hasPendingBulkInput) return "Hoàn tất hoặc hủy nội dung nhập nhanh trước khi khóa."
+  if (hasUnresolvedImportState) return "Hoàn tất hoặc hủy nhập Excel trước khi khóa phiên bản."
+  if (
+    Object.keys(validation.groupErrors).length > 0 ||
+    Object.keys(validation.subgroupErrors ?? {}).length > 0 ||
+    Object.keys(validation.criterionErrors).length > 0
+  ) {
+    return "Sửa các lỗi nội dung trước khi khóa phiên bản."
+  }
+  if (draft.groups.length < 1) return "Cần ít nhất một nhóm trước khi khóa phiên bản."
+  if (
+    !draft.groups.some(
+      (group) =>
+        group.criteria.length > 0 ||
+        group.subgroups.some((subgroup) => subgroup.criteria.length > 0)
+    )
+  ) {
+    return "Cần ít nhất một tiêu chí có nội dung trước khi khóa phiên bản."
+  }
+  return null
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
@@ -246,7 +246,7 @@ describe("technical configuration baseline locking and history", () => {
     expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Tải thêm phiên bản" })).toBeDisabled()
 
-    pending.resolve({ data: groupMutation(5, "Yêu cầu kỹ thuật chung") })
+    pending.resolve({ data: groupMutation(5, "Yêu cầu kỹ thuật chung", draft.id) })
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeEnabled()
     )

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
@@ -298,11 +298,14 @@ describe("technical configuration baseline download actions", () => {
     expect(screen.queryByRole("button", { name: "Tải mẫu trống" })).not.toBeInTheDocument()
   })
 
-  it("keeps both new actions unreachable on the production baseline screen", async () => {
+  it("mounts both XLSX v2 actions on the production baseline screen", async () => {
     renderTab()
 
     expect(await screen.findByRole("button", { name: "Tải template Excel" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Tải cấu hình hiện tại" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Tải mẫu trống" })).not.toBeInTheDocument()
+    expect(screen.getByRole("group", { name: "Công cụ cấu hình phân cấp" })).toHaveClass(
+      "flex-wrap"
+    )
+    expect(screen.getByRole("button", { name: "Tải cấu hình hiện tại" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Tải mẫu trống" })).toBeEnabled()
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
@@ -47,16 +47,22 @@ function renderActions({
   version = createHierarchicalDraft(),
   dirty = false,
   conflict = false,
+  disabled = false,
+  disabledMessage = null,
 }: {
   version?: TechnicalConfigurationBaselineDecodedDraft
   dirty?: boolean
   conflict?: boolean
+  disabled?: boolean
+  disabledMessage?: string | null
 } = {}) {
   return render(
     <TechnicalConfigurationBaselineDownloadActions
       version={version}
       dirty={dirty}
       conflict={conflict}
+      disabled={disabled}
+      disabledMessage={disabledMessage}
     />
   )
 }
@@ -284,6 +290,26 @@ describe("technical configuration baseline download actions", () => {
       expect(workbookCodec.downloadBlob).not.toHaveBeenCalled()
     }
   )
+
+  it("renders the supplied explanation while external state disables both actions", () => {
+    const disabledMessage = "Hoàn tất hoặc hủy nội dung nhập nhanh trước khi dùng công cụ Excel."
+
+    renderActions({ disabled: true, disabledMessage })
+
+    expect(screen.getByRole("button", { name: "Tải cấu hình hiện tại" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Tải mẫu trống" })).toBeDisabled()
+    expect(screen.getByText(disabledMessage)).toBeInTheDocument()
+  })
+
+  it("explains lifecycle blocking when no specific external message is available", () => {
+    renderActions({ disabled: true })
+
+    expect(screen.getByRole("button", { name: "Tải cấu hình hiện tại" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Tải mẫu trống" })).toBeDisabled()
+    expect(
+      screen.getByText("Chờ thao tác hiện tại hoàn tất trước khi dùng công cụ Excel.")
+    ).toBeInTheDocument()
+  })
 
   it("does not render download actions for a locked baseline", () => {
     renderActions({

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import-production-isolation.test.tsx
@@ -1,37 +1,128 @@
 import "@testing-library/jest-dom"
 
-import { screen } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   baselineVersionsResponse,
   createDraft,
+  createLockedVersion,
+  createPersistentQueryClient,
+  deferred,
   dossier,
   getBaselineRpcMock,
   renderTab,
 } from "./technical-configuration-baseline-tab-fixtures"
+import {
+  createHierarchyImportFile,
+  createHierarchyPreview,
+  createV2ParseResult,
+} from "./technical-configuration-baseline-hierarchy-import-fixtures"
+
+const compatibleParser = vi.hoisted(() => ({
+  parseFile: vi.fn(),
+}))
+
+vi.mock("@/lib/technical-configuration-baseline-excel-v2-parse", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/technical-configuration-baseline-excel-v2-parse")>()
+  return {
+    ...actual,
+    parseTechnicalConfigurationBaselineWorkbookFile: compatibleParser.parseFile,
+  }
+})
 
 const rpc = getBaselineRpcMock()
 
-describe("technical configuration hierarchy import production isolation", () => {
+describe("technical configuration hierarchy production activation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     rpc.getDossier.mockResolvedValue({ data: dossier })
     rpc.listVersions.mockResolvedValue(baselineVersionsResponse([createDraft()]))
+    compatibleParser.parseFile.mockResolvedValue(createV2ParseResult())
+    rpc.previewHierarchyImport.mockResolvedValue(createHierarchyPreview())
   })
 
-  it("keeps the dormant workflow unreachable from the production baseline tab", async () => {
+  it("mounts hierarchy workflows while preserving the legacy import path", async () => {
+    const user = userEvent.setup()
     renderTab()
 
     expect(await screen.findByRole("button", { name: "Tải template Excel" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Tải cấu hình hiện tại" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Tải mẫu trống" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Nhập cấu hình phân cấp" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Nhập từ Excel" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Tải cấu hình hiện tại" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Tải mẫu trống" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Nhập cấu hình phân cấp" })).toBeEnabled()
+    expect(screen.getAllByRole("button", { name: /Thêm nhóm con/i })).not.toHaveLength(0)
     expect(
       screen.queryByRole("dialog", { name: "Nhập cấu hình phân cấp từ Excel" })
     ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Nhập cấu hình phân cấp" }))
+
+    expect(
+      screen.getByRole("dialog", { name: "Nhập cấu hình phân cấp từ Excel" })
+    ).toBeInTheDocument()
     expect(rpc.previewHierarchyImport).not.toHaveBeenCalled()
     expect(rpc.applyHierarchyImport).not.toHaveBeenCalled()
+  })
+
+  it("keeps destructive replacement explicit and blocks navigation while apply is pending", async () => {
+    const user = userEvent.setup()
+    const pendingApply = deferred<{ data: ReturnType<typeof createDraft> }>()
+    const onNavigationBlockedChange = vi.fn()
+    rpc.applyHierarchyImport.mockReturnValue(pendingApply.promise)
+
+    renderTab(vi.fn(), createPersistentQueryClient(), onNavigationBlockedChange)
+    await user.click(await screen.findByRole("button", { name: "Nhập cấu hình phân cấp" }))
+    await user.upload(
+      screen.getByLabelText("Chọn workbook cấu hình phân cấp"),
+      createHierarchyImportFile()
+    )
+
+    const confirmation = await screen.findByRole("group", {
+      name: "Xác nhận thay thế toàn bộ cấu hình",
+    })
+    const applyButton = screen.getByRole("button", { name: "Áp dụng thay thế toàn bộ" })
+    expect(confirmation).toHaveTextContent("Xóa 0 mục chính, 0 nhóm con và 1 tiêu chí.")
+    expect(applyButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Khóa phiên bản", hidden: true })).toBeDisabled()
+    expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Tôi hiểu các mục bị thiếu trong workbook sẽ bị xóa",
+      })
+    )
+    expect(applyButton).toBeEnabled()
+    expect(rpc.applyHierarchyImport).not.toHaveBeenCalled()
+
+    await user.click(applyButton)
+    await waitFor(() => expect(rpc.applyHierarchyImport).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
+    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
+
+    await act(async () => {
+      pendingApply.resolve({ data: createDraft({ revision: 5 }) })
+      await pendingApply.promise
+    })
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Nhập cấu hình phân cấp từ Excel" })
+      ).not.toBeInTheDocument()
+    )
+    expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it("keeps XLSX v2 and hierarchy authoring controls draft-only", async () => {
+    rpc.listVersions.mockResolvedValueOnce(baselineVersionsResponse([createLockedVersion()]))
+    renderTab()
+
+    expect(await screen.findByText("Nội dung chỉ đọc")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("group", { name: "Công cụ cấu hình phân cấp" })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Nhập cấu hình phân cấp" })).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx
@@ -54,7 +54,7 @@ describe("technical configuration baseline hierarchy tab workflow", () => {
     rpc.getDossier.mockResolvedValue({ data: dossier })
   })
 
-  it("keeps production authoring hidden and allows locking a subgroup-only criterion draft", async () => {
+  it("mounts production authoring and allows locking a subgroup-only criterion draft", async () => {
     const user = userEvent.setup()
     const draft = createSubgroupOnlyDraft()
     mockVersions([draft])
@@ -62,9 +62,9 @@ describe("technical configuration baseline hierarchy tab workflow", () => {
 
     renderTab()
 
-    expect(await screen.findByText("Hạ tầng")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /Thêm nhóm con/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole("combobox", { name: /Chuyển tiêu chí/i })).not.toBeInTheDocument()
+    expect(await screen.findByDisplayValue("Hạ tầng")).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: /Thêm nhóm con/i })).not.toHaveLength(0)
+    expect(screen.getByRole("combobox", { name: /Chuyển tiêu chí/i })).toBeInTheDocument()
 
     const lockButton = screen.getByRole("button", { name: "Khóa phiên bản" })
     expect(lockButton).toBeEnabled()
@@ -117,7 +117,7 @@ describe("technical configuration baseline hierarchy tab workflow", () => {
     )
 
     renderTab()
-    await screen.findByText("Hạ tầng")
+    await screen.findByDisplayValue("Hạ tầng")
     await user.click(screen.getByRole("button", { name: "Khóa phiên bản" }))
     await user.click(
       within(screen.getByRole("alertdialog")).getByRole("button", {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab-fixtures.tsx
@@ -247,11 +247,12 @@ export function mockVersions(versions: TechnicalConfigurationBaselineDraftWire[]
 
 export function groupMutation(
   revision: number,
-  name: string
+  name: string,
+  baselineVersionId = "draft-1"
 ): TechnicalConfigurationBaselineGroupMutationWire {
   return {
     id: "group-1",
-    baseline_version_id: "draft-1",
+    baseline_version_id: baselineVersionId,
     name,
     sort_order: 1,
     created_at: timestamp,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
@@ -14,13 +14,17 @@ type TechnicalConfigurationBaselineDownloadActionsProps = {
   version: TechnicalConfigurationBaselineDecodedDraft
   dirty: boolean
   conflict: boolean
+  disabled?: boolean
+  disabledMessage?: string | null
 }
 
-/** Renders the draft-only XLSX v2 download actions without mounting them in production. */
+/** Renders production draft-only XLSX v2 download actions. */
 export function TechnicalConfigurationBaselineDownloadActions({
   version,
   dirty,
   conflict,
+  disabled: externallyDisabled = false,
+  disabledMessage = null,
 }: Readonly<TechnicalConfigurationBaselineDownloadActionsProps>) {
   const [downloadingIntent, setDownloadingIntent] =
     React.useState<TechnicalConfigurationBaselineDownloadIntent | null>(null)
@@ -33,8 +37,8 @@ export function TechnicalConfigurationBaselineDownloadActions({
     ? "Tải lại dữ liệu từ máy chủ trước khi tải tệp Excel."
     : dirty
       ? "Lưu thay đổi trước khi tải tệp Excel."
-      : null
-  const disabled = Boolean(guardMessage || downloadingIntent)
+      : disabledMessage
+  const disabled = Boolean(externallyDisabled || guardMessage || downloadingIntent)
 
   async function handleDownload(intent: TechnicalConfigurationBaselineDownloadIntent) {
     if (disabled || downloadingRef.current) return

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
@@ -25,7 +25,7 @@ export function TechnicalConfigurationBaselineDownloadActions({
   conflict,
   disabled: externallyDisabled = false,
   disabledMessage = null,
-}: Readonly<TechnicalConfigurationBaselineDownloadActionsProps>) {
+}: Readonly<TechnicalConfigurationBaselineDownloadActionsProps>): React.JSX.Element | null {
   const [downloadingIntent, setDownloadingIntent] =
     React.useState<TechnicalConfigurationBaselineDownloadIntent | null>(null)
   const [error, setError] = React.useState<string | null>(null)
@@ -40,7 +40,9 @@ export function TechnicalConfigurationBaselineDownloadActions({
       : disabledMessage
   const disabled = Boolean(externallyDisabled || guardMessage || downloadingIntent)
 
-  async function handleDownload(intent: TechnicalConfigurationBaselineDownloadIntent) {
+  async function handleDownload(
+    intent: TechnicalConfigurationBaselineDownloadIntent
+  ): Promise<void> {
     if (disabled || downloadingRef.current) return
     downloadingRef.current = true
     setDownloadingIntent(intent)

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDownloadActions.tsx
@@ -37,7 +37,10 @@ export function TechnicalConfigurationBaselineDownloadActions({
     ? "Tải lại dữ liệu từ máy chủ trước khi tải tệp Excel."
     : dirty
       ? "Lưu thay đổi trước khi tải tệp Excel."
-      : disabledMessage
+      : (disabledMessage ??
+        (externallyDisabled
+          ? "Chờ thao tác hiện tại hoàn tất trước khi dùng công cụ Excel."
+          : null))
   const disabled = Boolean(externallyDisabled || guardMessage || downloadingIntent)
 
   async function handleDownload(

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyImportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineHierarchyImportDialog.tsx
@@ -19,7 +19,7 @@ import {
 
 import { TechnicalConfigurationBaselineHierarchyImportPreview } from "./TechnicalConfigurationBaselineHierarchyImportPreview"
 
-/** Renders the dormant hierarchy-import dialog without production mounting. */
+/** Renders the production hierarchy-import dialog with destructive replacement confirmation. */
 export function TechnicalConfigurationBaselineHierarchyImportDialog({
   workflow,
 }: Readonly<{

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type * as React from "react"
 import { Upload } from "lucide-react"
 
 import type { TechnicalConfigurationBaselineDecodedDraft } from "../baseline-types"
@@ -24,7 +25,7 @@ export function TechnicalConfigurationBaselineProductionActions({
   disabled,
   disabledMessage,
   onRequestHierarchyImport,
-}: TechnicalConfigurationBaselineProductionActionsProps) {
+}: TechnicalConfigurationBaselineProductionActionsProps): React.JSX.Element | null {
   if (version.status !== "draft") return null
 
   const actionsDisabled = disabled || dirty || conflict

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { Upload } from "lucide-react"
+
+import type { TechnicalConfigurationBaselineDecodedDraft } from "../baseline-types"
+import { Button } from "@/components/ui/button"
+
+import { TechnicalConfigurationBaselineDownloadActions } from "./TechnicalConfigurationBaselineDownloadActions"
+
+type TechnicalConfigurationBaselineProductionActionsProps = Readonly<{
+  version: TechnicalConfigurationBaselineDecodedDraft
+  dirty: boolean
+  conflict: boolean
+  disabled: boolean
+  disabledMessage: string | null
+  onRequestHierarchyImport: () => void
+}>
+
+/** Mounts the P6B draft-only XLSX v2 and hierarchy import commands. */
+export function TechnicalConfigurationBaselineProductionActions({
+  version,
+  dirty,
+  conflict,
+  disabled,
+  disabledMessage,
+  onRequestHierarchyImport,
+}: TechnicalConfigurationBaselineProductionActionsProps) {
+  if (version.status !== "draft") return null
+
+  const actionsDisabled = disabled || dirty || conflict
+
+  return (
+    <div
+      role="group"
+      aria-label="Công cụ cấu hình phân cấp"
+      className="flex min-w-0 flex-wrap items-start gap-2"
+    >
+      <TechnicalConfigurationBaselineDownloadActions
+        version={version}
+        dirty={dirty}
+        conflict={conflict}
+        disabled={disabled}
+        disabledMessage={disabledMessage}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        disabled={actionsDisabled}
+        onClick={onRequestHierarchyImport}
+      >
+        <Upload className="size-4" aria-hidden="true" />
+        Nhập cấu hình phân cấp
+      </Button>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionSurfaces.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionSurfaces.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import type * as React from "react"
+
 import type { UseTechnicalConfigurationBaselineHierarchyImportResult } from "../_hooks/useTechnicalConfigurationBaselineHierarchyImport"
 import type { UseTechnicalConfigurationBaselineImportResult } from "../_hooks/useTechnicalConfigurationBaselineImport"
 import type { TechnicalConfigurationBaselineDecodedDraft } from "../baseline-types"
@@ -31,7 +33,7 @@ export function TechnicalConfigurationBaselineProductionSurfaces({
   legacyImport,
   hierarchyImport,
   onRequestHierarchyImport,
-}: TechnicalConfigurationBaselineProductionSurfacesProps) {
+}: TechnicalConfigurationBaselineProductionSurfacesProps): React.JSX.Element {
   return (
     <>
       {!isFocusMode && version ? (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionSurfaces.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionSurfaces.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import type { UseTechnicalConfigurationBaselineHierarchyImportResult } from "../_hooks/useTechnicalConfigurationBaselineHierarchyImport"
+import type { UseTechnicalConfigurationBaselineImportResult } from "../_hooks/useTechnicalConfigurationBaselineImport"
+import type { TechnicalConfigurationBaselineDecodedDraft } from "../baseline-types"
+
+import { TechnicalConfigurationBaselineHierarchyImportDialog } from "./TechnicalConfigurationBaselineHierarchyImportDialog"
+import { TechnicalConfigurationBaselineImportDialog } from "./TechnicalConfigurationBaselineImportDialog"
+import { TechnicalConfigurationBaselineProductionActions } from "./TechnicalConfigurationBaselineProductionActions"
+
+type TechnicalConfigurationBaselineProductionSurfacesProps = Readonly<{
+  isFocusMode: boolean
+  version: TechnicalConfigurationBaselineDecodedDraft | null
+  dirty: boolean
+  conflict: boolean
+  disabled: boolean
+  disabledMessage: string | null
+  legacyImport: UseTechnicalConfigurationBaselineImportResult
+  hierarchyImport: UseTechnicalConfigurationBaselineHierarchyImportResult
+  onRequestHierarchyImport: () => void
+}>
+
+/** Mounts production spreadsheet commands and their independent import dialogs. */
+export function TechnicalConfigurationBaselineProductionSurfaces({
+  isFocusMode,
+  version,
+  dirty,
+  conflict,
+  disabled,
+  disabledMessage,
+  legacyImport,
+  hierarchyImport,
+  onRequestHierarchyImport,
+}: TechnicalConfigurationBaselineProductionSurfacesProps) {
+  return (
+    <>
+      {!isFocusMode && version ? (
+        <TechnicalConfigurationBaselineProductionActions
+          version={version}
+          dirty={dirty}
+          conflict={conflict}
+          disabled={disabled}
+          disabledMessage={disabledMessage}
+          onRequestHierarchyImport={onRequestHierarchyImport}
+        />
+      ) : null}
+      <TechnicalConfigurationBaselineImportDialog workflow={legacyImport} />
+      <TechnicalConfigurationBaselineHierarchyImportDialog workflow={hierarchyImport} />
+    </>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -1,17 +1,19 @@
 import * as React from "react"
 
 import { useTechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor"
-import { useTechnicalConfigurationBaselineImport } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImport"
+import { useTechnicalConfigurationBaselineImportWorkflows } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
 import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import { useTechnicalConfigurationInlineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor"
+import { getTechnicalConfigurationBaselineLockBlockedReason } from "@/app/(app)/technical-configurations/TechnicalConfigurationBaselineLockReason"
 import { validateTechnicalConfigurationBaselineEditorDraft } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 
 import { TechnicalConfigurationBaselineAlerts } from "./TechnicalConfigurationBaselineAlerts"
 import { TechnicalConfigurationBaselineEditor } from "./TechnicalConfigurationBaselineEditor"
-import { TechnicalConfigurationBaselineImportDialog } from "./TechnicalConfigurationBaselineImportDialog"
+import { TechnicalConfigurationBaselineProductionSurfaces } from "./TechnicalConfigurationBaselineProductionSurfaces"
+import { TechnicalConfigurationBaselineVersionControls } from "./TechnicalConfigurationBaselineVersionControls"
 import { TechnicalConfigurationLockDialog } from "./TechnicalConfigurationLockDialog"
 import {
   TechnicalConfigurationBaselineLoadingState,
@@ -19,7 +21,6 @@ import {
   TechnicalConfigurationBaselineMissingState,
   TechnicalConfigurationBaselineQueryError,
 } from "./TechnicalConfigurationBaselineTabStates"
-import { TechnicalConfigurationVersionBar } from "./TechnicalConfigurationVersionBar"
 
 type TechnicalConfigurationBaselineTabProps = {
   dossier: TechnicalConfigurationDossierWire
@@ -48,8 +49,12 @@ export function TechnicalConfigurationBaselineTab({
   })
   const draft = baseline.editorDraft
   const selectedVersion = baseline.selectedVersion
-  const isImportBlocked = baseline.isDirty || bulkSessions.hasPendingInput
-  const baselineImport = useTechnicalConfigurationBaselineImport({
+  const isImportBlocked =
+    baseline.isDirty ||
+    baseline.isConflict ||
+    baseline.isLifecycleBusy ||
+    bulkSessions.hasPendingInput
+  const imports = useTechnicalConfigurationBaselineImportWorkflows({
     dossierId: dossier.id,
     selectedVersion,
     isBlocked: isImportBlocked,
@@ -61,41 +66,15 @@ export function TechnicalConfigurationBaselineTab({
     () => (draft ? validateTechnicalConfigurationBaselineEditorDraft(draft) : baseline.validation),
     [baseline.validation, draft]
   )
-  const lockBlockedReason = React.useMemo(() => {
-    if (!draft || selectedVersion?.status !== "draft") return null
-    if (baseline.isConflict) return "Tải lại dữ liệu từ máy chủ trước khi khóa phiên bản."
-    if (baseline.isDirty) return "Lưu thay đổi trước khi khóa phiên bản."
-    if (bulkSessions.hasPendingInput) return "Hoàn tất hoặc hủy nội dung nhập nhanh trước khi khóa."
-    if (baselineImport.hasUnresolvedState) {
-      return "Hoàn tất hoặc hủy nhập Excel trước khi khóa phiên bản."
-    }
-    if (
-      Object.keys(summaryValidation.groupErrors).length > 0 ||
-      Object.keys(summaryValidation.subgroupErrors ?? {}).length > 0 ||
-      Object.keys(summaryValidation.criterionErrors).length > 0
-    ) {
-      return "Sửa các lỗi nội dung trước khi khóa phiên bản."
-    }
-    if (draft.groups.length < 1) return "Cần ít nhất một nhóm trước khi khóa phiên bản."
-    if (
-      !draft.groups.some(
-        (group) =>
-          group.criteria.length > 0 ||
-          group.subgroups.some((subgroup) => subgroup.criteria.length > 0)
-      )
-    ) {
-      return "Cần ít nhất một tiêu chí có nội dung trước khi khóa phiên bản."
-    }
-    return null
-  }, [
-    baseline.isConflict,
-    baseline.isDirty,
-    baselineImport.hasUnresolvedState,
-    bulkSessions.hasPendingInput,
+  const lockBlockedReason = getTechnicalConfigurationBaselineLockBlockedReason({
     draft,
-    selectedVersion?.status,
-    summaryValidation,
-  ])
+    isSelectedDraft: selectedVersion?.status === "draft",
+    isConflict: baseline.isConflict,
+    isDirty: baseline.isDirty,
+    hasPendingBulkInput: bulkSessions.hasPendingInput,
+    hasUnresolvedImportState,
+    validation: summaryValidation,
+  })
   const inlineEditor = useTechnicalConfigurationInlineEditor({
     draft,
     validation: summaryValidation,
@@ -104,7 +83,7 @@ export function TechnicalConfigurationBaselineTab({
     onEditorChange: baseline.onEditorChange,
   })
   const isUnsafeToLeave =
-    baseline.isDirty || bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState
+    baseline.isDirty || bulkSessions.hasPendingInput || hasUnresolvedImportState
   const reportWorkspaceState = React.useCallback(
     (dirty: boolean, navigationBlocked: boolean) => {
       onDirtyChange(dirty)
@@ -113,9 +92,9 @@ export function TechnicalConfigurationBaselineTab({
     [onDirtyChange, onNavigationBlockedChange]
   )
   React.useEffect(() => {
-    reportWorkspaceState(isUnsafeToLeave, baselineImport.isApplying)
+    reportWorkspaceState(isUnsafeToLeave, imports.isApplying)
     return () => reportWorkspaceState(false, false)
-  }, [baselineImport.isApplying, isUnsafeToLeave, reportWorkspaceState])
+  }, [imports.isApplying, isUnsafeToLeave, reportWorkspaceState])
 
   useTechnicalConfigurationBeforeUnloadGuard(isUnsafeToLeave)
 
@@ -132,7 +111,7 @@ export function TechnicalConfigurationBaselineTab({
   }
 
   const handleReloadFromServer = () => {
-    if (bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState) return
+    if (bulkSessions.hasPendingInput || hasUnresolvedImportState) return
     if (selectedVersion?.status === "locked") {
       void baseline.onRefreshVersions().catch(() => undefined)
       return
@@ -153,7 +132,7 @@ export function TechnicalConfigurationBaselineTab({
 
     const selectVersion = () => {
       bulkSessions.clearAll()
-      baselineImport.reset()
+      imports.reset()
       baseline.onSelectVersion(versionId, { force: isUnsafeToLeave })
       inlineEditor.prepareForReload(nextVersion.groups[0]?.id ?? "")
     }
@@ -215,64 +194,66 @@ export function TechnicalConfigurationBaselineTab({
       className="flex min-h-0 flex-1 flex-col gap-3"
     >
       <div className="shrink-0">
-        {isFocusMode ? (
-          <div
-            role="region"
-            aria-label="Ngữ cảnh cấu hình đang chỉnh sửa"
-            className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-b pb-2 text-sm"
-          >
-            <strong className="truncate font-semibold">{dossier.name}</strong>
-            <span className="text-muted-foreground">
-              Phiên bản {selectedVersion.version_number} ·{" "}
-              {selectedVersion.status === "locked" ? "Đã khóa" : "Bản nháp"}
-            </span>
-          </div>
-        ) : (
-          <TechnicalConfigurationVersionBar
-            versions={baseline.versions}
-            selectedVersion={selectedVersion}
-            lockBlockedReason={lockBlockedReason}
-            status={{
-              hasDraft: baseline.hasDraft,
-              isCreating: baseline.isCreating,
-              isLocking: baseline.isLocking,
-              isCopying: baseline.isCopying,
-              isLoadingMoreVersions: baseline.isLoadingMoreVersions,
-              hasLoadMoreError: baseline.hasLoadMoreError,
-              isNavigationDisabled: baseline.isLifecycleBusy,
-              hasMoreVersions: baseline.hasMoreVersions,
-              isDownloadingTemplate: baselineImport.isDownloading,
-              isImportBusy: baselineImport.isPreviewing || baselineImport.isApplying,
-              isImportBlocked,
-            }}
-            onSelectVersion={handleSelectVersion}
-            onLoadMoreVersions={() => void baseline.onLoadMoreVersions()}
-            onRequestLock={() => setIsLockDialogOpen(true)}
-            onCreateBlank={baseline.onCreate}
-            onCopy={() => void handleCopy()}
-            onDownloadTemplate={() => void baselineImport.downloadTemplate()}
-            onRequestImport={baselineImport.openDialog}
-          />
-        )}
+        <TechnicalConfigurationBaselineVersionControls
+          dossierName={dossier.name}
+          isFocusMode={isFocusMode}
+          versions={baseline.versions}
+          selectedVersion={selectedVersion}
+          lockBlockedReason={lockBlockedReason}
+          status={{
+            hasDraft: baseline.hasDraft,
+            isCreating: baseline.isCreating,
+            isLocking: baseline.isLocking,
+            isCopying: baseline.isCopying,
+            isLoadingMoreVersions: baseline.isLoadingMoreVersions,
+            hasLoadMoreError: baseline.hasLoadMoreError,
+            isNavigationDisabled: baseline.isLifecycleBusy,
+            hasMoreVersions: baseline.hasMoreVersions,
+            isDownloadingTemplate: imports.legacyImport.isDownloading,
+            isImportBusy: imports.legacyImport.isPreviewing || imports.legacyImport.isApplying,
+            isImportBlocked,
+          }}
+          onSelectVersion={handleSelectVersion}
+          onLoadMoreVersions={() => void baseline.onLoadMoreVersions()}
+          onRequestLock={() => setIsLockDialogOpen(true)}
+          onCreateBlank={baseline.onCreate}
+          onCopy={() => void handleCopy()}
+          onDownloadTemplate={() => void imports.legacyImport.downloadTemplate()}
+          onRequestImport={imports.openLegacyImport}
+        />
       </div>
+
+      <TechnicalConfigurationBaselineProductionSurfaces
+        isFocusMode={isFocusMode}
+        version={imports.decodedVersion}
+        dirty={baseline.isDirty}
+        conflict={baseline.isConflict}
+        disabled={baseline.isLifecycleBusy || bulkSessions.hasPendingInput}
+        disabledMessage={
+          bulkSessions.hasPendingInput
+            ? "Hoàn tất hoặc hủy nội dung nhập nhanh trước khi dùng công cụ Excel."
+            : null
+        }
+        legacyImport={imports.legacyImport}
+        hierarchyImport={imports.hierarchyImport}
+        onRequestHierarchyImport={imports.openHierarchyImport}
+      />
 
       <TechnicalConfigurationBaselineAlerts
         isConflict={baseline.isConflict}
         isReloading={baseline.isReloading}
-        isReloadBlocked={bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState}
+        isReloadBlocked={bulkSessions.hasPendingInput || hasUnresolvedImportState}
         pendingInputDescriptionId={
           bulkSessions.hasPendingInput ? "technical-configuration-pending-bulk-status" : undefined
         }
         saveError={
-          baselineImport.operationError ??
+          imports.operationError ??
           baseline.createError ??
           baseline.saveError ??
           baseline.lifecycleError
         }
         onReload={handleReloadFromServer}
       />
-
-      <TechnicalConfigurationBaselineImportDialog workflow={baselineImport} />
 
       {selectedVersion.status === "locked" ? (
         <TechnicalConfigurationBaselineLockedState version={selectedVersion} />
@@ -310,6 +291,7 @@ export function TechnicalConfigurationBaselineTab({
           onBulkAccept={inlineEditor.acceptBulk}
           onSave={baseline.onSave}
           onToggleFocusMode={onToggleFocusMode}
+          hierarchyAuthoring={inlineEditor.hierarchyAuthoring}
         />
       ) : null}
 
@@ -322,7 +304,6 @@ export function TechnicalConfigurationBaselineTab({
           onConfirm={() => void handleConfirmLock()}
         />
       ) : null}
-
       {discardConfirmationDialog}
     </div>
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
@@ -1,3 +1,5 @@
+import type * as React from "react"
+
 import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
 
 import {
@@ -36,11 +38,10 @@ export function TechnicalConfigurationBaselineVersionControls({
   onCopy,
   onDownloadTemplate,
   onRequestImport,
-}: TechnicalConfigurationBaselineVersionControlsProps) {
+}: TechnicalConfigurationBaselineVersionControlsProps): React.JSX.Element {
   if (isFocusMode) {
     return (
-      <div
-        role="region"
+      <section
         aria-label="Ngữ cảnh cấu hình đang chỉnh sửa"
         className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-b pb-2 text-sm"
       >
@@ -49,7 +50,7 @@ export function TechnicalConfigurationBaselineVersionControls({
           Phiên bản {selectedVersion.version_number} ·{" "}
           {selectedVersion.status === "locked" ? "Đã khóa" : "Bản nháp"}
         </span>
-      </div>
+      </section>
     )
   }
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
@@ -1,0 +1,71 @@
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+
+import {
+  TechnicalConfigurationVersionBar,
+  type TechnicalConfigurationVersionBarStatus,
+} from "./TechnicalConfigurationVersionBar"
+
+type TechnicalConfigurationBaselineVersionControlsProps = Readonly<{
+  dossierName: string
+  isFocusMode: boolean
+  versions: TechnicalConfigurationBaselineDraftWire[]
+  selectedVersion: TechnicalConfigurationBaselineDraftWire
+  lockBlockedReason: string | null
+  status: TechnicalConfigurationVersionBarStatus
+  onSelectVersion: (versionId: string) => void
+  onLoadMoreVersions: () => void
+  onRequestLock: () => void
+  onCreateBlank: () => void
+  onCopy: () => void
+  onDownloadTemplate: () => void
+  onRequestImport: () => void
+}>
+
+/** Renders the compact focus context or the full baseline version controls. */
+export function TechnicalConfigurationBaselineVersionControls({
+  dossierName,
+  isFocusMode,
+  versions,
+  selectedVersion,
+  lockBlockedReason,
+  status,
+  onSelectVersion,
+  onLoadMoreVersions,
+  onRequestLock,
+  onCreateBlank,
+  onCopy,
+  onDownloadTemplate,
+  onRequestImport,
+}: TechnicalConfigurationBaselineVersionControlsProps) {
+  if (isFocusMode) {
+    return (
+      <div
+        role="region"
+        aria-label="Ngữ cảnh cấu hình đang chỉnh sửa"
+        className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 border-b pb-2 text-sm"
+      >
+        <strong className="truncate font-semibold">{dossierName}</strong>
+        <span className="text-muted-foreground">
+          Phiên bản {selectedVersion.version_number} ·{" "}
+          {selectedVersion.status === "locked" ? "Đã khóa" : "Bản nháp"}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <TechnicalConfigurationVersionBar
+      versions={versions}
+      selectedVersion={selectedVersion}
+      lockBlockedReason={lockBlockedReason}
+      status={status}
+      onSelectVersion={onSelectVersion}
+      onLoadMoreVersions={onLoadMoreVersions}
+      onRequestLock={onRequestLock}
+      onCreateBlank={onCreateBlank}
+      onCopy={onCopy}
+      onDownloadTemplate={onDownloadTemplate}
+      onRequestImport={onRequestImport}
+    />
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
@@ -6,23 +6,25 @@ import { Button } from "@/components/ui/button"
 import { SingleSelect } from "@/components/ui/heroui/SingleSelect"
 import { formatVietnamDateTime } from "@/lib/date-utils"
 
+export type TechnicalConfigurationVersionBarStatus = Readonly<{
+  hasDraft: boolean
+  isCreating: boolean
+  isLocking: boolean
+  isCopying: boolean
+  isLoadingMoreVersions: boolean
+  hasLoadMoreError: boolean
+  isNavigationDisabled: boolean
+  hasMoreVersions: boolean
+  isDownloadingTemplate: boolean
+  isImportBusy: boolean
+  isImportBlocked: boolean
+}>
+
 type TechnicalConfigurationVersionBarProps = {
   versions: TechnicalConfigurationBaselineDraftWire[]
   selectedVersion: TechnicalConfigurationBaselineDraftWire
   lockBlockedReason: string | null
-  status: {
-    hasDraft: boolean
-    isCreating: boolean
-    isLocking: boolean
-    isCopying: boolean
-    isLoadingMoreVersions: boolean
-    hasLoadMoreError: boolean
-    isNavigationDisabled: boolean
-    hasMoreVersions: boolean
-    isDownloadingTemplate: boolean
-    isImportBusy: boolean
-    isImportBlocked: boolean
-  }
+  status: TechnicalConfigurationVersionBarStatus
   onSelectVersion: (versionId: string) => void
   onLoadMoreVersions: () => void
   onRequestLock: () => void

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows.ts
@@ -1,0 +1,82 @@
+import * as React from "react"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import { decodeTechnicalConfigurationBaselineDraftWire } from "../technical-configuration-baseline-decoders"
+import { useTechnicalConfigurationBaselineHierarchyImport } from "./useTechnicalConfigurationBaselineHierarchyImport"
+import { useTechnicalConfigurationBaselineImport } from "./useTechnicalConfigurationBaselineImport"
+
+type UseTechnicalConfigurationBaselineImportWorkflowsOptions = Readonly<{
+  dossierId: string
+  selectedVersion: TechnicalConfigurationBaselineDraftWire | null
+  isBlocked: boolean
+  onApplied: (version: TechnicalConfigurationBaselineDraftWire) => Promise<void>
+  onConflict: (versionId: string) => Promise<void>
+  onUnresolvedStateChange: (unresolved: boolean) => void
+}>
+
+/** Composes legacy and hierarchy import lifecycles without conflating their state. */
+export function useTechnicalConfigurationBaselineImportWorkflows({
+  dossierId,
+  selectedVersion,
+  isBlocked,
+  onApplied,
+  onConflict,
+  onUnresolvedStateChange,
+}: UseTechnicalConfigurationBaselineImportWorkflowsOptions) {
+  const unresolvedRef = React.useRef({ hierarchy: false, legacy: false })
+  const decodedVersion = React.useMemo(
+    () =>
+      selectedVersion
+        ? decodeTechnicalConfigurationBaselineDraftWire(selectedVersion, "selectedVersion")
+        : null,
+    [selectedVersion]
+  )
+
+  const reportUnresolvedState = React.useCallback(
+    (workflow: "hierarchy" | "legacy", unresolved: boolean) => {
+      unresolvedRef.current[workflow] = unresolved
+      onUnresolvedStateChange(unresolvedRef.current.hierarchy || unresolvedRef.current.legacy)
+    },
+    [onUnresolvedStateChange]
+  )
+
+  const legacyImport = useTechnicalConfigurationBaselineImport({
+    dossierId,
+    selectedVersion,
+    isBlocked,
+    onApplied,
+    onConflict,
+    onUnresolvedStateChange: React.useCallback(
+      (unresolved: boolean) => reportUnresolvedState("legacy", unresolved),
+      [reportUnresolvedState]
+    ),
+  })
+  const hierarchyImport = useTechnicalConfigurationBaselineHierarchyImport({
+    selectedVersion: decodedVersion,
+    isBlocked,
+    onApplied,
+    onConflict,
+    onUnresolvedStateChange: React.useCallback(
+      (unresolved: boolean) => reportUnresolvedState("hierarchy", unresolved),
+      [reportUnresolvedState]
+    ),
+  })
+
+  return {
+    decodedVersion,
+    legacyImport,
+    hierarchyImport,
+    isApplying: legacyImport.isApplying || hierarchyImport.isApplying,
+    operationError: hierarchyImport.operationError ?? legacyImport.operationError,
+    reset: () => {
+      legacyImport.reset()
+      hierarchyImport.reset()
+    },
+    openLegacyImport: () => {
+      if (!hierarchyImport.open) legacyImport.openDialog()
+    },
+    openHierarchyImport: () => {
+      if (!legacyImport.open) hierarchyImport.openDialog()
+    },
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImportWorkflows.ts
@@ -1,9 +1,18 @@
 import * as React from "react"
 
-import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import type {
+  TechnicalConfigurationBaselineDecodedDraft,
+  TechnicalConfigurationBaselineDraftWire,
+} from "../baseline-types"
 import { decodeTechnicalConfigurationBaselineDraftWire } from "../technical-configuration-baseline-decoders"
-import { useTechnicalConfigurationBaselineHierarchyImport } from "./useTechnicalConfigurationBaselineHierarchyImport"
-import { useTechnicalConfigurationBaselineImport } from "./useTechnicalConfigurationBaselineImport"
+import {
+  useTechnicalConfigurationBaselineHierarchyImport,
+  type UseTechnicalConfigurationBaselineHierarchyImportResult,
+} from "./useTechnicalConfigurationBaselineHierarchyImport"
+import {
+  useTechnicalConfigurationBaselineImport,
+  type UseTechnicalConfigurationBaselineImportResult,
+} from "./useTechnicalConfigurationBaselineImport"
 
 type UseTechnicalConfigurationBaselineImportWorkflowsOptions = Readonly<{
   dossierId: string
@@ -14,6 +23,17 @@ type UseTechnicalConfigurationBaselineImportWorkflowsOptions = Readonly<{
   onUnresolvedStateChange: (unresolved: boolean) => void
 }>
 
+export type UseTechnicalConfigurationBaselineImportWorkflowsResult = Readonly<{
+  decodedVersion: TechnicalConfigurationBaselineDecodedDraft | null
+  legacyImport: UseTechnicalConfigurationBaselineImportResult
+  hierarchyImport: UseTechnicalConfigurationBaselineHierarchyImportResult
+  isApplying: boolean
+  operationError: string | null
+  reset: () => void
+  openLegacyImport: () => void
+  openHierarchyImport: () => void
+}>
+
 /** Composes legacy and hierarchy import lifecycles without conflating their state. */
 export function useTechnicalConfigurationBaselineImportWorkflows({
   dossierId,
@@ -22,7 +42,7 @@ export function useTechnicalConfigurationBaselineImportWorkflows({
   onApplied,
   onConflict,
   onUnresolvedStateChange,
-}: UseTechnicalConfigurationBaselineImportWorkflowsOptions) {
+}: UseTechnicalConfigurationBaselineImportWorkflowsOptions): UseTechnicalConfigurationBaselineImportWorkflowsResult {
   const unresolvedRef = React.useRef({ hierarchy: false, legacy: false })
   const decodedVersion = React.useMemo(
     () =>


### PR DESCRIPTION
## Summary

- activate the production draft-only XLSX v2 current-data and blank-template downloads
- mount hierarchy import with authoritative preview, explicit destructive replacement confirmation, stale-revision recovery, and aggregate navigation blocking
- enable existing subgroup authoring while retaining the legacy workbook import path
- extract version controls and lock-reason composition so the baseline tab remains within source-size and React Doctor limits

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P3C/P3D/P4C/legacy regressions: 67/67 passed
- full technical-configuration regressions: 109 files, 854/854 tests passed
- `node scripts/npm-run.js run react-doctor`: 100/100, no issues
- `node scripts/npm-run.js run build`
- `openspec validate revise-technical-configuration-baseline-hierarchy --strict`
- `git diff --check`
- independent specification and code-quality reviews: zero actionable findings
- pre-commit and pre-push Lefthook gates passed

## Scope Notes

- Browser route testing remains intentionally skipped because credentials are unavailable; OpenSpec P6B.2 remains unchecked with a dated note.
- No SQL/RPC contract changes, migrations, live database writes, environment files, credentials, or secrets are included.
- Evaluation, comparison, and result-export production components were not modified and their full regressions passed.

Closes #909

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates the P6B hierarchy UI on the production baseline screen: XLSX v2 downloads, hierarchy import, and subgroup authoring are now draft‑only; locked versions remain read‑only. Excel actions now explain why they are disabled. Implements #909.

- Composes legacy and XLSX v2 imports with `useTechnicalConfigurationBaselineImportWorkflows`; tracks unresolved states independently; blocks navigation while any apply runs; surfaces a single operation error.
- Mounts draft-only production actions/dialogs via `TechnicalConfigurationBaselineProductionSurfaces` and `TechnicalConfigurationBaselineProductionActions`; reuses `TechnicalConfigurationBaselineDownloadActions` with `disabled`/`disabledMessage`; responsive, accessible action group.
- Preserves guards: dirty/conflict/lifecycle‑busy/pending‑bulk‑entry block downloads/import, reload/copy/lock, and before‑unload; hierarchy import keeps explicit destructive replacement confirmation.
- Extracts `TechnicalConfigurationBaselineVersionControls` and `TechnicalConfigurationBaselineLockReason` to centralize lock blocking; editor receives `hierarchyAuthoring`; focus mode and version behavior unchanged.
- Updates tests for activation, blocking, disabled‑reason messaging, accessibility, and wrapping; OpenSpec marks P6B.1/P6B.3 complete; browser route tests intentionally skipped. No SQL/RPC/migrations or env changes.

<sup>Written for commit fa7c36bdbb40d088cfaa25017b5b2445c679bea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XLSX v2 download actions for draft technical-configuration baselines.
  * Enabled hierarchy import with explicit destructive-replacement confirmation.
  * Added hierarchy authoring controls, including subgroup creation and criterion movement.
  * Added responsive version controls and production configuration tools.

* **Bug Fixes**
  * Improved safeguards for unsaved changes, conflicts, incomplete imports, validation errors, and pending updates.
  * Prevented conflicting import dialogs and blocked navigation while changes are being applied.
  * Kept editing and production actions unavailable for locked versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->