### PR TITLE
test(db-quality-gate): add Phase 0 RED contract

### DIFF
--- a/openspec/changes/add-database-quality-gate/phase-0-characterization.md
+++ b/openspec/changes/add-database-quality-gate/phase-0-characterization.md
@@ -1,0 +1,83 @@
+# Phase 0 Characterization and RED Contract
+
+Recorded on 2026-08-16 for `add-database-quality-gate`.
+
+## Scope
+
+This checkpoint adds only contract tests and characterization evidence. It does
+not add a gate runner, committed registry, migration SQL, CI configuration,
+GitHub ruleset change, Oracle mutation, or live Supabase write.
+
+## Repository and Environment Facts
+
+- Root migration inventory:
+  - `supabase/migrations` has 330 root SQL files.
+  - 41 files use a legacy `YYYYMMDD` prefix, 288 use a
+    `YYYYMMDDHHMMSS` prefix, and one uses the noncanonical
+    `202511061200` prefix.
+  - The legacy date-only prefix has duplicate values; no duplicate 14-digit
+    timestamp prefix was observed.
+  - The lexical source high-water is
+    `20260815105027_harden_device_quota_unlink_contract.sql`.
+  - This is characterization only. The future gate must classify source
+    membership and ordering deterministically instead of assuming that every
+    existing legacy filename is ambiguous.
+- Read-only live Supabase inspection found 324 applied migration records with
+  high-water `20260816044031`.
+- Read-only Oracle inspection found the persistent `qltbyt_test` baseline at
+  the same 324-record, `20260816044031` high-water. The self-hosted Supabase
+  containers were healthy and PostgreSQL, Kong, and Supavisor listeners
+  remained loopback-only.
+- Root-source and live record counts/high-waters are intentionally recorded as
+  separate facts. The gate must not infer a one-to-one identity mapping from
+  filenames or timestamps alone.
+- `supabase/tests` contains 89 SQL files. All contain `BEGIN`; 71 contain
+  `ROLLBACK`. No SQL test was executed in this phase, and filename conventions
+  do not classify a test as default-safe.
+- GitHub has one branch ruleset, `my_rules` (ID `12360764`), but it is
+  disabled and has no rules.
+- Wayfinder #938 is closed as of `2026-08-16T09:29:20Z`. It settles that
+  ordinary gate runs operate offline, pre-live uses read-only live comparison,
+  and restored-baseline catch-up occurs after a successful live apply using
+  migrations already verified as live-applied. Unexplained drift or
+  refresh/catch-up failure is fail-closed as `BLOCKING` or `INCOMPLETE`.
+
+## RED Contract
+
+The new suites specify the future runner-neutral modules under
+`scripts/db-quality-gate/`:
+
+| Suite                                                | Required behavior                                                                                   |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `database-quality-gate-contract.test.ts`             | Finding classifications, aggregate outcomes, exit codes, deterministic JSON, and Markdown rendering |
+| `database-quality-gate-hash.test.ts`                 | One-terminal-newline normalization and content-preserving SHA-256                                   |
+| `database-quality-gate-registry.test.ts`             | Applied lock, waiver, invariant, and SQL-test metadata schema contracts                             |
+| `database-quality-gate-migration-repository.test.ts` | Legacy mutation/rename/deletion, lock history, pending editability, and ambiguous ordering          |
+| `database-quality-gate-baseline.test.ts`             | Identity-based baseline comparison and no-new-regressions behavior                                  |
+| `database-quality-gate-approvals.test.ts`            | Candidate evidence, approval-bearing commits, invalidation, expiry, revocation, and review evidence |
+
+Expected RED command:
+
+```bash
+node scripts/npm-run.js run test:run -- scripts/__tests__/database-quality-gate-contract.test.ts scripts/__tests__/database-quality-gate-hash.test.ts scripts/__tests__/database-quality-gate-registry.test.ts scripts/__tests__/database-quality-gate-migration-repository.test.ts scripts/__tests__/database-quality-gate-baseline.test.ts scripts/__tests__/database-quality-gate-approvals.test.ts --reporter=verbose
+```
+
+Observed result: 6 failed test files and 25 failed tests. Every failure was the
+expected `ERR_MODULE_NOT_FOUND` for an unimplemented module under the absolute
+repository path `scripts/db-quality-gate/*.ts`. No test compilation, fixture,
+or unrelated runtime failure was observed.
+
+The pure outcome/report, hashing, registry, and approval seams are intended for
+the Phase 1 contract core. The repository inspection and identity-baseline
+seams require the Phase 2 static implementation. Later phases must make these
+tests green without weakening the Phase 0 contracts.
+
+## Boundaries Preserved
+
+- No migration source, lock history, Oracle database, GitHub ruleset, or live
+  Supabase state was changed.
+- The live migration query was read-only through Supabase MCP.
+- Oracle access was read-only and did not clone, restore, catch up, or execute
+  SQL tests.
+- A gate result, approval, merge, or this characterization never authorizes a
+  live write.

--- a/openspec/changes/add-database-quality-gate/tasks.md
+++ b/openspec/changes/add-database-quality-gate/tasks.md
@@ -25,24 +25,24 @@
 **Purpose:** Lock current repository and environment behavior before adding the
 gate.
 
-- [ ] 0.1 Reconfirm the current root migration inventory, ordering edge cases,
+- [x] 0.1 Reconfirm the current root migration inventory, ordering edge cases,
       live migration high-water, restored-baseline high-water, SQL-test
       inventory, Oracle runtime, and GitHub ruleset state.
-- [ ] 0.2 Add failing tests for deterministic finding classifications, aggregate
+- [x] 0.2 Add failing tests for deterministic finding classifications, aggregate
       outcomes, exit codes `0/1/2`, and JSON/Markdown report consistency.
-- [ ] 0.3 Add failing tests for canonical terminal-newline normalization and
+- [x] 0.3 Add failing tests for canonical terminal-newline normalization and
       content-preserving SHA-256 behavior.
-- [ ] 0.4 Add failing registry-schema tests for applied lock, waivers,
+- [x] 0.4 Add failing registry-schema tests for applied lock, waivers,
       invariants, and SQL-test metadata.
-- [ ] 0.5 Add failing fixture-repository tests for legacy mutation, rename,
+- [x] 0.5 Add failing fixture-repository tests for legacy mutation, rename,
       deletion, lock-history mutation, pending-file editability, and ambiguous
       migration ordering.
-- [ ] 0.6 Add failing tests for identity-based baseline comparison and
+- [x] 0.6 Add failing tests for identity-based baseline comparison and
       no-new-regressions behavior.
-- [ ] 0.7 Add failing DANGEROUS approval tests for candidate evidence,
+- [x] 0.7 Add failing DANGEROUS approval tests for candidate evidence,
       approval-bearing commits, content invalidation, expiry, revocation, and
       missing review evidence.
-- [ ] 0.8 Record the expected RED failures without changing production behavior,
+- [x] 0.8 Record the expected RED failures without changing production behavior,
       migration SQL, GitHub settings, Oracle databases, or live Supabase.
 
 **Review boundary:** Tests and characterization only.

--- a/scripts/__tests__/database-quality-gate-approvals.test.ts
+++ b/scripts/__tests__/database-quality-gate-approvals.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type DangerousFinding = {
+  classification: "DANGEROUS"
+  fingerprint: string
+  migrationSha256: string
+  ruleId: string
+}
+
+type CandidateEvidence = {
+  candidateCommit: string
+  findingFingerprint: string
+  migrationSha256: string
+  reportDigest: string
+}
+
+type Approval = {
+  approvalCommit: string
+  candidateCommit: string
+  expiresAt?: string
+  findingFingerprint: string
+  id: string
+  migrationSha256: string
+  reviewEvidence?: string
+  revokedAt?: string
+  ruleId: string
+  status: "active" | "revoked" | "superseded"
+}
+
+type ApprovalEvaluation = {
+  accepted: boolean
+  finding: DangerousFinding
+  outcome: "FAILED" | "PASS"
+}
+
+type ApprovalsModule = {
+  evaluateDangerousApproval: (input: {
+    approval?: Approval
+    candidateEvidence: CandidateEvidence
+    finding: DangerousFinding
+    finalCommit: string
+    now: string
+  }) => ApprovalEvaluation
+}
+
+const FINDING: DangerousFinding = {
+  classification: "DANGEROUS",
+  fingerprint: "dangerous-fingerprint",
+  migrationSha256: "1".repeat(64),
+  ruleId: "sql.dangerous-statement",
+}
+
+const CANDIDATE_EVIDENCE: CandidateEvidence = {
+  candidateCommit: "a".repeat(40),
+  findingFingerprint: FINDING.fingerprint,
+  migrationSha256: FINDING.migrationSha256,
+  reportDigest: "candidate-report-digest",
+}
+
+function approval(overrides: Partial<Approval> = {}): Approval {
+  return {
+    approvalCommit: "b".repeat(40),
+    candidateCommit: CANDIDATE_EVIDENCE.candidateCommit,
+    findingFingerprint: FINDING.fingerprint,
+    id: "approval-1",
+    migrationSha256: FINDING.migrationSha256,
+    reviewEvidence: "PR #936 reviewed by maintainer",
+    ruleId: FINDING.ruleId,
+    status: "active",
+    ...overrides,
+  }
+}
+
+describe("database quality gate DANGEROUS approval contract", () => {
+  it("fails a DANGEROUS finding with no approval record", async () => {
+    const approvals = await loadDatabaseQualityGateModule<ApprovalsModule>("approvals")
+
+    const result = approvals.evaluateDangerousApproval({
+      candidateEvidence: CANDIDATE_EVIDENCE,
+      finding: FINDING,
+      finalCommit: "b".repeat(40),
+      now: "2026-08-16T09:29:20Z",
+    })
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.accepted).toBe(false)
+  })
+
+  it("accepts only candidate evidence bound to the approval-bearing commit and retains DANGEROUS classification", async () => {
+    const approvals = await loadDatabaseQualityGateModule<ApprovalsModule>("approvals")
+
+    const result = approvals.evaluateDangerousApproval({
+      approval: approval(),
+      candidateEvidence: CANDIDATE_EVIDENCE,
+      finding: FINDING,
+      finalCommit: "b".repeat(40),
+      now: "2026-08-16T09:29:20Z",
+    })
+
+    expect(result.outcome).toBe("PASS")
+    expect(result.accepted).toBe(true)
+    expect(result.finding.classification).toBe("DANGEROUS")
+  })
+
+  it("invalidates approval evidence when migration content or approval-bearing commit changes", async () => {
+    const approvals = await loadDatabaseQualityGateModule<ApprovalsModule>("approvals")
+    const changedFinding: DangerousFinding = {
+      ...FINDING,
+      migrationSha256: "2".repeat(64),
+    }
+
+    const contentChanged = approvals.evaluateDangerousApproval({
+      approval: approval(),
+      candidateEvidence: CANDIDATE_EVIDENCE,
+      finding: changedFinding,
+      finalCommit: "b".repeat(40),
+      now: "2026-08-16T09:29:20Z",
+    })
+    const approvalCommitChanged = approvals.evaluateDangerousApproval({
+      approval: approval(),
+      candidateEvidence: CANDIDATE_EVIDENCE,
+      finding: FINDING,
+      finalCommit: "c".repeat(40),
+      now: "2026-08-16T09:29:20Z",
+    })
+
+    expect(contentChanged).toMatchObject({ accepted: false, outcome: "FAILED" })
+    expect(approvalCommitChanged).toMatchObject({ accepted: false, outcome: "FAILED" })
+  })
+
+  it("rejects expired, revoked, and unreviewed approvals", async () => {
+    const approvals = await loadDatabaseQualityGateModule<ApprovalsModule>("approvals")
+    const invalidApprovals = [
+      approval({ expiresAt: "2026-08-16T09:29:19Z" }),
+      approval({ revokedAt: "2026-08-16T09:00:00Z", status: "revoked" }),
+      approval({ reviewEvidence: undefined }),
+    ]
+
+    for (const invalidApproval of invalidApprovals) {
+      const result = approvals.evaluateDangerousApproval({
+        approval: invalidApproval,
+        candidateEvidence: CANDIDATE_EVIDENCE,
+        finding: FINDING,
+        finalCommit: "b".repeat(40),
+        now: "2026-08-16T09:29:20Z",
+      })
+
+      expect(result).toMatchObject({ accepted: false, outcome: "FAILED" })
+    }
+  })
+})

--- a/scripts/__tests__/database-quality-gate-baseline.test.ts
+++ b/scripts/__tests__/database-quality-gate-baseline.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type FindingIdentity = {
+  classification: "BLOCKING" | "DANGEROUS" | "WARNING"
+  fingerprint: string
+  ruleId: string
+}
+
+type BaselineComparison = {
+  newFindings: FindingIdentity[]
+  outcome: "FAILED" | "PASS"
+  resolvedBaselineFindings: FindingIdentity[]
+}
+
+type BaselineModule = {
+  compareFindingBaseline: (input: {
+    baseline: FindingIdentity[]
+    current: FindingIdentity[]
+  }) => BaselineComparison
+}
+
+const LEGACY_FINDING: FindingIdentity = {
+  classification: "BLOCKING",
+  fingerprint: "legacy-fingerprint",
+  ruleId: "migration.legacy-content",
+}
+
+const NEW_FINDING: FindingIdentity = {
+  classification: "BLOCKING",
+  fingerprint: "new-fingerprint",
+  ruleId: "migration.legacy-content",
+}
+
+describe("database quality gate identity-based baseline comparison", () => {
+  it("accepts unchanged historical baseline debt by stable finding identity", async () => {
+    const baseline = await loadDatabaseQualityGateModule<BaselineModule>("baseline")
+
+    const result = baseline.compareFindingBaseline({
+      baseline: [LEGACY_FINDING],
+      current: [LEGACY_FINDING],
+    })
+
+    expect(result.outcome).toBe("PASS")
+    expect(result.newFindings).toEqual([])
+    expect(result.resolvedBaselineFindings).toEqual([])
+  })
+
+  it("fails when a new finding replaces a resolved one even if counts are unchanged", async () => {
+    const baseline = await loadDatabaseQualityGateModule<BaselineModule>("baseline")
+
+    const result = baseline.compareFindingBaseline({
+      baseline: [LEGACY_FINDING],
+      current: [NEW_FINDING],
+    })
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.newFindings).toEqual([NEW_FINDING])
+    expect(result.resolvedBaselineFindings).toEqual([LEGACY_FINDING])
+  })
+
+  it("fails when an additional finding appears beside unchanged baseline debt", async () => {
+    const baseline = await loadDatabaseQualityGateModule<BaselineModule>("baseline")
+
+    const result = baseline.compareFindingBaseline({
+      baseline: [LEGACY_FINDING],
+      current: [LEGACY_FINDING, NEW_FINDING],
+    })
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.newFindings).toEqual([NEW_FINDING])
+  })
+})

--- a/scripts/__tests__/database-quality-gate-contract.test.ts
+++ b/scripts/__tests__/database-quality-gate-contract.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type FindingClassification = "WARNING" | "DANGEROUS" | "BLOCKING"
+type GateOutcome = "PASS" | "FAILED" | "INCOMPLETE"
+
+type Finding = {
+  approval?: {
+    acceptedForAggregate: boolean
+    id: string
+  }
+  classification: FindingClassification
+  fingerprint: string
+  ruleId: string
+}
+
+type GateReport = {
+  baselineMigrationHighWater: string
+  createdAt: string
+  digest: string
+  executorEnvironment: Record<string, string>
+  findings: Finding[]
+  inputHashes: Record<string, string>
+  lane: "static"
+  migrationIdentities: Array<{ path: string; sha256: string }>
+  outcome: GateOutcome
+  runId: string
+  schemaVersion: 1
+  subjectCommit: string
+}
+
+type ContractModule = {
+  aggregateOutcome: (input: {
+    evidenceAvailable: boolean
+    findings: Finding[]
+    requiredChecksComplete: boolean
+  }) => GateOutcome
+  outcomeExitCode: (outcome: GateOutcome) => 0 | 1 | 2
+  renderMarkdownReport: (report: GateReport) => string
+  serializeReport: (report: GateReport) => string
+}
+
+const WARNING_FINDING: Finding = {
+  classification: "WARNING",
+  fingerprint: "warning-fingerprint",
+  ruleId: "test.warning",
+}
+
+const DANGEROUS_FINDING: Finding = {
+  classification: "DANGEROUS",
+  fingerprint: "dangerous-fingerprint",
+  ruleId: "test.dangerous",
+}
+
+const APPROVED_DANGEROUS_FINDING: Finding = {
+  ...DANGEROUS_FINDING,
+  approval: {
+    acceptedForAggregate: true,
+    id: "approval-1",
+  },
+}
+
+const BLOCKING_FINDING: Finding = {
+  classification: "BLOCKING",
+  fingerprint: "blocking-fingerprint",
+  ruleId: "test.blocking",
+}
+
+function createReport(findings: Finding[], outcome: GateOutcome): GateReport {
+  return {
+    baselineMigrationHighWater: "20260816044031",
+    createdAt: "2026-08-16T09:29:20Z",
+    digest: "report-digest",
+    executorEnvironment: {
+      postgres: "17.6",
+      supabase: "v1.26.08",
+    },
+    findings,
+    inputHashes: {
+      appliedLock: "lock-hash",
+      invariants: "invariants-hash",
+      sqlTests: "tests-hash",
+      waivers: "waivers-hash",
+    },
+    lane: "static",
+    migrationIdentities: [
+      {
+        path: "supabase/migrations/20270101000000_add_contract.sql",
+        sha256: "migration-hash",
+      },
+    ],
+    outcome,
+    runId: "run-123",
+    schemaVersion: 1,
+    subjectCommit: "a".repeat(40),
+  }
+}
+
+describe("database quality gate result contract", () => {
+  it("returns PASS and exit code 0 only after complete checks with no unresolved dangerous finding", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+
+    const outcome = contract.aggregateOutcome({
+      evidenceAvailable: true,
+      findings: [WARNING_FINDING],
+      requiredChecksComplete: true,
+    })
+
+    expect(outcome).toBe("PASS")
+    expect(contract.outcomeExitCode(outcome)).toBe(0)
+  })
+
+  it("returns FAILED and exit code 1 for an unresolved BLOCKING finding", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+
+    const outcome = contract.aggregateOutcome({
+      evidenceAvailable: true,
+      findings: [BLOCKING_FINDING],
+      requiredChecksComplete: true,
+    })
+
+    expect(outcome).toBe("FAILED")
+    expect(contract.outcomeExitCode(outcome)).toBe(1)
+  })
+
+  it("returns FAILED and exit code 1 for an unresolved DANGEROUS finding", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+
+    const outcome = contract.aggregateOutcome({
+      evidenceAvailable: true,
+      findings: [DANGEROUS_FINDING],
+      requiredChecksComplete: true,
+    })
+
+    expect(outcome).toBe("FAILED")
+    expect(contract.outcomeExitCode(outcome)).toBe(1)
+  })
+
+  it("accepts an approved DANGEROUS finding for aggregate PASS without changing its classification", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+
+    const outcome = contract.aggregateOutcome({
+      evidenceAvailable: true,
+      findings: [APPROVED_DANGEROUS_FINDING],
+      requiredChecksComplete: true,
+    })
+
+    expect(APPROVED_DANGEROUS_FINDING.classification).toBe("DANGEROUS")
+    expect(outcome).toBe("PASS")
+    expect(contract.outcomeExitCode(outcome)).toBe(0)
+  })
+
+  it("returns INCOMPLETE and exit code 2 when required evidence is unavailable", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+
+    const outcome = contract.aggregateOutcome({
+      evidenceAvailable: false,
+      findings: [],
+      requiredChecksComplete: false,
+    })
+
+    expect(outcome).toBe("INCOMPLETE")
+    expect(contract.outcomeExitCode(outcome)).toBe(2)
+  })
+
+  it("serializes equivalent reports deterministically and renders Markdown from the JSON report", async () => {
+    const contract = await loadDatabaseQualityGateModule<ContractModule>("contract")
+    const report = createReport([WARNING_FINDING, BLOCKING_FINDING], "FAILED")
+    const reorderedEquivalentReport: GateReport = {
+      ...report,
+      findings: [BLOCKING_FINDING, WARNING_FINDING],
+      inputHashes: {
+        waivers: "waivers-hash",
+        sqlTests: "tests-hash",
+        invariants: "invariants-hash",
+        appliedLock: "lock-hash",
+      },
+    }
+
+    const serializedReport = contract.serializeReport(report)
+    const parsedReport = JSON.parse(serializedReport) as GateReport
+    const markdown = contract.renderMarkdownReport(parsedReport)
+
+    expect(contract.serializeReport(reorderedEquivalentReport)).toBe(serializedReport)
+    expect(parsedReport).toEqual(report)
+    expect(markdown).toContain("run-123")
+    expect(markdown).toContain("FAILED")
+    expect(markdown).toContain("test.warning")
+    expect(markdown).toContain("test.blocking")
+    expect(markdown).toContain("report-digest")
+  })
+})

--- a/scripts/__tests__/database-quality-gate-hash.test.ts
+++ b/scripts/__tests__/database-quality-gate-hash.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canonicalTerminalNewline,
+  loadDatabaseQualityGateModule,
+  sha256,
+} from "./database-quality-gate-test-support"
+
+type MigrationSourceModule = {
+  canonicalizeMigrationContent: (content: string) => string
+  migrationContentSha256: (content: string) => string
+}
+
+describe("database quality gate migration content hashing", () => {
+  it("removes exactly one optional terminal newline before hashing", async () => {
+    const source = await loadDatabaseQualityGateModule<MigrationSourceModule>("migration-source")
+    const withoutTerminalNewline = "SELECT 1;"
+    const withTerminalNewline = `${withoutTerminalNewline}\n`
+
+    expect(source.canonicalizeMigrationContent(withoutTerminalNewline)).toBe(
+      canonicalTerminalNewline(withoutTerminalNewline)
+    )
+    expect(source.canonicalizeMigrationContent(withTerminalNewline)).toBe(
+      canonicalTerminalNewline(withTerminalNewline)
+    )
+    expect(source.migrationContentSha256(withoutTerminalNewline)).toBe(
+      sha256(canonicalTerminalNewline(withoutTerminalNewline))
+    )
+    expect(source.migrationContentSha256(withTerminalNewline)).toBe(
+      source.migrationContentSha256(withoutTerminalNewline)
+    )
+  })
+
+  it("preserves every byte beyond one terminal newline", async () => {
+    const source = await loadDatabaseQualityGateModule<MigrationSourceModule>("migration-source")
+    const canonical = "SELECT 1;"
+    const twoTerminalNewlines = `${canonical}\n\n`
+    const windowsTerminalNewline = `${canonical}\r\n`
+
+    expect(source.canonicalizeMigrationContent(twoTerminalNewlines)).toBe(`${canonical}\n`)
+    expect(source.migrationContentSha256(twoTerminalNewlines)).not.toBe(
+      source.migrationContentSha256(canonical)
+    )
+    expect(source.migrationContentSha256(windowsTerminalNewline)).not.toBe(
+      source.migrationContentSha256(`${canonical}\n`)
+    )
+  })
+
+  it("changes the SHA-256 digest when SQL content changes", async () => {
+    const source = await loadDatabaseQualityGateModule<MigrationSourceModule>("migration-source")
+    const first = "CREATE TABLE public.example (id bigint PRIMARY KEY);"
+    const second = "CREATE TABLE public.example (id bigint PRIMARY KEY, name text);"
+
+    expect(source.migrationContentSha256(first)).toMatch(/^[a-f0-9]{64}$/)
+    expect(source.migrationContentSha256(first)).not.toBe(source.migrationContentSha256(second))
+  })
+})

--- a/scripts/__tests__/database-quality-gate-migration-repository.test.ts
+++ b/scripts/__tests__/database-quality-gate-migration-repository.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  cleanupFixtureRepositories,
+  createFixtureRepository,
+  fixtureJson,
+  loadDatabaseQualityGateModule,
+  sha256,
+} from "./database-quality-gate-test-support"
+
+type RepositoryFinding = {
+  classification: "BLOCKING" | "INCOMPLETE"
+  ruleId: string
+}
+
+type RepositoryInspection = {
+  findings: RepositoryFinding[]
+  outcome: "FAILED" | "INCOMPLETE" | "PASS"
+}
+
+type MigrationRepositoryModule = {
+  inspectMigrationRepository: (input: {
+    previousAppliedLock?: unknown
+    repositoryRoot: string
+  }) => RepositoryInspection
+}
+
+const LEGACY_PATH = "supabase/migrations/20241220_add_completion_tracking.sql"
+const LEGACY_SQL = "CREATE TABLE public.completion_tracking (id bigint PRIMARY KEY);\n"
+const PENDING_PATH = "supabase/migrations/20270101000000_add_pending_contract.sql"
+
+function appliedLock(legacyEntries: Array<{ path: string; sha256: string }> = []) {
+  return {
+    applied: [],
+    cutover: {
+      commit: "a".repeat(40),
+      migrationRoot: "supabase/migrations",
+    },
+    legacy: legacyEntries,
+    schemaVersion: 1,
+  }
+}
+
+function repositoryWithLock(
+  files: Record<string, string>,
+  lock = appliedLock([
+    {
+      path: LEGACY_PATH,
+      sha256: sha256(LEGACY_SQL),
+    },
+  ])
+) {
+  return createFixtureRepository({
+    "supabase/applied-migrations.lock.json": fixtureJson(lock),
+    ...files,
+  })
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("database quality gate migration repository inspection", () => {
+  it("blocks a legacy migration whose canonical content changed", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<MigrationRepositoryModule>("migration-repository")
+    const repository = repositoryWithLock({
+      [LEGACY_PATH]:
+        "CREATE TABLE public.completion_tracking (id bigint PRIMARY KEY, note text);\n",
+    })
+
+    const result = source.inspectMigrationRepository({ repositoryRoot: repository.root })
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "migration.legacy-content",
+      })
+    )
+  })
+
+  it("blocks a renamed or deleted legacy migration path", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<MigrationRepositoryModule>("migration-repository")
+    const renamedRepository = repositoryWithLock({
+      "supabase/migrations/20241220_completion_tracking_renamed.sql": LEGACY_SQL,
+    })
+    const deletedRepository = repositoryWithLock({})
+
+    const renamedResult = source.inspectMigrationRepository({
+      repositoryRoot: renamedRepository.root,
+    })
+    const deletedResult = source.inspectMigrationRepository({
+      repositoryRoot: deletedRepository.root,
+    })
+
+    expect(renamedResult.outcome).toBe("FAILED")
+    expect(deletedResult.outcome).toBe("FAILED")
+    expect(renamedResult.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "migration.legacy-path",
+      })
+    )
+    expect(deletedResult.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "migration.legacy-path",
+      })
+    )
+  })
+
+  it("blocks a lock history mutation even when the migration file is unchanged", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<MigrationRepositoryModule>("migration-repository")
+    const previousLock = appliedLock([
+      {
+        path: LEGACY_PATH,
+        sha256: sha256(LEGACY_SQL),
+      },
+    ])
+    const currentLock = appliedLock([])
+    const repository = repositoryWithLock(
+      {
+        [LEGACY_PATH]: LEGACY_SQL,
+      },
+      currentLock
+    )
+
+    const result = source.inspectMigrationRepository({
+      previousAppliedLock: previousLock,
+      repositoryRoot: repository.root,
+    })
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "migration.lock-history",
+      })
+    )
+  })
+
+  it("keeps a post-cutover migration absent from the lock editable before live apply", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<MigrationRepositoryModule>("migration-repository")
+    const repository = repositoryWithLock(
+      {
+        [PENDING_PATH]: "CREATE TABLE public.pending_contract (id bigint PRIMARY KEY);\n",
+      },
+      appliedLock()
+    )
+
+    const result = source.inspectMigrationRepository({ repositoryRoot: repository.root })
+
+    expect(result.outcome).toBe("PASS")
+    expect(result.findings).toEqual([])
+  })
+
+  it("returns INCOMPLETE instead of guessing an ambiguous root migration order", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<MigrationRepositoryModule>("migration-repository")
+    const repository = repositoryWithLock(
+      {
+        "supabase/migrations/20270101000000_first.sql": "SELECT 1;\n",
+        "supabase/migrations/20270101000000_second.sql": "SELECT 2;\n",
+      },
+      appliedLock()
+    )
+
+    const result = source.inspectMigrationRepository({ repositoryRoot: repository.root })
+
+    expect(result.outcome).toBe("INCOMPLETE")
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "INCOMPLETE",
+        ruleId: "migration.source-order",
+      })
+    )
+  })
+})

--- a/scripts/__tests__/database-quality-gate-registry.test.ts
+++ b/scripts/__tests__/database-quality-gate-registry.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type ValidationFinding = {
+  classification: "BLOCKING" | "INCOMPLETE"
+  ruleId: string
+}
+
+type RegistryValidation = {
+  findings: ValidationFinding[]
+  valid: boolean
+}
+
+type RegistryModule = {
+  validateRegistrySet: (input: {
+    appliedLock: unknown
+    invariants: unknown
+    previousAppliedLock?: unknown
+    sqlTests: unknown
+    waivers: unknown
+  }) => RegistryValidation
+}
+
+function validRegistries() {
+  return {
+    appliedLock: {
+      applied: [],
+      cutover: {
+        commit: "a".repeat(40),
+        migrationRoot: "supabase/migrations",
+      },
+      legacy: [
+        {
+          path: "supabase/migrations/20241220_add_completion_tracking.sql",
+          sha256: "1".repeat(64),
+        },
+      ],
+      schemaVersion: 1,
+    },
+    invariants: {
+      schemaVersion: 1,
+      tables: [
+        {
+          allowedOperations: ["SELECT"],
+          classification: "rpc-only",
+          enforcement: "guarded RPC",
+          evidence: "Wayfinder #935",
+          owner: "postgres",
+          table: "public.nhan_vien",
+        },
+      ],
+    },
+    sqlTests: {
+      schemaVersion: 1,
+      tests: [
+        {
+          evidence: "existing smoke test",
+          fixture: "none",
+          path: "supabase/tests/equipment_list_enhanced_active_repair_smoke.sql",
+          purpose: "equipment list regression",
+          runner: "psql",
+          safety: "default-safe",
+          timeoutMs: 30000,
+          transaction: "rollback-required",
+        },
+      ],
+    },
+    waivers: {
+      approvals: [] as Array<Record<string, unknown>>,
+      schemaVersion: 1,
+    },
+  }
+}
+
+describe("database quality gate registry schemas", () => {
+  it("accepts a complete applied-lock, waiver, invariant, and SQL-test registry set", async () => {
+    const registry = await loadDatabaseQualityGateModule<RegistryModule>("registries")
+    const input = validRegistries()
+
+    expect(registry.validateRegistrySet(input)).toEqual({
+      findings: [],
+      valid: true,
+    })
+  })
+
+  it("rejects an applied lock that rewrites protected lock history", async () => {
+    const registry = await loadDatabaseQualityGateModule<RegistryModule>("registries")
+    const previous = validRegistries()
+    const current = validRegistries()
+    current.appliedLock.legacy[0].sha256 = "2".repeat(64)
+
+    const result = registry.validateRegistrySet({
+      ...current,
+      previousAppliedLock: previous.appliedLock,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "registry.applied-lock.append-only",
+      })
+    )
+  })
+
+  it("rejects a waiver that is not bound to reviewed candidate evidence", async () => {
+    const registry = await loadDatabaseQualityGateModule<RegistryModule>("registries")
+    const input = validRegistries()
+    input.waivers.approvals.push({
+      approvalCommit: "b".repeat(40),
+      candidateCommit: "a".repeat(40),
+      id: "approval-1",
+      ruleId: "sql.dangerous",
+      status: "active",
+    })
+
+    const result = registry.validateRegistrySet(input)
+
+    expect(result.valid).toBe(false)
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "registry.waivers.schema",
+      })
+    )
+  })
+
+  it("rejects unknown table intent and incomplete SQL-test execution metadata", async () => {
+    const registry = await loadDatabaseQualityGateModule<RegistryModule>("registries")
+    const input = validRegistries()
+    input.invariants.tables[0].classification = "unclassified"
+    input.sqlTests.tests[0].transaction = ""
+
+    const result = registry.validateRegistrySet(input)
+
+    expect(result.valid).toBe(false)
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          classification: "INCOMPLETE",
+          ruleId: "registry.invariants.table-intent",
+        }),
+        expect.objectContaining({
+          classification: "BLOCKING",
+          ruleId: "registry.sql-tests.schema",
+        }),
+      ])
+    )
+  })
+})

--- a/scripts/__tests__/database-quality-gate-test-support.ts
+++ b/scripts/__tests__/database-quality-gate-test-support.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const temporaryRepositories: string[] = []
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url))
+const REPOSITORY_ROOT = path.resolve(TEST_DIRECTORY, "../..")
+
+export const DATABASE_QUALITY_GATE_MODULE_ROOT = path.join(
+  REPOSITORY_ROOT,
+  "scripts",
+  "db-quality-gate"
+)
+
+export type FixtureRepository = {
+  root: string
+  path: (...segments: string[]) => string
+}
+
+export function canonicalTerminalNewline(content: string) {
+  return content.endsWith("\n") ? content.slice(0, -1) : content
+}
+
+export function sha256(content: string) {
+  return createHash("sha256").update(content).digest("hex")
+}
+
+export function createFixtureRepository(files: Record<string, string>): FixtureRepository {
+  const root = mkdtempSync(path.join(tmpdir(), "database-quality-gate-"))
+  temporaryRepositories.push(root)
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.resolve(root, relativePath)
+    const fixtureRoot = `${root}${path.sep}`
+
+    if (!filePath.startsWith(fixtureRoot)) {
+      throw new Error(`Fixture path escapes temporary repository: ${relativePath}`)
+    }
+
+    mkdirSync(path.dirname(filePath), { recursive: true })
+    writeFileSync(filePath, content)
+  }
+
+  return {
+    root,
+    path: (...segments) => path.join(root, ...segments),
+  }
+}
+
+export function fixtureJson(value: unknown) {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+export function cleanupFixtureRepositories() {
+  for (const repository of temporaryRepositories.splice(0)) {
+    rmSync(repository, { force: true, recursive: true })
+  }
+}
+
+export function loadDatabaseQualityGateModule<T>(moduleName: string): Promise<T> {
+  const modulePath = pathToFileURL(
+    path.join(DATABASE_QUALITY_GATE_MODULE_ROOT, `${moduleName}.ts`)
+  ).href
+  return import(modulePath) as Promise<T>
+}


### PR DESCRIPTION
## Summary
- characterize current migration, live/baseline, SQL-test, Oracle, ruleset, and #938 lifecycle state
- add the Phase 0 RED contract suites and fixture support without gate implementation
- record the expected 6-suite / 25-test RED state

## Verification
- `format:check`, `verify:no-explicit-any`, `verify:dedupe`, and `typecheck` pass
- focused Phase 0 Vitest is intentionally RED: 6 failed files / 25 failed tests, all due to absent `scripts/db-quality-gate/*.ts` modules
- `react-doctor` reports no changed source files

## Boundaries
No migration, live Supabase, Oracle mutation, GitHub ruleset change, CI, or gate runner implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Establishes the Phase 0 RED contract for the database quality gate and records repository/runtime characterization. No gate implementation ships and production behavior is unchanged; we move from no gate tests to six intentional RED suites defining the required contracts.

**Review notes**
- Adds `openspec/changes/add-database-quality-gate/phase-0-characterization.md` documenting migration inventory, live/baseline high-water, SQL test inventory, and ruleset facts.
- Introduces six failing Vitest suites that define runner-neutral contracts for:
  - Aggregate outcomes/exit codes and deterministic JSON/Markdown reports.
  - Migration content hashing with single-terminal-newline canonicalization.
  - Registry schemas (applied lock, waivers, invariants, SQL-test metadata).
  - Repository inspection (legacy content/path, lock history, pending editability, ambiguous ordering).
  - Identity-based baseline comparison.
  - DANGEROUS approval evaluation.
- Expected state: 6 files / 25 tests fail with `ERR_MODULE_NOT_FOUND` for `scripts/db-quality-gate/{contract,migration-source,registries,migration-repository,baseline,approvals}.ts`.
- No changes to migration SQL, live Supabase, Oracle, CI, or GitHub rulesets. `format:check`, `verify:*`, and `typecheck` pass; `react-doctor` reports no changed source files.

<sup>Written for commit d88f74acaed4863a4b7cab7dc07b1785bd1e54da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

