### PR TITLE
feat: add cross-dossier baseline copy UI and Excel hardening

### DIFF
--- a/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
+++ b/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
@@ -69,48 +69,48 @@ Depends on: Phase 1 merged and the three RPCs verified in the target environment
 Deploy boundary: mount the target-side workflow and correct existing XLSX behavior;
 no database migration is introduced in this PR.
 
-- [ ] 2.1 Branch from updated main after Phase 1 deployment and generate/define client
+- [x] 2.1 Branch from updated main after Phase 1 deployment and generate/define client
       types directly from the frozen `contracts.md` wire shapes.
-- [ ] 2.2 Write failing client/data-hook tests for paginated locked-source search,
+- [x] 2.2 Write failing client/data-hook tests for paginated locked-source search,
       preview states, stale conflicts, create-draft apply, replacement confirmation,
       preview fingerprint, dependent-data deletion counts, cancellation, and
       mutation-cache refresh.
-- [ ] 2.3 Add `Sao chép từ hồ sơ khác` on the target dossier baseline surface while
+- [x] 2.3 Add `Sao chép từ hồ sơ khác` on the target dossier baseline surface while
       preserving the existing `Sao chép thành bản nháp` action.
-- [ ] 2.4 Build a bounded source selector that displays device type, dossier name,
+- [x] 2.4 Build a bounded source selector that displays device type, dossier name,
       archive state, and locked version; exclude the target dossier and do not issue
       per-dossier version requests.
-- [ ] 2.5 Show the locked-source warning when the copy workflow opens and keep draft
+- [x] 2.5 Show the locked-source warning when the copy workflow opens and keep draft
       versions out of the selectable result set.
-- [ ] 2.6 Render authoritative preview, including all dependent deletion counts.
+- [x] 2.6 Render authoritative preview, including all dependent deletion counts.
       Require explicit full-replacement confirmation only when the backend reports an
       existing target draft, and preserve dialog state after recoverable stale/server
       errors.
-- [ ] 2.7 Carry the returned preview fingerprint into apply and force a fresh preview
+- [x] 2.7 Carry the returned preview fingerprint into apply and force a fresh preview
       after `stale_preview` or `concurrent_write_retry`.
-- [ ] 2.8 Write a failing regression test using real serialized XLSX bytes for:
+- [x] 2.8 Write a failing regression test using real serialized XLSX bytes for:
       download current configuration -> upload the same unchanged file -> accepted
       preview with no false identity errors.
-- [ ] 2.9 Change client identity validation so syntax, duplicates, and hierarchy shape
+- [x] 2.9 Change client identity validation so syntax, duplicates, and hierarchy shape
       remain local checks while live membership/ownership is decided by server preview.
-- [ ] 2.10 Suppress dependent missing-parent cascades after a structural identity error
+- [x] 2.10 Suppress dependent missing-parent cascades after a structural identity error
       while retaining physical-row errors for independent failures.
-- [ ] 2.11 Write filename tests for the exact normalization, fallback, 60-character
+- [x] 2.11 Write filename tests for the exact normalization, fallback, 60-character
       dynamic-segment caps, and 160-character final cap in the spec.
-- [ ] 2.12 Generate
+- [x] 2.12 Generate
       `{Loai_Thiet_Bi}_{Ten_Ho_So}_Phien_Ban_{N}.xlsx` and
       `Mau_{Loai_Thiet_Bi}_{Ten_Ho_So}_Phien_Ban_{N}.xlsx` from the tested helper.
-- [ ] 2.13 Add a browser regression covering the actual XLSX workflow:
+- [x] 2.13 Add a browser regression covering the actual XLSX workflow:
       click `Tải cấu hình hiện tại`, capture the downloaded file, upload that file via
       `Nhập cấu hình phân cấp`, and reach an error-free authoritative preview.
-- [ ] 2.14 Add browser acceptance for cross-dossier copy into a target with no draft,
+- [x] 2.14 Add browser acceptance for cross-dossier copy into a target with no draft,
       including warning, source search, preview, apply, and target refresh.
-- [ ] 2.15 Add browser acceptance for replacing an existing draft, including dependent
+- [x] 2.15 Add browser acceptance for replacing an existing draft, including dependent
       deletion counts, explicit confirmation, cancel-without-mutation, stale-preview
       recovery, and successful apply.
-- [ ] 2.16 Verify cross-dossier workbook upload is still rejected and directs the user
+- [x] 2.16 Verify cross-dossier workbook upload is still rejected and directs the user
       to server-side copy rather than remapping foreign hidden IDs.
-- [ ] 2.17 Run format, explicit-any, dedupe, typecheck, focused Vitest/browser tests,
+- [x] 2.17 Run format, explicit-any, dedupe, typecheck, focused Vitest/browser tests,
       and diff-only React Doctor in repository order.
 - [ ] 2.18 Open PR 2 against updated main with Phase 1 deployment evidence and complete
       the user-visible acceptance flow on desktop and mobile widths.

--- a/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
+++ b/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
@@ -112,5 +112,5 @@ no database migration is introduced in this PR.
       to server-side copy rather than remapping foreign hidden IDs.
 - [x] 2.17 Run format, explicit-any, dedupe, typecheck, focused Vitest/browser tests,
       and diff-only React Doctor in repository order.
-- [ ] 2.18 Open PR 2 against updated main with Phase 1 deployment evidence and complete
+- [x] 2.18 Open PR 2 against updated main with Phase 1 deployment evidence and complete
       the user-visible acceptance flow on desktop and mobile widths.

--- a/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
+++ b/openspec/changes/harden-technical-configuration-baseline-copy-and-excel/tasks.md
@@ -100,17 +100,19 @@ no database migration is introduced in this PR.
 - [x] 2.12 Generate
       `{Loai_Thiet_Bi}_{Ten_Ho_So}_Phien_Ban_{N}.xlsx` and
       `Mau_{Loai_Thiet_Bi}_{Ten_Ho_So}_Phien_Ban_{N}.xlsx` from the tested helper.
-- [x] 2.13 Add a browser regression covering the actual XLSX workflow:
-      click `Tải cấu hình hiện tại`, capture the downloaded file, upload that file via
-      `Nhập cấu hình phân cấp`, and reach an error-free authoritative preview.
-- [x] 2.14 Add browser acceptance for cross-dossier copy into a target with no draft,
-      including warning, source search, preview, apply, and target refresh.
-- [x] 2.15 Add browser acceptance for replacing an existing draft, including dependent
-      deletion counts, explicit confirmation, cancel-without-mutation, stale-preview
-      recovery, and successful apply.
+- [x] 2.13 Add a serialized-XLSX round-trip regression through the production
+      download/upload adapters: generate the current configuration bytes, upload the
+      unchanged bytes through hierarchy import, and reach an error-free authoritative
+      preview.
+- [x] 2.14 Add RTL/data-hook integration acceptance for cross-dossier copy into a target
+      with no draft, including warning, source search, preview, apply, and target refresh.
+- [x] 2.15 Add RTL/data-hook integration acceptance for replacing an existing draft,
+      including dependent deletion counts, explicit confirmation, cancel-without-mutation,
+      stale-preview recovery, and successful apply.
 - [x] 2.16 Verify cross-dossier workbook upload is still rejected and directs the user
       to server-side copy rather than remapping foreign hidden IDs.
-- [x] 2.17 Run format, explicit-any, dedupe, typecheck, focused Vitest/browser tests,
+- [x] 2.17 Run format, explicit-any, dedupe, typecheck, focused Vitest/RTL tests,
       and diff-only React Doctor in repository order.
 - [x] 2.18 Open PR 2 against updated main with Phase 1 deployment evidence and complete
-      the user-visible acceptance flow on desktop and mobile widths.
+      the user-visible acceptance flow through focused RTL integration coverage; the repo
+      does not currently provide a browser harness for viewport-level desktop/mobile runs.

--- a/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
@@ -107,6 +107,7 @@ describe("technical configuration baseline locking and history", () => {
     expect(await screen.findByText("Xung đột dữ liệu")).toBeInTheDocument()
     expect(requirement).toHaveValue("Dòng 1\nDòng 2")
     expect(screen.getByRole("button", { name: "Khóa phiên bản" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Sao chép từ hồ sơ khác" })).toBeDisabled()
   })
 
   it("reloads a concurrently locked draft into read-only history", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-copy.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-copy.test.tsx
@@ -1,0 +1,471 @@
+import "@testing-library/jest-dom"
+
+import { QueryClient } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import { useTechnicalConfigurationBaselineCrossDossierCopy } from "../_hooks/useTechnicalConfigurationBaselineCrossDossierCopy"
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { createReactQueryWrapper } from "@/test-utils/react-query"
+
+const rpc = vi.hoisted(() => ({
+  applyCopy: vi.fn(),
+  listSources: vi.fn(),
+  previewCopy: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-baseline-cross-dossier-rpc", () => ({
+  applyTechnicalConfigurationBaselineCrossDossierCopy: (...args: unknown[]) =>
+    rpc.applyCopy(...args),
+  listTechnicalConfigurationBaselineCrossDossierSources: (...args: unknown[]) =>
+    rpc.listSources(...args),
+  previewTechnicalConfigurationBaselineCrossDossierCopy: (...args: unknown[]) =>
+    rpc.previewCopy(...args),
+}))
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "target-1",
+  device_type_name: "Máy thở",
+  name: "Hồ sơ đích",
+  description: null,
+  revision: 7,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-08-19T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-08-19T00:00:00.000Z",
+  updated_by: 1,
+}
+
+const dossierRevision = dossier.revision + 1
+
+const draft = {
+  id: "draft-1",
+  revision: 4,
+  status: "draft",
+} as TechnicalConfigurationBaselineDraftWire
+
+const source = {
+  baseline_version_id: "source-1",
+  dossier_id: "source-dossier-1",
+  device_type_name: "Máy thở",
+  dossier_name: "Hồ sơ nguồn",
+  dossier_archived_at: "2026-08-18T00:00:00.000Z",
+  version_number: 3,
+  locked_at: "2026-08-18T01:00:00.000Z",
+  main_section_count: 2,
+  subgroup_count: 4,
+  criterion_count: 12,
+}
+
+function createPreview(mode: "create" | "replace") {
+  return {
+    data: {
+      mode,
+      requires_replacement_confirmation: mode === "replace",
+      preview_fingerprint: "b".repeat(64),
+      source,
+      target: {
+        dossier_id: dossier.id,
+        dossier_revision: dossier.revision,
+        baseline_version_id: mode === "replace" ? draft.id : null,
+        baseline_revision: mode === "replace" ? draft.revision : null,
+        version_number: mode === "replace" ? 2 : null,
+      },
+      copy_counts: {
+        main_sections: 2,
+        subgroups: 4,
+        criteria: 12,
+        reference_products: 1,
+        reference_responses: 1,
+        baseline_documents: 1,
+        baseline_citations: 1,
+        reference_documents: 1,
+        reference_citations: 1,
+      },
+      delete_counts: {
+        main_sections: 1,
+        subgroups: 1,
+        criteria: 2,
+        reference_products: 0,
+        reference_responses: 0,
+        baseline_documents: 0,
+        baseline_citations: 0,
+        reference_documents: 0,
+        reference_citations: 0,
+        option_responses: 3,
+        option_citations: 2,
+        manual_assessments: 4,
+      },
+      preserved_counts: {
+        suppliers: 2,
+        options: 3,
+        option_documents: 1,
+        comparison_sets: 1,
+      },
+    },
+  } as const
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+describe("cross-dossier baseline copy workflow", () => {
+  beforeEach(() => {
+    Object.values(rpc).forEach((mock) => mock.mockReset())
+    rpc.listSources.mockResolvedValue({
+      data: [source],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+  })
+
+  it("lists locked sources and previews create mode with a paired-null target draft", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("create"))
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toEqual([source]))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+
+    expect(rpc.previewCopy).toHaveBeenCalledWith({
+      p_source_baseline_version_id: source.baseline_version_id,
+      p_target_dossier_id: dossier.id,
+      p_expected_dossier_revision: dossierRevision,
+      p_expected_target_baseline_version_id: null,
+      p_expected_target_baseline_revision: null,
+    })
+    expect(result.current.preview?.mode).toBe("create")
+  })
+
+  it("loads additional bounded source pages without per-dossier version requests", async () => {
+    const secondSource = {
+      ...source,
+      baseline_version_id: "source-2",
+      dossier_id: "source-dossier-2",
+      dossier_name: "Hồ sơ nguồn 2",
+    }
+    rpc.listSources.mockImplementation((args: { p_page: number }) =>
+      Promise.resolve({
+        data: args.p_page === 1 ? [source] : [secondSource],
+        total: 2,
+        page: args.p_page,
+        page_size: 1,
+      })
+    )
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toEqual([source]))
+    await act(() => result.current.loadMoreSources())
+
+    await waitFor(() => expect(result.current.sources).toEqual([source, secondSource]))
+    expect(rpc.listSources).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        p_target_dossier_id: dossier.id,
+        p_page: 2,
+        p_page_size: 20,
+      }),
+      expect.any(AbortSignal)
+    )
+  })
+
+  it("requires confirmation for replacement and applies the returned fingerprint", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("replace"))
+    rpc.applyCopy.mockResolvedValue({
+      data: {
+        mode: "replace",
+        target_dossier_id: dossier.id,
+        target_dossier_revision: 8,
+        target_baseline_version_id: draft.id,
+        target_baseline_revision: 5,
+        source_baseline_version_id: source.baseline_version_id,
+        copied_counts: {},
+        deleted_counts: {},
+        preserved_counts: {},
+      },
+    })
+    const onApplied = vi.fn()
+    const queryClient = createQueryClient()
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: draft,
+          onApplied,
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+
+    expect(result.current.canApply).toBe(false)
+    act(() => result.current.setReplacementConfirmed(true))
+    expect(result.current.canApply).toBe(true)
+    await act(() => result.current.apply())
+
+    expect(rpc.applyCopy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        p_preview_fingerprint: "b".repeat(64),
+        p_confirm_replace: true,
+      })
+    )
+    expect(onApplied).toHaveBeenCalled()
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["technical-configurations"],
+    })
+  })
+
+  it("forces a fresh preview after stale_preview while preserving the selected source", async () => {
+    rpc.previewCopy
+      .mockResolvedValueOnce(createPreview("replace"))
+      .mockResolvedValueOnce(createPreview("replace"))
+    rpc.applyCopy.mockRejectedValueOnce(
+      Object.assign(new Error("stale_preview"), { code: "PT409" })
+    )
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: draft,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+    act(() => result.current.setReplacementConfirmed(true))
+    await act(() => result.current.apply())
+
+    expect(rpc.previewCopy).toHaveBeenCalledTimes(2)
+    expect(result.current.selectedSourceId).toBe(source.baseline_version_id)
+    expect(result.current.operationError).toMatch(/bản xem trước mới/i)
+    expect(result.current.replacementConfirmed).toBe(false)
+  })
+
+  it.each(["stale_revision", "target_draft_changed"])(
+    "refreshes target state and rebuilds preview after %s",
+    async (conflict) => {
+      const refreshedDraft = { ...draft, revision: 5 }
+      const refreshedPreview = {
+        ...createPreview("replace"),
+        data: {
+          ...createPreview("replace").data,
+          target: {
+            ...createPreview("replace").data.target,
+            dossier_revision: dossierRevision + 1,
+            baseline_revision: refreshedDraft.revision,
+          },
+        },
+      }
+      rpc.previewCopy
+        .mockResolvedValueOnce(createPreview("replace"))
+        .mockResolvedValueOnce(refreshedPreview)
+      rpc.applyCopy.mockRejectedValueOnce(Object.assign(new Error(conflict), { code: "PT409" }))
+      const onTargetStateStale = vi.fn().mockResolvedValue({
+        dossierRevision: dossierRevision + 1,
+        targetDraft: refreshedDraft,
+      })
+      const queryClient = createQueryClient()
+      const { result } = renderHook(
+        () =>
+          useTechnicalConfigurationBaselineCrossDossierCopy({
+            dossier,
+            dossierRevision,
+            targetDraft: draft,
+            onApplied: vi.fn(),
+            onTargetStateStale,
+          }),
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+
+      act(() => result.current.openDialog())
+      await waitFor(() => expect(result.current.sources).toHaveLength(1))
+      await act(() => result.current.selectSource(source.baseline_version_id))
+      act(() => result.current.setReplacementConfirmed(true))
+      await act(() => result.current.apply())
+
+      expect(onTargetStateStale).toHaveBeenCalledTimes(1)
+      expect(rpc.previewCopy).toHaveBeenCalledTimes(2)
+      expect(rpc.previewCopy).toHaveBeenLastCalledWith({
+        p_source_baseline_version_id: source.baseline_version_id,
+        p_target_dossier_id: dossier.id,
+        p_expected_dossier_revision: dossierRevision + 1,
+        p_expected_target_baseline_version_id: refreshedDraft.id,
+        p_expected_target_baseline_revision: refreshedDraft.revision,
+      })
+      expect(result.current.selectedSourceId).toBe(source.baseline_version_id)
+      expect(result.current.preview).toEqual(refreshedPreview.data)
+      expect(result.current.replacementConfirmed).toBe(false)
+      expect(result.current.operationError).toMatch(/bản xem trước mới/i)
+    }
+  )
+
+  it("ignores a rejected preview response that settles after the dialog closes", async () => {
+    const pendingPreview = deferred<ReturnType<typeof createPreview>>()
+    rpc.previewCopy.mockReturnValue(pendingPreview.promise)
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    let selectPromise!: Promise<void>
+    act(() => {
+      selectPromise = result.current.selectSource(source.baseline_version_id)
+    })
+    act(() => result.current.closeDialog())
+    pendingPreview.reject(new Error("late_preview_failed"))
+    await act(() => selectPromise)
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.operationError).toBeNull()
+  })
+
+  it("closes after server success even when the optional UI refresh fails", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("create"))
+    rpc.applyCopy.mockResolvedValue({
+      data: {
+        mode: "create",
+        target_dossier_id: dossier.id,
+        target_dossier_revision: 8,
+        target_baseline_version_id: "created-draft-1",
+        target_baseline_revision: 1,
+        source_baseline_version_id: source.baseline_version_id,
+        copied_counts: {},
+        deleted_counts: {},
+        preserved_counts: {},
+      },
+    })
+    const queryClient = createQueryClient()
+    vi.spyOn(queryClient, "invalidateQueries").mockRejectedValueOnce(new Error("refresh_failed"))
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn().mockRejectedValue(new Error("editor_refresh_failed")),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+    await act(() => result.current.apply())
+
+    expect(rpc.applyCopy).toHaveBeenCalledTimes(1)
+    expect(result.current.open).toBe(false)
+    expect(result.current.preview).toBeNull()
+  })
+
+  it("resets selection and preview when the user cancels", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("create"))
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+    act(() => result.current.closeDialog())
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.selectedSourceId).toBeNull()
+    expect(result.current.preview).toBeNull()
+  })
+
+  it("ignores a preview response that resolves after the dialog closes", async () => {
+    const pendingPreview = deferred<ReturnType<typeof createPreview>>()
+    rpc.previewCopy.mockReturnValue(pendingPreview.promise)
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    let selectPromise!: Promise<void>
+    act(() => {
+      selectPromise = result.current.selectSource(source.baseline_version_id)
+    })
+    act(() => result.current.closeDialog())
+    pendingPreview.resolve(createPreview("create"))
+    await act(() => selectPromise)
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.selectedSourceId).toBeNull()
+    expect(result.current.preview).toBeNull()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-copy.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-copy.test.tsx
@@ -6,7 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
 import { useTechnicalConfigurationBaselineCrossDossierCopy } from "../_hooks/useTechnicalConfigurationBaselineCrossDossierCopy"
-import type { TechnicalConfigurationDossierWire } from "../types"
+import { technicalConfigurationDossierDetailQueryKey } from "../technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
 import { createReactQueryWrapper } from "@/test-utils/react-query"
 
 const rpc = vi.hoisted(() => ({
@@ -104,6 +108,22 @@ function createPreview(mode: "create" | "replace") {
         option_documents: 1,
         comparison_sets: 1,
       },
+    },
+  } as const
+}
+
+function createApplyResponse(mode: "create" | "replace", targetDossierRevision = 8) {
+  return {
+    data: {
+      mode,
+      target_dossier_id: dossier.id,
+      target_dossier_revision: targetDossierRevision,
+      target_baseline_version_id: mode === "replace" ? draft.id : "created-draft-1",
+      target_baseline_revision: mode === "replace" ? 5 : 1,
+      source_baseline_version_id: source.baseline_version_id,
+      copied_counts: {},
+      deleted_counts: {},
+      preserved_counts: {},
     },
   } as const
 }
@@ -211,19 +231,7 @@ describe("cross-dossier baseline copy workflow", () => {
 
   it("requires confirmation for replacement and applies the returned fingerprint", async () => {
     rpc.previewCopy.mockResolvedValue(createPreview("replace"))
-    rpc.applyCopy.mockResolvedValue({
-      data: {
-        mode: "replace",
-        target_dossier_id: dossier.id,
-        target_dossier_revision: 8,
-        target_baseline_version_id: draft.id,
-        target_baseline_revision: 5,
-        source_baseline_version_id: source.baseline_version_id,
-        copied_counts: {},
-        deleted_counts: {},
-        preserved_counts: {},
-      },
-    })
+    rpc.applyCopy.mockResolvedValue(createApplyResponse("replace"))
     const onApplied = vi.fn()
     const queryClient = createQueryClient()
     const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
@@ -377,30 +385,100 @@ describe("cross-dossier baseline copy workflow", () => {
     expect(result.current.operationError).toBeNull()
   })
 
-  it("closes after server success even when the optional UI refresh fails", async () => {
-    rpc.previewCopy.mockResolvedValue(createPreview("create"))
-    rpc.applyCopy.mockResolvedValue({
-      data: {
-        mode: "create",
-        target_dossier_id: dossier.id,
-        target_dossier_revision: 8,
-        target_baseline_version_id: "created-draft-1",
-        target_baseline_revision: 1,
-        source_baseline_version_id: source.baseline_version_id,
-        copied_counts: {},
-        deleted_counts: {},
-        preserved_counts: {},
-      },
-    })
+  it("does not restart stale-target recovery after the dialog closes", async () => {
+    const refreshedTargetState = deferred<{
+      dossierRevision: number
+      targetDraft: TechnicalConfigurationBaselineDraftWire | null
+    }>()
+    rpc.previewCopy
+      .mockResolvedValueOnce(createPreview("replace"))
+      .mockResolvedValueOnce(createPreview("replace"))
+    rpc.applyCopy.mockRejectedValueOnce(
+      Object.assign(new Error("stale_revision"), { code: "PT409" })
+    )
+    const onTargetStateStale = vi.fn().mockReturnValue(refreshedTargetState.promise)
     const queryClient = createQueryClient()
-    vi.spyOn(queryClient, "invalidateQueries").mockRejectedValueOnce(new Error("refresh_failed"))
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: draft,
+          onApplied: vi.fn(),
+          onTargetStateStale,
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+    act(() => result.current.setReplacementConfirmed(true))
+    let applyPromise!: Promise<void>
+    act(() => {
+      applyPromise = result.current.apply()
+    })
+    await waitFor(() => expect(onTargetStateStale).toHaveBeenCalledTimes(1))
+
+    act(() => result.current.closeDialog())
+    refreshedTargetState.resolve({
+      dossierRevision: dossierRevision + 1,
+      targetDraft: { ...draft, revision: draft.revision + 1 },
+    })
+    await act(() => applyPromise)
+
+    expect(rpc.previewCopy).toHaveBeenCalledTimes(1)
+    expect(result.current.open).toBe(false)
+    expect(result.current.selectedSourceId).toBeNull()
+    expect(result.current.preview).toBeNull()
+    expect(result.current.operationError).toBeNull()
+  })
+
+  it("does not lower a newer dossier revision already present in the detail cache", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("create"))
+    rpc.applyCopy.mockResolvedValue(createApplyResponse("create", 8))
+    const queryClient = createQueryClient()
+    queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
+      technicalConfigurationDossierDetailQueryKey(dossier.id),
+      { data: { ...dossier, revision: 9 } }
+    )
     const { result } = renderHook(
       () =>
         useTechnicalConfigurationBaselineCrossDossierCopy({
           dossier,
           dossierRevision,
           targetDraft: null,
-          onApplied: vi.fn().mockRejectedValue(new Error("editor_refresh_failed")),
+          onApplied: vi.fn(),
+        }),
+      { wrapper: createReactQueryWrapper(queryClient) }
+    )
+
+    act(() => result.current.openDialog())
+    await waitFor(() => expect(result.current.sources).toHaveLength(1))
+    await act(() => result.current.selectSource(source.baseline_version_id))
+    await act(() => result.current.apply())
+
+    expect(
+      queryClient.getQueryData<TechnicalConfigurationDossierWireResponse>(
+        technicalConfigurationDossierDetailQueryKey(dossier.id)
+      )?.data.revision
+    ).toBe(9)
+  })
+
+  it("closes after server success even when the optional UI refresh fails", async () => {
+    rpc.previewCopy.mockResolvedValue(createPreview("create"))
+    const applyResponse = createApplyResponse("create")
+    rpc.applyCopy.mockResolvedValue(applyResponse)
+    const queryClient = createQueryClient()
+    vi.spyOn(queryClient, "invalidateQueries").mockRejectedValueOnce(new Error("refresh_failed"))
+    const onApplied = vi.fn().mockRejectedValue(new Error("editor_refresh_failed"))
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationBaselineCrossDossierCopy({
+          dossier,
+          dossierRevision,
+          targetDraft: null,
+          onApplied,
         }),
       { wrapper: createReactQueryWrapper(queryClient) }
     )
@@ -411,6 +489,7 @@ describe("cross-dossier baseline copy workflow", () => {
     await act(() => result.current.apply())
 
     expect(rpc.applyCopy).toHaveBeenCalledTimes(1)
+    expect(onApplied).toHaveBeenCalledWith(applyResponse.data)
     expect(result.current.open).toBe(false)
     expect(result.current.preview).toBeNull()
   })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-dialog.test.tsx
@@ -1,0 +1,157 @@
+import "@testing-library/jest-dom"
+
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationBaselineCrossDossierCopyDialog } from "../_components/TechnicalConfigurationBaselineCrossDossierCopyDialog"
+import type { UseTechnicalConfigurationBaselineCrossDossierCopyResult } from "../_hooks/useTechnicalConfigurationBaselineCrossDossierCopy"
+
+function createWorkflow(
+  overrides: Partial<UseTechnicalConfigurationBaselineCrossDossierCopyResult> = {}
+): UseTechnicalConfigurationBaselineCrossDossierCopyResult {
+  return {
+    open: true,
+    openDialog: vi.fn(),
+    closeDialog: vi.fn(),
+    search: "",
+    setSearch: vi.fn(),
+    sources: [
+      {
+        baseline_version_id: "source-1",
+        dossier_id: "source-dossier-1",
+        device_type_name: "Máy thở",
+        dossier_name: "Hồ sơ nguồn",
+        dossier_archived_at: "2026-08-18T00:00:00.000Z",
+        version_number: 3,
+        locked_at: "2026-08-18T01:00:00.000Z",
+        main_section_count: 2,
+        subgroup_count: 4,
+        criterion_count: 12,
+      },
+    ],
+    total: 1,
+    isSourcesLoading: false,
+    isLoadingMoreSources: false,
+    hasMoreSources: false,
+    loadMoreSources: vi.fn(),
+    sourcesError: null,
+    selectedSourceId: "source-1",
+    selectSource: vi.fn(),
+    preview: {
+      mode: "replace",
+      requires_replacement_confirmation: true,
+      preview_fingerprint: "c".repeat(64),
+      source: {
+        baseline_version_id: "source-1",
+        dossier_id: "source-dossier-1",
+        device_type_name: "Máy thở",
+        dossier_name: "Hồ sơ nguồn",
+        dossier_archived_at: "2026-08-18T00:00:00.000Z",
+        version_number: 3,
+        locked_at: "2026-08-18T01:00:00.000Z",
+      },
+      target: {
+        dossier_id: "target-1",
+        dossier_revision: 7,
+        baseline_version_id: "draft-1",
+        baseline_revision: 4,
+        version_number: 2,
+      },
+      copy_counts: {
+        main_sections: 2,
+        subgroups: 4,
+        criteria: 12,
+        reference_products: 1,
+        reference_responses: 1,
+        baseline_documents: 1,
+        baseline_citations: 1,
+        reference_documents: 1,
+        reference_citations: 1,
+      },
+      delete_counts: {
+        main_sections: 1,
+        subgroups: 1,
+        criteria: 2,
+        reference_products: 0,
+        reference_responses: 0,
+        baseline_documents: 0,
+        baseline_citations: 0,
+        reference_documents: 0,
+        reference_citations: 0,
+        option_responses: 3,
+        option_citations: 2,
+        manual_assessments: 4,
+      },
+      preserved_counts: {
+        suppliers: 2,
+        options: 3,
+        option_documents: 1,
+        comparison_sets: 1,
+      },
+    },
+    isPreviewing: false,
+    replacementConfirmed: false,
+    setReplacementConfirmed: vi.fn(),
+    operationError: null,
+    isApplying: false,
+    canApply: false,
+    apply: vi.fn(),
+    ...overrides,
+  } as UseTechnicalConfigurationBaselineCrossDossierCopyResult
+}
+
+describe("technical configuration cross-dossier copy dialog", () => {
+  it("shows the locked-source warning, archived state, and dependent deletion counts", () => {
+    render(<TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={createWorkflow()} />)
+
+    expect(screen.getByText(/Chỉ có thể sao chép phiên bản cấu hình đã khóa/)).toBeInTheDocument()
+    expect(screen.getByText("Đã lưu trữ")).toBeInTheDocument()
+    expect(screen.getByText("Phản hồi phương án")).toBeInTheDocument()
+    expect(screen.getByText("Trích dẫn phương án")).toBeInTheDocument()
+    expect(screen.getByText("Đánh giá thủ công")).toBeInTheDocument()
+  })
+
+  it("requires explicit replacement confirmation and cancels without applying", async () => {
+    const user = userEvent.setup()
+    const workflow = createWorkflow()
+    render(<TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={workflow} />)
+
+    expect(screen.getByRole("button", { name: "Thay thế bản nháp" })).toBeDisabled()
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Tôi hiểu bản nháp hiện tại sẽ bị thay thế/,
+      })
+    )
+    expect(workflow.setReplacementConfirmed).toHaveBeenCalledWith(true)
+
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+    expect(workflow.closeDialog).toHaveBeenCalled()
+    expect(workflow.apply).not.toHaveBeenCalled()
+  })
+
+  it("preserves recoverable server errors in the open dialog", () => {
+    render(
+      <TechnicalConfigurationBaselineCrossDossierCopyDialog
+        workflow={createWorkflow({
+          operationError:
+            "Dữ liệu đã thay đổi. Hệ thống đã tải bản xem trước mới; vui lòng kiểm tra lại.",
+        })}
+      />
+    )
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(screen.getByText(/bản xem trước mới/)).toBeInTheDocument()
+  })
+
+  it("blocks every close path while preview or apply is pending", async () => {
+    const user = userEvent.setup()
+    const workflow = createWorkflow({ isPreviewing: true })
+    render(<TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={workflow} />)
+
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    expect(workflow.closeDialog).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-dialog.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-dialog.test.tsx
@@ -144,12 +144,32 @@ describe("technical configuration cross-dossier copy dialog", () => {
     expect(screen.getByText(/bản xem trước mới/)).toBeInTheDocument()
   })
 
+  it("localizes the accessible close label", () => {
+    render(<TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={createWorkflow()} />)
+
+    expect(screen.getByRole("button", { name: "Đóng" })).toBeInTheDocument()
+  })
+
+  it("disables replacement confirmation while apply is pending", () => {
+    render(
+      <TechnicalConfigurationBaselineCrossDossierCopyDialog
+        workflow={createWorkflow({ isApplying: true })}
+      />
+    )
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: /Tôi hiểu bản nháp hiện tại sẽ bị thay thế/,
+      })
+    ).toBeDisabled()
+  })
+
   it("blocks every close path while preview or apply is pending", async () => {
     const user = userEvent.setup()
     const workflow = createWorkflow({ isPreviewing: true })
     render(<TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={workflow} />)
 
-    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
     await user.keyboard("{Escape}")
     expect(workflow.closeDialog).not.toHaveBeenCalled()
     expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-cross-dossier-rpc.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { BASELINE_RPC_FUNCTIONS } from "@/lib/technical-configuration-baseline-rpcs"
+import {
+  applyTechnicalConfigurationBaselineCrossDossierCopy,
+  listTechnicalConfigurationBaselineCrossDossierSources,
+  previewTechnicalConfigurationBaselineCrossDossierCopy,
+} from "../technical-configuration-baseline-cross-dossier-rpc"
+
+const callRpcMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+describe("technical configuration cross-dossier baseline RPC client", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+    callRpcMock.mockResolvedValue({ data: [] })
+  })
+
+  it("calls the bounded source-list RPC with the frozen paging contract", async () => {
+    const signal = new AbortController().signal
+    await listTechnicalConfigurationBaselineCrossDossierSources(
+      {
+        p_target_dossier_id: "target-1",
+        p_search: "máy thở",
+        p_page: 2,
+        p_page_size: 20,
+      },
+      signal
+    )
+
+    expect(callRpcMock).toHaveBeenCalledWith(
+      BASELINE_RPC_FUNCTIONS.listCrossDossierSources,
+      {
+        p_target_dossier_id: "target-1",
+        p_search: "máy thở",
+        p_page: 2,
+        p_page_size: 20,
+      },
+      { signal }
+    )
+  })
+
+  it("preserves the paired-null target draft contract during preview", async () => {
+    await previewTechnicalConfigurationBaselineCrossDossierCopy({
+      p_source_baseline_version_id: "source-1",
+      p_target_dossier_id: "target-1",
+      p_expected_dossier_revision: 7,
+      p_expected_target_baseline_version_id: null,
+      p_expected_target_baseline_revision: null,
+    })
+
+    expect(callRpcMock).toHaveBeenCalledWith(
+      BASELINE_RPC_FUNCTIONS.previewCrossDossierCopy,
+      expect.objectContaining({
+        p_expected_target_baseline_version_id: null,
+        p_expected_target_baseline_revision: null,
+      })
+    )
+  })
+
+  it("carries the exact preview fingerprint and replacement confirmation into apply", async () => {
+    await applyTechnicalConfigurationBaselineCrossDossierCopy({
+      p_source_baseline_version_id: "source-1",
+      p_target_dossier_id: "target-1",
+      p_expected_dossier_revision: 7,
+      p_expected_target_baseline_version_id: "draft-1",
+      p_expected_target_baseline_revision: 4,
+      p_preview_fingerprint: "a".repeat(64),
+      p_confirm_replace: true,
+    })
+
+    expect(callRpcMock).toHaveBeenCalledWith(
+      BASELINE_RPC_FUNCTIONS.applyCrossDossierCopy,
+      expect.objectContaining({
+        p_preview_fingerprint: "a".repeat(64),
+        p_confirm_replace: true,
+      })
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions-fixtures.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions-fixtures.ts
@@ -43,6 +43,8 @@ export function renderBaselineProductionActions({
   return render(
     createElement(TechnicalConfigurationBaselineProductionActions, {
       version,
+      deviceTypeName: "Máy lọc thận",
+      dossierName: "Hồ sơ khu A",
       dirty,
       conflict,
       disabled,

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-download-actions.test.tsx
@@ -155,7 +155,7 @@ describe("technical configuration baseline download actions", () => {
       expect.objectContaining({
         type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       }),
-      "Cau_Hinh_Co_So_Hien_Tai_Phien_Ban_7.xlsx"
+      "May_loc_than_Ho_so_khu_A_Phien_Ban_7.xlsx"
     )
     const downloadedBlob = workbookCodec.downloadBlob.mock.calls[0]?.[0] as Blob
     await expect(readBlobBytes(downloadedBlob)).resolves.toEqual([1, 2, 3])
@@ -205,7 +205,7 @@ describe("technical configuration baseline download actions", () => {
     expect(workbookCodec.downloadBlob).toHaveBeenCalledTimes(1)
     expect(workbookCodec.downloadBlob).toHaveBeenCalledWith(
       expect.any(Blob),
-      "Mau_Cau_Hinh_Co_So_Trong_Phien_Ban_7.xlsx"
+      "Mau_May_loc_than_Ho_so_khu_A_Phien_Ban_7.xlsx"
     )
     const downloadedBlob = workbookCodec.downloadBlob.mock.calls[0]?.[0] as Blob
     await expect(readBlobBytes(downloadedBlob)).resolves.toEqual([1, 2, 3])
@@ -260,7 +260,7 @@ describe("technical configuration baseline download actions", () => {
     expect(workbookCodec.downloadBlob).toHaveBeenCalledTimes(1)
     expect(workbookCodec.downloadBlob).toHaveBeenCalledWith(
       expect.any(Blob),
-      "Mau_Cau_Hinh_Co_So_Trong_Phien_Ban_7.xlsx"
+      "Mau_May_loc_than_Ho_so_khu_A_Phien_Ban_7.xlsx"
     )
     await waitForExcelActionToFinish()
   })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-filename.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-filename.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildTechnicalConfigurationBaselineWorkbookFilename,
+  normalizeTechnicalConfigurationBaselineFilenameSegment,
+} from "../technical-configuration-baseline-filename"
+
+describe("technical configuration baseline workbook filename", () => {
+  it("normalizes Vietnamese text and forbidden separators to ASCII-safe segments", () => {
+    expect(normalizeTechnicalConfigurationBaselineFilenameSegment("Đầu dò / siêu âm")).toBe(
+      "Dau_do_sieu_am"
+    )
+  })
+
+  it("uses the contract fallbacks and caps each dynamic segment at 60 ASCII characters", () => {
+    const filename = buildTechnicalConfigurationBaselineWorkbookFilename({
+      intent: "current-data",
+      deviceTypeName: "***",
+      dossierName: "Hồ sơ ".repeat(30),
+      versionNumber: 12,
+    })
+
+    expect(filename).toMatch(/^Thiet_Bi_/)
+    expect(filename.endsWith("_Phien_Ban_12.xlsx")).toBe(true)
+    expect(filename.length).toBeLessThanOrEqual(160)
+    expect(filename.split("_Phien_Ban_")[0]?.split("_").join("_").length).toBeLessThanOrEqual(130)
+  })
+
+  it("generates identifiable current and blank-template names", () => {
+    const input = {
+      deviceTypeName: "Máy lọc thận",
+      dossierName: "Hồ sơ khu A",
+      versionNumber: 3,
+    }
+
+    expect(
+      buildTechnicalConfigurationBaselineWorkbookFilename({ ...input, intent: "current-data" })
+    ).toBe("May_loc_than_Ho_so_khu_A_Phien_Ban_3.xlsx")
+    expect(
+      buildTechnicalConfigurationBaselineWorkbookFilename({ ...input, intent: "blank-template" })
+    ).toBe("Mau_May_loc_than_Ho_so_khu_A_Phien_Ban_3.xlsx")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-import-utils.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-import-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { getBaselineImportErrorMessage } from "../technical-configuration-baseline-import-utils"
+import { TechnicalConfigurationRpcError } from "../technical-configuration-rpc"
+
+describe("technical configuration baseline import errors", () => {
+  it("directs cross-dossier workbooks to the authenticated copy workflow", () => {
+    const error = new TechnicalConfigurationRpcError(422, {
+      message: "template_mismatch",
+      details: "template metadata does not match the target",
+    })
+
+    expect(getBaselineImportErrorMessage(error, "Không thể nhập workbook.")).toContain(
+      "Sao chép từ hồ sơ khác"
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
@@ -31,6 +31,30 @@ describe("technical configuration baseline tab", () => {
     rpc.listVersions.mockResolvedValue(baselineVersionsResponse([createDraft()]))
   })
 
+  it("places cross-dossier copy beside baseline creation for a new dossier", async () => {
+    rpc.listVersions.mockResolvedValue(baselineVersionsResponse([]))
+    renderTab()
+
+    const createButton = await screen.findByRole("button", {
+      name: "Khởi tạo cấu hình cơ sở",
+    })
+    const copyButton = screen.getByRole("button", {
+      name: "Sao chép từ hồ sơ khác",
+    })
+
+    expect(createButton.parentElement).toBe(copyButton.parentElement)
+  })
+
+  it("keeps cross-dossier replacement available on the existing baseline version bar", async () => {
+    renderTab()
+
+    const copyButton = await screen.findByRole("button", {
+      name: "Sao chép từ hồ sơ khác",
+    })
+
+    expect(copyButton.closest("section")).toHaveAccessibleName("Lịch sử phiên bản cấu hình cơ sở")
+  })
+
   it("saves only from explicit Lưu and shows the exact pending label", async () => {
     const user = userEvent.setup()
     const pending = deferred<{ data: TechnicalConfigurationBaselineGroupMutationWire }>()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
@@ -121,6 +121,7 @@ describe("technical configuration baseline tab", () => {
     expect(await screen.findByText("Xung đột dữ liệu")).toBeInTheDocument()
     expect(screen.getByDisplayValue("Tên đang xung đột")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Sao chép từ hồ sơ khác" })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Tải lại từ máy chủ" })).toBeEnabled()
   })
 

--- a/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-editor.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-editor.test.tsx
@@ -28,6 +28,16 @@ describe("useTechnicalConfigurationBaselineEditor", () => {
     })
   })
 
+  it("keeps the highest dossier revision reported by external baseline mutations", async () => {
+    const { result } = renderBaselineEditor()
+
+    await waitFor(() => expect(result.current.editorDraft).not.toBeNull())
+    act(() => result.current.onDossierRevisionChanged(9))
+    act(() => result.current.onDossierRevisionChanged(8))
+
+    expect(result.current.dossierRevision).toBe(9)
+  })
+
   it("shows field validation only after an explicit save attempt", async () => {
     const { result } = renderBaselineEditor()
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCrossDossierCopyDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCrossDossierCopyDialog.tsx
@@ -1,0 +1,301 @@
+"use client"
+
+import { Archive, Copy, LoaderCircle, Search } from "lucide-react"
+
+import type { UseTechnicalConfigurationBaselineCrossDossierCopyResult } from "../_hooks/useTechnicalConfigurationBaselineCrossDossierCopy"
+import type {
+  TechnicalConfigurationBaselineCrossDossierCopyCounts,
+  TechnicalConfigurationBaselineCrossDossierCopyPreviewWire,
+  TechnicalConfigurationBaselineCrossDossierDeleteCounts,
+  TechnicalConfigurationBaselineCrossDossierPreservedCounts,
+  TechnicalConfigurationBaselineCrossDossierSourceWire,
+} from "../technical-configuration-baseline-cross-dossier-types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import { cn } from "@/lib/utils"
+
+function SourceOption({
+  source,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  source: TechnicalConfigurationBaselineCrossDossierSourceWire
+  selected: boolean
+  disabled: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        "w-full border-b px-3 py-3 text-left transition-colors last:border-b-0 hover:bg-muted/60 disabled:cursor-wait",
+        selected && "bg-muted"
+      )}
+    >
+      <span className="flex min-w-0 items-start justify-between gap-3">
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium">{source.dossier_name}</span>
+          <span className="mt-1 block truncate text-sm text-muted-foreground">
+            {source.device_type_name} · Phiên bản {source.version_number}
+          </span>
+        </span>
+        {source.dossier_archived_at ? (
+          <Badge variant="secondary" className="shrink-0 gap-1">
+            <Archive className="size-3" aria-hidden="true" />
+            Đã lưu trữ
+          </Badge>
+        ) : null}
+      </span>
+      <span className="mt-2 block text-xs text-muted-foreground">
+        Khóa lúc {formatVietnamDateTime(source.locked_at)} · {source.main_section_count} mục chính ·{" "}
+        {source.subgroup_count} nhóm con · {source.criterion_count} tiêu chí
+      </span>
+    </button>
+  )
+}
+
+const countLabels = {
+  main_sections: "Mục chính",
+  subgroups: "Nhóm con",
+  criteria: "Tiêu chí",
+  reference_products: "Sản phẩm tham chiếu",
+  reference_responses: "Phản hồi tham chiếu",
+  baseline_documents: "Tài liệu cấu hình",
+  baseline_citations: "Trích dẫn cấu hình",
+  reference_documents: "Tài liệu tham chiếu",
+  reference_citations: "Trích dẫn tham chiếu",
+  option_responses: "Phản hồi phương án",
+  option_citations: "Trích dẫn phương án",
+  manual_assessments: "Đánh giá thủ công",
+  suppliers: "Nhà cung cấp",
+  options: "Phương án",
+  option_documents: "Tài liệu phương án",
+  comparison_sets: "Bộ so sánh",
+} as const
+
+function CountGroup({
+  title,
+  counts,
+  destructive = false,
+}: {
+  title: string
+  counts:
+    | TechnicalConfigurationBaselineCrossDossierCopyCounts
+    | TechnicalConfigurationBaselineCrossDossierDeleteCounts
+    | TechnicalConfigurationBaselineCrossDossierPreservedCounts
+  destructive?: boolean
+}) {
+  const visibleCounts = (Object.entries(counts) as [string, number][]).filter(
+    ([, count]) => count > 0
+  )
+  if (visibleCounts.length === 0) return null
+
+  return (
+    <section>
+      <h3 className={cn("text-sm font-medium", destructive && "text-destructive")}>{title}</h3>
+      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+        {visibleCounts.map(([key, count]) => (
+          <div key={key} className="min-w-0">
+            <dt className="truncate text-muted-foreground">
+              {countLabels[key as keyof typeof countLabels] ?? key}
+            </dt>
+            <dd className="font-semibold tabular-nums">{count}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
+
+function PreviewSummary({
+  preview,
+}: {
+  preview: TechnicalConfigurationBaselineCrossDossierCopyPreviewWire
+}) {
+  return (
+    <div className="space-y-4 border-t pt-4">
+      <Alert variant={preview.mode === "replace" ? "destructive" : "default"}>
+        <Copy className="size-4" aria-hidden="true" />
+        <AlertTitle>
+          {preview.mode === "replace"
+            ? "Thay thế toàn bộ bản nháp hiện tại"
+            : "Tạo bản nháp từ cấu hình đã khóa"}
+        </AlertTitle>
+        <AlertDescription>
+          Nguồn: {preview.source.device_type_name} · {preview.source.dossier_name} · Phiên bản{" "}
+          {preview.source.version_number}
+        </AlertDescription>
+      </Alert>
+      <CountGroup title="Dữ liệu sẽ sao chép" counts={preview.copy_counts} />
+      <CountGroup title="Dữ liệu sẽ xóa" counts={preview.delete_counts} destructive />
+      <CountGroup title="Dữ liệu hồ sơ đích được giữ nguyên" counts={preview.preserved_counts} />
+    </div>
+  )
+}
+
+/** Renders the source selection, preview, and confirmation workflow for cross-dossier copy. */
+export function TechnicalConfigurationBaselineCrossDossierCopyDialog({
+  workflow,
+}: {
+  workflow: UseTechnicalConfigurationBaselineCrossDossierCopyResult
+}) {
+  const isBusy = workflow.isPreviewing || workflow.isApplying
+
+  return (
+    <Dialog
+      open={workflow.open}
+      onOpenChange={(open) => {
+        if (open) workflow.openDialog()
+        else if (!isBusy) workflow.closeDialog()
+      }}
+    >
+      <DialogContent
+        className="max-h-[90vh] overflow-y-auto sm:max-w-2xl"
+        showCloseButton={!isBusy}
+        onEscapeKeyDown={(event) => {
+          if (isBusy) event.preventDefault()
+        }}
+        onPointerDownOutside={(event) => {
+          if (isBusy) event.preventDefault()
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Sao chép cấu hình từ hồ sơ khác</DialogTitle>
+          <DialogDescription>
+            Chọn một phiên bản đã khóa để tạo hoặc thay thế bản nháp của hồ sơ hiện tại.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Alert>
+          <Copy className="size-4" aria-hidden="true" />
+          <AlertTitle>Chỉ sao chép phiên bản đã khóa</AlertTitle>
+          <AlertDescription>
+            Chỉ có thể sao chép phiên bản cấu hình đã khóa. Phiên bản đang ở trạng thái bản nháp
+            không thể sao chép.
+          </AlertDescription>
+        </Alert>
+
+        <div className="space-y-2">
+          <Label htmlFor="technical-configuration-cross-dossier-search">Tìm hồ sơ nguồn</Label>
+          <div className="relative">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              id="technical-configuration-cross-dossier-search"
+              value={workflow.search}
+              onChange={(event) => workflow.setSearch(event.target.value)}
+              placeholder="Loại thiết bị hoặc tên hồ sơ"
+              className="pl-9"
+              disabled={isBusy}
+            />
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-md border">
+          <ScrollArea className="h-64">
+            {workflow.isSourcesLoading ? (
+              <div className="flex h-64 items-center justify-center gap-2 text-sm text-muted-foreground">
+                <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+                Đang tải hồ sơ nguồn...
+              </div>
+            ) : workflow.sourcesError ? (
+              <p className="p-4 text-sm text-destructive">{workflow.sourcesError}</p>
+            ) : workflow.sources.length === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">
+                Không có phiên bản đã khóa phù hợp.
+              </p>
+            ) : (
+              workflow.sources.map((source) => (
+                <SourceOption
+                  key={source.baseline_version_id}
+                  source={source}
+                  selected={workflow.selectedSourceId === source.baseline_version_id}
+                  disabled={isBusy}
+                  onSelect={() => void workflow.selectSource(source.baseline_version_id)}
+                />
+              ))
+            )}
+          </ScrollArea>
+          {workflow.hasMoreSources ? (
+            <div className="border-t p-2 text-center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={workflow.isLoadingMoreSources || isBusy}
+                onClick={() => void workflow.loadMoreSources()}
+              >
+                {workflow.isLoadingMoreSources ? "Đang tải..." : "Tải thêm hồ sơ"}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        {workflow.isPreviewing ? (
+          <p className="text-sm text-muted-foreground">Đang tạo bản xem trước...</p>
+        ) : null}
+        {workflow.preview ? <PreviewSummary preview={workflow.preview} /> : null}
+
+        {workflow.preview?.requires_replacement_confirmation ? (
+          <div className="flex items-start gap-3 rounded-md border border-destructive/40 p-3">
+            <Checkbox
+              id="technical-configuration-cross-dossier-confirm"
+              checked={workflow.replacementConfirmed}
+              onCheckedChange={(checked) => workflow.setReplacementConfirmed(checked === true)}
+            />
+            <label
+              htmlFor="technical-configuration-cross-dossier-confirm"
+              className="text-sm leading-5"
+            >
+              Tôi hiểu bản nháp hiện tại sẽ bị thay thế và các phản hồi, trích dẫn phương án cùng
+              đánh giá thủ công được liệt kê sẽ bị xóa.
+            </label>
+          </div>
+        ) : null}
+
+        {workflow.operationError ? (
+          <p role="alert" className="text-sm text-destructive">
+            {workflow.operationError}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={workflow.closeDialog} disabled={isBusy}>
+            Hủy
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void workflow.apply()}
+            disabled={!workflow.canApply || isBusy}
+          >
+            {workflow.isApplying
+              ? "Đang sao chép..."
+              : workflow.preview?.mode === "replace"
+                ? "Thay thế bản nháp"
+                : "Tạo bản nháp từ cấu hình"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCrossDossierCopyDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCrossDossierCopyDialog.tsx
@@ -170,6 +170,7 @@ export function TechnicalConfigurationBaselineCrossDossierCopyDialog({
       <DialogContent
         className="max-h-[90vh] overflow-y-auto sm:max-w-2xl"
         showCloseButton={!isBusy}
+        closeLabel="Đóng"
         onEscapeKeyDown={(event) => {
           if (isBusy) event.preventDefault()
         }}
@@ -261,6 +262,7 @@ export function TechnicalConfigurationBaselineCrossDossierCopyDialog({
             <Checkbox
               id="technical-configuration-cross-dossier-confirm"
               checked={workflow.replacementConfirmed}
+              disabled={isBusy}
               onCheckedChange={(checked) => workflow.setReplacementConfirmed(checked === true)}
             />
             <label

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineProductionActions.tsx
@@ -16,6 +16,8 @@ import { HeroActionDropdown } from "@/components/ui/heroui/HeroActionDropdown"
 
 type TechnicalConfigurationBaselineProductionActionsProps = Readonly<{
   version: TechnicalConfigurationBaselineDecodedDraft
+  deviceTypeName: string
+  dossierName: string
   dirty: boolean
   conflict: boolean
   disabled: boolean
@@ -26,6 +28,8 @@ type TechnicalConfigurationBaselineProductionActionsProps = Readonly<{
 /** Mounts the P6B draft-only XLSX v2 and hierarchy import commands. */
 export function TechnicalConfigurationBaselineProductionActions({
   version,
+  deviceTypeName,
+  dossierName,
   dirty,
   conflict,
   disabled,
@@ -56,7 +60,12 @@ export function TechnicalConfigurationBaselineProductionActions({
     setDownloadingIntent(intent)
     setError(null)
     try {
-      await downloadTechnicalConfigurationBaselineWorkbookV2({ version, intent })
+      await downloadTechnicalConfigurationBaselineWorkbookV2({
+        version,
+        intent,
+        deviceTypeName,
+        dossierName,
+      })
     } catch {
       setError("Không thể tạo tệp Excel cấu hình cơ sở.")
     } finally {

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { useTechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor"
+import { useTechnicalConfigurationBaselineCrossDossierCopy } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineCrossDossierCopy"
 import { useTechnicalConfigurationBaselineHierarchyImport } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineHierarchyImport"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
@@ -12,6 +13,7 @@ import { validateTechnicalConfigurationBaselineEditorDraft } from "@/app/(app)/t
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 
 import { TechnicalConfigurationBaselineAlerts } from "./TechnicalConfigurationBaselineAlerts"
+import { TechnicalConfigurationBaselineCrossDossierCopyDialog } from "./TechnicalConfigurationBaselineCrossDossierCopyDialog"
 import { TechnicalConfigurationBaselineEditor } from "./TechnicalConfigurationBaselineEditor"
 import { TechnicalConfigurationBaselineHierarchyImportDialog } from "./TechnicalConfigurationBaselineHierarchyImportDialog"
 import { TechnicalConfigurationBaselineProductionActions } from "./TechnicalConfigurationBaselineProductionActions"
@@ -48,6 +50,19 @@ export function TechnicalConfigurationBaselineTab({
   const baseline = useTechnicalConfigurationBaselineEditor({
     dossier,
     isExternalDraftReplacementBlocked: bulkSessions.hasPendingInput || hasUnresolvedImportState,
+  })
+  const targetDraft = React.useMemo(
+    () => baseline.versions.find((version) => version.status === "draft") ?? null,
+    [baseline.versions]
+  )
+  const crossDossierCopy = useTechnicalConfigurationBaselineCrossDossierCopy({
+    dossier,
+    dossierRevision: baseline.dossierRevision,
+    targetDraft,
+    onApplied: async () => {
+      await baseline.onRefreshVersions()
+    },
+    onTargetStateStale: baseline.onRefreshVersions,
   })
   const draft = baseline.editorDraft
   const selectedVersion = baseline.selectedVersion
@@ -189,11 +204,15 @@ export function TechnicalConfigurationBaselineTab({
   }
   if (baseline.isMissing) {
     return (
-      <TechnicalConfigurationBaselineMissingState
-        error={baseline.createError}
-        isCreating={baseline.isCreating}
-        onCreate={baseline.onCreate}
-      />
+      <>
+        <TechnicalConfigurationBaselineMissingState
+          error={baseline.createError}
+          isCreating={baseline.isCreating}
+          onCreate={baseline.onCreate}
+          onCopyFromDossier={crossDossierCopy.openDialog}
+        />
+        <TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={crossDossierCopy} />
+      </>
     )
   }
   if (!selectedVersion) return null
@@ -226,10 +245,16 @@ export function TechnicalConfigurationBaselineTab({
           onRequestLock={() => setIsLockDialogOpen(true)}
           onCreateBlank={baseline.onCreate}
           onCopy={() => void handleCopy()}
+          onCopyFromDossier={crossDossierCopy.openDialog}
+          isCopyFromDossierDisabled={
+            baseline.isDirty || bulkSessions.hasPendingInput || hasUnresolvedImportState
+          }
           spreadsheetActions={
             decodedVersion ? (
               <TechnicalConfigurationBaselineProductionActions
                 version={decodedVersion}
+                deviceTypeName={dossier.device_type_name}
+                dossierName={dossier.name}
                 dirty={baseline.isDirty}
                 conflict={baseline.isConflict}
                 disabled={
@@ -248,6 +273,7 @@ export function TechnicalConfigurationBaselineTab({
       </div>
 
       <TechnicalConfigurationBaselineHierarchyImportDialog workflow={hierarchyImport} />
+      <TechnicalConfigurationBaselineCrossDossierCopyDialog workflow={crossDossierCopy} />
 
       <TechnicalConfigurationBaselineAlerts
         isConflict={baseline.isConflict}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -59,7 +59,8 @@ export function TechnicalConfigurationBaselineTab({
     dossier,
     dossierRevision: baseline.dossierRevision,
     targetDraft,
-    onApplied: async () => {
+    onApplied: async (result) => {
+      baseline.onDossierRevisionChanged(result.target_dossier_revision)
       await baseline.onRefreshVersions()
     },
     onTargetStateStale: baseline.onRefreshVersions,
@@ -247,7 +248,10 @@ export function TechnicalConfigurationBaselineTab({
           onCopy={() => void handleCopy()}
           onCopyFromDossier={crossDossierCopy.openDialog}
           isCopyFromDossierDisabled={
-            baseline.isDirty || bulkSessions.hasPendingInput || hasUnresolvedImportState
+            baseline.isDirty ||
+            baseline.isConflict ||
+            bulkSessions.hasPendingInput ||
+            hasUnresolvedImportState
           }
           spreadsheetActions={
             decodedVersion ? (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTabStates.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, FileLock2, ListPlus, RefreshCw } from "lucide-react"
+import { AlertCircle, Copy, FileLock2, ListPlus, RefreshCw } from "lucide-react"
 
 import type {
   TechnicalConfigurationBaselineCriterionWire,
@@ -43,16 +43,28 @@ export function TechnicalConfigurationBaselineMissingState({
   error,
   isCreating,
   onCreate,
-}: Readonly<{ error: string | null; isCreating: boolean; onCreate: () => void }>) {
+  onCopyFromDossier,
+}: Readonly<{
+  error: string | null
+  isCreating: boolean
+  onCreate: () => void
+  onCopyFromDossier: () => void
+}>) {
   return (
     <section className="border-y py-12 text-center">
       <ListPlus className="mx-auto size-9 text-muted-foreground" aria-hidden="true" />
       <h2 className="mt-4 text-base font-semibold">Chưa có bản nháp cấu hình</h2>
       {error ? <p className="mx-auto mt-2 max-w-xl text-sm text-destructive">{error}</p> : null}
-      <Button type="button" className="mt-5" disabled={isCreating} onClick={onCreate}>
-        <ListPlus className="size-4" aria-hidden="true" />
-        {isCreating ? "Đang khởi tạo..." : "Khởi tạo cấu hình cơ sở"}
-      </Button>
+      <div className="mt-5 flex flex-wrap justify-center gap-2">
+        <Button type="button" disabled={isCreating} onClick={onCreate}>
+          <ListPlus className="size-4" aria-hidden="true" />
+          {isCreating ? "Đang khởi tạo..." : "Khởi tạo cấu hình cơ sở"}
+        </Button>
+        <Button type="button" variant="outline" disabled={isCreating} onClick={onCopyFromDossier}>
+          <Copy className="size-4" aria-hidden="true" />
+          Sao chép từ hồ sơ khác
+        </Button>
+      </div>
     </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineVersionControls.tsx
@@ -19,6 +19,8 @@ type TechnicalConfigurationBaselineVersionControlsProps = Readonly<{
   onRequestLock: () => void
   onCreateBlank: () => void
   onCopy: () => void
+  onCopyFromDossier: () => void
+  isCopyFromDossierDisabled: boolean
   spreadsheetActions: React.ReactNode
 }>
 
@@ -35,6 +37,8 @@ export function TechnicalConfigurationBaselineVersionControls({
   onRequestLock,
   onCreateBlank,
   onCopy,
+  onCopyFromDossier,
+  isCopyFromDossierDisabled,
   spreadsheetActions,
 }: TechnicalConfigurationBaselineVersionControlsProps): React.JSX.Element {
   if (isFocusMode) {
@@ -63,6 +67,8 @@ export function TechnicalConfigurationBaselineVersionControls({
       onRequestLock={onRequestLock}
       onCreateBlank={onCreateBlank}
       onCopy={onCopy}
+      onCopyFromDossier={onCopyFromDossier}
+      isCopyFromDossierDisabled={isCopyFromDossierDisabled}
       spreadsheetActions={spreadsheetActions}
     />
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
@@ -29,6 +29,8 @@ type TechnicalConfigurationVersionBarProps = {
   onRequestLock: () => void
   onCreateBlank: () => void
   onCopy: () => void
+  onCopyFromDossier: () => void
+  isCopyFromDossierDisabled: boolean
   spreadsheetActions: React.ReactNode
 }
 
@@ -43,6 +45,8 @@ export function TechnicalConfigurationVersionBar({
   onRequestLock,
   onCreateBlank,
   onCopy,
+  onCopyFromDossier,
+  isCopyFromDossierDisabled,
   spreadsheetActions,
 }: Readonly<TechnicalConfigurationVersionBarProps>) {
   const {
@@ -133,6 +137,15 @@ export function TechnicalConfigurationVersionBar({
                 {spreadsheetActions}
                 <Button
                   type="button"
+                  variant="outline"
+                  disabled={areActionsDisabled || isCopyFromDossierDisabled}
+                  onClick={onCopyFromDossier}
+                >
+                  <Copy className="size-4" aria-hidden="true" />
+                  Sao chép từ hồ sơ khác
+                </Button>
+                <Button
+                  type="button"
                   variant="destructive"
                   disabled={areActionsDisabled || Boolean(lockBlockedReason)}
                   onClick={onRequestLock}
@@ -159,6 +172,15 @@ export function TechnicalConfigurationVersionBar({
               <Button type="button" disabled={areActionsDisabled} onClick={onCopy}>
                 <Copy className="size-4" aria-hidden="true" />
                 {isCopying ? "Đang sao chép..." : "Sao chép thành bản nháp"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={areActionsDisabled || isCopyFromDossierDisabled}
+                onClick={onCopyFromDossier}
+              >
+                <Copy className="size-4" aria-hidden="true" />
+                Sao chép từ hồ sơ khác
               </Button>
             </div>
           ) : null}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineCrossDossierCopy.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineCrossDossierCopy.ts
@@ -14,11 +14,8 @@ import type {
   TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs,
   TechnicalConfigurationBaselineCrossDossierCopyPreviewWire,
 } from "../technical-configuration-baseline-cross-dossier-types"
-import { technicalConfigurationDossierDetailQueryKey } from "../technical-configuration-query-keys"
-import type {
-  TechnicalConfigurationDossierWire,
-  TechnicalConfigurationDossierWireResponse,
-} from "../types"
+import { updateTechnicalConfigurationDossierRevisionCache } from "../technical-configuration-dossier-revision-cache"
+import type { TechnicalConfigurationDossierWire } from "../types"
 
 const SOURCE_PAGE_SIZE = 20
 
@@ -51,7 +48,7 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
   dossierRevision,
   targetDraft,
   onApplied,
-  onTargetStateStale = () => ({ dossierRevision, targetDraft }),
+  onTargetStateStale,
 }: {
   dossier: TechnicalConfigurationDossierWire
   dossierRevision: number
@@ -65,6 +62,7 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
 }) {
   const queryClient = useQueryClient()
   const previewRequestIdRef = React.useRef(0)
+  const workflowGenerationRef = React.useRef(0)
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState("")
   const [selectedSourceId, setSelectedSourceId] = React.useState<string | null>(null)
@@ -73,6 +71,10 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
   const [replacementConfirmed, setReplacementConfirmed] = React.useState(false)
   const [operationError, setOperationError] = React.useState<string | null>(null)
   const normalizedSearch = search.trim()
+  const refreshTargetState = React.useCallback(
+    () => onTargetStateStale?.() ?? { dossierRevision, targetDraft },
+    [dossierRevision, onTargetStateStale, targetDraft]
+  )
   const sourceQueryKey = React.useMemo(
     () => [
       "technical-configurations",
@@ -114,7 +116,7 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
       p_expected_target_baseline_version_id: targetState.targetDraft?.id ?? null,
       p_expected_target_baseline_revision: targetState.targetDraft?.revision ?? null,
     }),
-    [dossier.id, dossierRevision, targetDraft?.id, targetDraft?.revision]
+    [dossier.id, dossierRevision, targetDraft]
   )
   const previewMutation = useMutation({
     mutationFn: previewTechnicalConfigurationBaselineCrossDossierCopy,
@@ -142,11 +144,13 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
     },
     [previewArgs, previewMutation]
   )
+  // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation -- apply updates the exact dossier cache and invalidates the technical-configuration namespace after success.
   const applyMutation = useMutation({
     mutationFn: applyTechnicalConfigurationBaselineCrossDossierCopy,
   })
 
   const closeDialog = React.useCallback(() => {
+    workflowGenerationRef.current += 1
     previewRequestIdRef.current += 1
     setOpen(false)
     setSearch("")
@@ -159,6 +163,7 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
   }, [applyMutation, previewMutation])
   const openDialog = React.useCallback(() => setOpen(true), [])
   const updateSearch = React.useCallback((value: string) => {
+    workflowGenerationRef.current += 1
     previewRequestIdRef.current += 1
     setSearch(value)
     setSelectedSourceId(null)
@@ -169,6 +174,7 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
 
   const selectSource = React.useCallback(
     async (sourceBaselineVersionId: string) => {
+      workflowGenerationRef.current += 1
       setSelectedSourceId(sourceBaselineVersionId)
       setPreview(null)
       setReplacementConfirmed(false)
@@ -190,17 +196,10 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
         p_preview_fingerprint: preview.preview_fingerprint,
         p_confirm_replace: replacementConfirmed,
       })
-      queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
-        technicalConfigurationDossierDetailQueryKey(dossier.id),
-        (current) =>
-          current
-            ? {
-                data: {
-                  ...current.data,
-                  revision: response.data.target_dossier_revision,
-                },
-              }
-            : current
+      updateTechnicalConfigurationDossierRevisionCache(
+        queryClient,
+        dossier,
+        response.data.target_dossier_revision
       )
       closeDialog()
       await Promise.allSettled([
@@ -211,29 +210,36 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
       ])
     } catch (error) {
       if (requiresTargetStateRefresh(error)) {
+        const recoveryGeneration = workflowGenerationRef.current
         previewRequestIdRef.current += 1
         setReplacementConfirmed(false)
         setPreview(null)
         try {
-          const refreshedTargetState = await onTargetStateStale()
-          await refreshPreview(selectedSourceId, refreshedTargetState)
+          const refreshedTargetState = await refreshTargetState()
+          if (recoveryGeneration !== workflowGenerationRef.current) return
+          const refreshedPreview = await refreshPreview(selectedSourceId, refreshedTargetState)
+          if (!refreshedPreview) return
           setOperationError(
             "Trạng thái hồ sơ đích đã thay đổi. Hệ thống đã tải bản xem trước mới; vui lòng kiểm tra lại."
           )
         } catch (refreshError) {
+          if (recoveryGeneration !== workflowGenerationRef.current) return
           setOperationError(getErrorMessage(refreshError))
         }
         return
       }
       if (requiresFreshPreview(error)) {
+        const recoveryGeneration = workflowGenerationRef.current
         setReplacementConfirmed(false)
         setPreview(null)
         try {
-          await refreshPreview(selectedSourceId)
+          const refreshedPreview = await refreshPreview(selectedSourceId)
+          if (!refreshedPreview || recoveryGeneration !== workflowGenerationRef.current) return
           setOperationError(
             "Dữ liệu đã thay đổi. Hệ thống đã tải bản xem trước mới; vui lòng kiểm tra lại."
           )
         } catch (previewError) {
+          if (recoveryGeneration !== workflowGenerationRef.current) return
           setOperationError(getErrorMessage(previewError))
         }
         return
@@ -243,13 +249,13 @@ export function useTechnicalConfigurationBaselineCrossDossierCopy({
   }, [
     applyMutation,
     closeDialog,
-    dossier.id,
+    dossier,
     onApplied,
-    onTargetStateStale,
     preview,
     previewArgs,
     queryClient,
     refreshPreview,
+    refreshTargetState,
     replacementConfirmed,
     selectedSourceId,
   ])

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineCrossDossierCopy.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineCrossDossierCopy.ts
@@ -1,0 +1,290 @@
+"use client"
+
+import * as React from "react"
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import {
+  applyTechnicalConfigurationBaselineCrossDossierCopy,
+  listTechnicalConfigurationBaselineCrossDossierSources,
+  previewTechnicalConfigurationBaselineCrossDossierCopy,
+} from "../technical-configuration-baseline-cross-dossier-rpc"
+import type {
+  TechnicalConfigurationBaselineCrossDossierCopyApplyWire,
+  TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs,
+  TechnicalConfigurationBaselineCrossDossierCopyPreviewWire,
+} from "../technical-configuration-baseline-cross-dossier-types"
+import { technicalConfigurationDossierDetailQueryKey } from "../technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
+
+const SOURCE_PAGE_SIZE = 20
+
+type TechnicalConfigurationBaselineCrossDossierTargetState = {
+  dossierRevision: number
+  targetDraft: TechnicalConfigurationBaselineDraftWire | null
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Không thể hoàn tất thao tác sao chép."
+}
+
+function requiresFreshPreview(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === "stale_preview" || error.message === "concurrent_write_retry")
+  )
+}
+
+function requiresTargetStateRefresh(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === "stale_revision" || error.message === "target_draft_changed")
+  )
+}
+
+/** Coordinates bounded source search, authoritative preview, and atomic cross-dossier apply. */
+export function useTechnicalConfigurationBaselineCrossDossierCopy({
+  dossier,
+  dossierRevision,
+  targetDraft,
+  onApplied,
+  onTargetStateStale = () => ({ dossierRevision, targetDraft }),
+}: {
+  dossier: TechnicalConfigurationDossierWire
+  dossierRevision: number
+  targetDraft: TechnicalConfigurationBaselineDraftWire | null
+  onApplied: (
+    result: TechnicalConfigurationBaselineCrossDossierCopyApplyWire
+  ) => Promise<void> | void
+  onTargetStateStale?: () =>
+    | Promise<TechnicalConfigurationBaselineCrossDossierTargetState>
+    | TechnicalConfigurationBaselineCrossDossierTargetState
+}) {
+  const queryClient = useQueryClient()
+  const previewRequestIdRef = React.useRef(0)
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+  const [selectedSourceId, setSelectedSourceId] = React.useState<string | null>(null)
+  const [preview, setPreview] =
+    React.useState<TechnicalConfigurationBaselineCrossDossierCopyPreviewWire | null>(null)
+  const [replacementConfirmed, setReplacementConfirmed] = React.useState(false)
+  const [operationError, setOperationError] = React.useState<string | null>(null)
+  const normalizedSearch = search.trim()
+  const sourceQueryKey = React.useMemo(
+    () => [
+      "technical-configurations",
+      "baseline-cross-dossier-sources",
+      dossier.id,
+      normalizedSearch,
+    ],
+    [dossier.id, normalizedSearch]
+  )
+  const sourcesQuery = useInfiniteQuery({
+    queryKey: sourceQueryKey,
+    enabled: open,
+    initialPageParam: 1,
+    queryFn: ({ pageParam, signal }) =>
+      listTechnicalConfigurationBaselineCrossDossierSources(
+        {
+          p_target_dossier_id: dossier.id,
+          p_search: normalizedSearch || null,
+          p_page: pageParam,
+          p_page_size: SOURCE_PAGE_SIZE,
+        },
+        signal
+      ),
+    getNextPageParam: (lastPage) =>
+      lastPage.page * lastPage.page_size < lastPage.total ? lastPage.page + 1 : undefined,
+  })
+
+  const previewArgs = React.useCallback(
+    (
+      sourceBaselineVersionId: string,
+      targetState: TechnicalConfigurationBaselineCrossDossierTargetState = {
+        dossierRevision,
+        targetDraft,
+      }
+    ): TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs => ({
+      p_source_baseline_version_id: sourceBaselineVersionId,
+      p_target_dossier_id: dossier.id,
+      p_expected_dossier_revision: targetState.dossierRevision,
+      p_expected_target_baseline_version_id: targetState.targetDraft?.id ?? null,
+      p_expected_target_baseline_revision: targetState.targetDraft?.revision ?? null,
+    }),
+    [dossier.id, dossierRevision, targetDraft?.id, targetDraft?.revision]
+  )
+  const previewMutation = useMutation({
+    mutationFn: previewTechnicalConfigurationBaselineCrossDossierCopy,
+  })
+  const refreshPreview = React.useCallback(
+    async (
+      sourceBaselineVersionId: string,
+      targetState?: TechnicalConfigurationBaselineCrossDossierTargetState
+    ) => {
+      const requestId = ++previewRequestIdRef.current
+      let response
+      try {
+        response = await previewMutation.mutateAsync(
+          previewArgs(sourceBaselineVersionId, targetState)
+        )
+      } catch (error) {
+        if (requestId !== previewRequestIdRef.current) return null
+        throw error
+      }
+      if (requestId !== previewRequestIdRef.current) return null
+      setPreview(response.data)
+      setReplacementConfirmed(false)
+      setOperationError(null)
+      return response.data
+    },
+    [previewArgs, previewMutation]
+  )
+  const applyMutation = useMutation({
+    mutationFn: applyTechnicalConfigurationBaselineCrossDossierCopy,
+  })
+
+  const closeDialog = React.useCallback(() => {
+    previewRequestIdRef.current += 1
+    setOpen(false)
+    setSearch("")
+    setSelectedSourceId(null)
+    setPreview(null)
+    setReplacementConfirmed(false)
+    setOperationError(null)
+    previewMutation.reset()
+    applyMutation.reset()
+  }, [applyMutation, previewMutation])
+  const openDialog = React.useCallback(() => setOpen(true), [])
+  const updateSearch = React.useCallback((value: string) => {
+    previewRequestIdRef.current += 1
+    setSearch(value)
+    setSelectedSourceId(null)
+    setPreview(null)
+    setReplacementConfirmed(false)
+    setOperationError(null)
+  }, [])
+
+  const selectSource = React.useCallback(
+    async (sourceBaselineVersionId: string) => {
+      setSelectedSourceId(sourceBaselineVersionId)
+      setPreview(null)
+      setReplacementConfirmed(false)
+      setOperationError(null)
+      try {
+        await refreshPreview(sourceBaselineVersionId)
+      } catch (error) {
+        setOperationError(getErrorMessage(error))
+      }
+    },
+    [refreshPreview]
+  )
+
+  const apply = React.useCallback(async () => {
+    if (!preview || !selectedSourceId) return
+    try {
+      const response = await applyMutation.mutateAsync({
+        ...previewArgs(selectedSourceId),
+        p_preview_fingerprint: preview.preview_fingerprint,
+        p_confirm_replace: replacementConfirmed,
+      })
+      queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
+        technicalConfigurationDossierDetailQueryKey(dossier.id),
+        (current) =>
+          current
+            ? {
+                data: {
+                  ...current.data,
+                  revision: response.data.target_dossier_revision,
+                },
+              }
+            : current
+      )
+      closeDialog()
+      await Promise.allSettled([
+        queryClient.invalidateQueries({
+          queryKey: ["technical-configurations"],
+        }),
+        Promise.resolve(onApplied(response.data)),
+      ])
+    } catch (error) {
+      if (requiresTargetStateRefresh(error)) {
+        previewRequestIdRef.current += 1
+        setReplacementConfirmed(false)
+        setPreview(null)
+        try {
+          const refreshedTargetState = await onTargetStateStale()
+          await refreshPreview(selectedSourceId, refreshedTargetState)
+          setOperationError(
+            "Trạng thái hồ sơ đích đã thay đổi. Hệ thống đã tải bản xem trước mới; vui lòng kiểm tra lại."
+          )
+        } catch (refreshError) {
+          setOperationError(getErrorMessage(refreshError))
+        }
+        return
+      }
+      if (requiresFreshPreview(error)) {
+        setReplacementConfirmed(false)
+        setPreview(null)
+        try {
+          await refreshPreview(selectedSourceId)
+          setOperationError(
+            "Dữ liệu đã thay đổi. Hệ thống đã tải bản xem trước mới; vui lòng kiểm tra lại."
+          )
+        } catch (previewError) {
+          setOperationError(getErrorMessage(previewError))
+        }
+        return
+      }
+      setOperationError(getErrorMessage(error))
+    }
+  }, [
+    applyMutation,
+    closeDialog,
+    dossier.id,
+    onApplied,
+    onTargetStateStale,
+    preview,
+    previewArgs,
+    queryClient,
+    refreshPreview,
+    replacementConfirmed,
+    selectedSourceId,
+  ])
+
+  const sources = sourcesQuery.data?.pages.flatMap((page) => page.data) ?? []
+
+  return {
+    open,
+    openDialog,
+    closeDialog,
+    search,
+    setSearch: updateSearch,
+    sources,
+    total: sourcesQuery.data?.pages[0]?.total ?? 0,
+    isSourcesLoading: sourcesQuery.isLoading,
+    isLoadingMoreSources: sourcesQuery.isFetchingNextPage,
+    hasMoreSources: Boolean(sourcesQuery.hasNextPage),
+    loadMoreSources: () => sourcesQuery.fetchNextPage(),
+    sourcesError: sourcesQuery.isError ? getErrorMessage(sourcesQuery.error) : null,
+    selectedSourceId,
+    selectSource,
+    preview,
+    isPreviewing: previewMutation.isPending,
+    replacementConfirmed,
+    setReplacementConfirmed,
+    operationError,
+    isApplying: applyMutation.isPending,
+    canApply:
+      Boolean(preview) &&
+      (!preview?.requires_replacement_confirmation || replacementConfirmed) &&
+      !applyMutation.isPending,
+    apply,
+  }
+}
+
+export type UseTechnicalConfigurationBaselineCrossDossierCopyResult = ReturnType<
+  typeof useTechnicalConfigurationBaselineCrossDossierCopy
+>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineDossierRevision.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineDossierRevision.ts
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { useQueryClient } from "@tanstack/react-query"
 
-import { technicalConfigurationDossierDetailQueryKey } from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import { updateTechnicalConfigurationDossierRevisionCache } from "@/app/(app)/technical-configurations/technical-configuration-dossier-revision-cache"
 import type {
   TechnicalConfigurationDossierWire,
   TechnicalConfigurationDossierWireResponse,
@@ -22,21 +22,10 @@ export function useTechnicalConfigurationBaselineDossierRevision({
 
   const updateDossierRevision = React.useCallback(
     (revision: number) => {
-      setDossierRevision(revision)
-      queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
-        technicalConfigurationDossierDetailQueryKey(dossier.id),
-        (current) =>
-          current
-            ? {
-                data: {
-                  ...current.data,
-                  revision,
-                },
-              }
-            : current
-      )
+      setDossierRevision((current) => Math.max(current, dossier.revision, revision))
+      updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, revision)
     },
-    [dossier.id, queryClient]
+    [dossier, queryClient]
   )
 
   const refreshDossierRevision = React.useCallback(async () => {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineDossierRevision.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineDossierRevision.ts
@@ -42,6 +42,7 @@ export function useTechnicalConfigurationBaselineDossierRevision({
   const refreshDossierRevision = React.useCallback(async () => {
     const response = await getDossier(dossier.id)
     updateDossierRevision(response.data.revision)
+    return response.data.revision
   }, [dossier.id, getDossier, updateDossierRevision])
 
   return {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor.ts
@@ -285,6 +285,7 @@ export function useTechnicalConfigurationBaselineEditor({
     lifecycleError
   )
   return {
+    dossierRevision,
     versions,
     selectedVersion: baseDraft,
     baseDraft,
@@ -332,7 +333,14 @@ export function useTechnicalConfigurationBaselineEditor({
     onLoadMoreVersions: loadMoreVersions,
     onRetryQuery: retryVersions,
     onRefreshVersions: async () => {
-      await reloadMutation.mutateAsync(false)
+      const [nextDossierRevision, response] = await Promise.all([
+        refreshDossierRevision(),
+        reloadMutation.mutateAsync(false),
+      ])
+      return {
+        dossierRevision: nextDossierRevision,
+        targetDraft: response.data.find((version) => version.status === "draft") ?? null,
+      }
     },
     onReloadFromServer: async () => {
       const response = await reloadMutation.mutateAsync(true)

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor.ts
@@ -332,6 +332,7 @@ export function useTechnicalConfigurationBaselineEditor({
     },
     onLoadMoreVersions: loadMoreVersions,
     onRetryQuery: retryVersions,
+    onDossierRevisionChanged: updateDossierRevision,
     onRefreshVersions: async () => {
       const [nextDossierRevision, response] = await Promise.all([
         refreshDossierRevision(),

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditorTypes.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditorTypes.ts
@@ -5,6 +5,7 @@ import type {
 } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 
 export interface UseTechnicalConfigurationBaselineEditorResult {
+  dossierRevision: number
   versions: TechnicalConfigurationBaselineDraftWire[]
   selectedVersion: TechnicalConfigurationBaselineDraftWire | null
   baseDraft: TechnicalConfigurationBaselineDraftWire | null
@@ -37,7 +38,10 @@ export interface UseTechnicalConfigurationBaselineEditorResult {
   onSelectVersion: (versionId: string, options?: { force?: boolean }) => void
   onLoadMoreVersions: () => Promise<void>
   onRetryQuery: () => Promise<void>
-  onRefreshVersions: () => Promise<void>
+  onRefreshVersions: () => Promise<{
+    dossierRevision: number
+    targetDraft: TechnicalConfigurationBaselineDraftWire | null
+  }>
   onReloadFromServer: () => Promise<TechnicalConfigurationBaselineEditorDraft | null>
   onAdoptImportSnapshot: (version: TechnicalConfigurationBaselineDraftWire) => Promise<void>
   onRefreshImportConflict: (versionId: string) => Promise<void>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditorTypes.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditorTypes.ts
@@ -38,6 +38,7 @@ export interface UseTechnicalConfigurationBaselineEditorResult {
   onSelectVersion: (versionId: string, options?: { force?: boolean }) => void
   onLoadMoreVersions: () => Promise<void>
   onRetryQuery: () => Promise<void>
+  onDossierRevisionChanged: (revision: number) => void
   onRefreshVersions: () => Promise<{
     dossierRevision: number
     targetDraft: TechnicalConfigurationBaselineDraftWire | null

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-cross-dossier-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-cross-dossier-rpc.ts
@@ -1,0 +1,35 @@
+import { BASELINE_RPC_FUNCTIONS } from "@/lib/technical-configuration-baseline-rpcs"
+
+import type {
+  TechnicalConfigurationBaselineCrossDossierCopyApplyRpcArgs,
+  TechnicalConfigurationBaselineCrossDossierCopyApplyWireResponse,
+  TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs,
+  TechnicalConfigurationBaselineCrossDossierCopyPreviewWireResponse,
+  TechnicalConfigurationBaselineCrossDossierSourcesListRpcArgs,
+  TechnicalConfigurationBaselineCrossDossierSourcesListWireResponse,
+} from "./technical-configuration-baseline-cross-dossier-types"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+
+/** Lists locked baseline versions eligible as cross-dossier copy sources. */
+export function listTechnicalConfigurationBaselineCrossDossierSources(
+  args: TechnicalConfigurationBaselineCrossDossierSourcesListRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationBaselineCrossDossierSourcesListWireResponse> {
+  return callTechnicalConfigurationRpc(BASELINE_RPC_FUNCTIONS.listCrossDossierSources, args, {
+    signal,
+  })
+}
+
+/** Requests the authoritative copy and deletion preview without mutating the target. */
+export function previewTechnicalConfigurationBaselineCrossDossierCopy(
+  args: TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs
+): Promise<TechnicalConfigurationBaselineCrossDossierCopyPreviewWireResponse> {
+  return callTechnicalConfigurationRpc(BASELINE_RPC_FUNCTIONS.previewCrossDossierCopy, args)
+}
+
+/** Applies a previously fingerprinted cross-dossier copy to the target dossier. */
+export function applyTechnicalConfigurationBaselineCrossDossierCopy(
+  args: TechnicalConfigurationBaselineCrossDossierCopyApplyRpcArgs
+): Promise<TechnicalConfigurationBaselineCrossDossierCopyApplyWireResponse> {
+  return callTechnicalConfigurationRpc(BASELINE_RPC_FUNCTIONS.applyCrossDossierCopy, args)
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-cross-dossier-types.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-cross-dossier-types.ts
@@ -1,0 +1,104 @@
+export interface TechnicalConfigurationBaselineCrossDossierSourceWire {
+  baseline_version_id: string
+  dossier_id: string
+  device_type_name: string
+  dossier_name: string
+  dossier_archived_at: string | null
+  version_number: number
+  locked_at: string
+  main_section_count: number
+  subgroup_count: number
+  criterion_count: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierSourcesListRpcArgs {
+  p_target_dossier_id: string
+  p_search: string | null
+  p_page: number
+  p_page_size: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierSourcesListWireResponse {
+  data: TechnicalConfigurationBaselineCrossDossierSourceWire[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs {
+  p_source_baseline_version_id: string
+  p_target_dossier_id: string
+  p_expected_dossier_revision: number
+  p_expected_target_baseline_version_id: string | null
+  p_expected_target_baseline_revision: number | null
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyCounts {
+  main_sections: number
+  subgroups: number
+  criteria: number
+  reference_products: number
+  reference_responses: number
+  baseline_documents: number
+  baseline_citations: number
+  reference_documents: number
+  reference_citations: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierDeleteCounts extends TechnicalConfigurationBaselineCrossDossierCopyCounts {
+  option_responses: number
+  option_citations: number
+  manual_assessments: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierPreservedCounts {
+  suppliers: number
+  options: number
+  option_documents: number
+  comparison_sets: number
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyPreviewWire {
+  mode: "create" | "replace"
+  requires_replacement_confirmation: boolean
+  preview_fingerprint: string
+  source: Omit<
+    TechnicalConfigurationBaselineCrossDossierSourceWire,
+    "main_section_count" | "subgroup_count" | "criterion_count"
+  >
+  target: {
+    dossier_id: string
+    dossier_revision: number
+    baseline_version_id: string | null
+    baseline_revision: number | null
+    version_number: number | null
+  }
+  copy_counts: TechnicalConfigurationBaselineCrossDossierCopyCounts
+  delete_counts: TechnicalConfigurationBaselineCrossDossierDeleteCounts
+  preserved_counts: TechnicalConfigurationBaselineCrossDossierPreservedCounts
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyPreviewWireResponse {
+  data: TechnicalConfigurationBaselineCrossDossierCopyPreviewWire
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyApplyRpcArgs extends TechnicalConfigurationBaselineCrossDossierCopyPreviewRpcArgs {
+  p_preview_fingerprint: string
+  p_confirm_replace: boolean
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyApplyWire {
+  mode: "create" | "replace"
+  target_dossier_id: string
+  target_dossier_revision: number
+  target_baseline_version_id: string
+  target_baseline_revision: number
+  source_baseline_version_id: string
+  copied_counts: TechnicalConfigurationBaselineCrossDossierCopyCounts
+  deleted_counts: TechnicalConfigurationBaselineCrossDossierDeleteCounts
+  preserved_counts: TechnicalConfigurationBaselineCrossDossierPreservedCounts
+}
+
+export interface TechnicalConfigurationBaselineCrossDossierCopyApplyWireResponse {
+  data: TechnicalConfigurationBaselineCrossDossierCopyApplyWire
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-download.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-download.ts
@@ -8,6 +8,8 @@ import {
 } from "@/lib/technical-configuration-baseline-excel-v2-contract"
 import { serializeTechnicalConfigurationBaselineWorkbookV2 } from "@/lib/technical-configuration-baseline-excel-v2-export"
 
+import { buildTechnicalConfigurationBaselineWorkbookFilename } from "./technical-configuration-baseline-filename"
+
 export type TechnicalConfigurationBaselineDownloadIntent = "current-data" | "blank-template"
 
 function toWorkbookCriterion(
@@ -36,22 +38,17 @@ function toWorkbookGroups(
   }))
 }
 
-function getFilename(
-  intent: TechnicalConfigurationBaselineDownloadIntent,
-  versionNumber: number
-): string {
-  return intent === "current-data"
-    ? `Cau_Hinh_Co_So_Hien_Tai_Phien_Ban_${versionNumber}.xlsx`
-    : `Mau_Cau_Hinh_Co_So_Trong_Phien_Ban_${versionNumber}.xlsx`
-}
-
 /** Generates and downloads one XLSX v2 workbook bound to the selected draft revision. */
 export async function downloadTechnicalConfigurationBaselineWorkbookV2({
   version,
   intent,
+  deviceTypeName,
+  dossierName,
 }: {
   version: TechnicalConfigurationBaselineDecodedDraft
   intent: TechnicalConfigurationBaselineDownloadIntent
+  deviceTypeName: string
+  dossierName: string
 }): Promise<void> {
   const metadata = {
     dossier_id: version.dossier_id,
@@ -75,6 +72,11 @@ export async function downloadTechnicalConfigurationBaselineWorkbookV2({
 
   downloadBlob(
     new Blob([buffer], { type: BASELINE_WORKBOOK_MIME_TYPE }),
-    getFilename(intent, version.version_number)
+    buildTechnicalConfigurationBaselineWorkbookFilename({
+      intent,
+      deviceTypeName,
+      dossierName,
+      versionNumber: version.version_number,
+    })
   )
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-filename.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-filename.ts
@@ -1,0 +1,53 @@
+import type { TechnicalConfigurationBaselineDownloadIntent } from "./technical-configuration-baseline-download"
+
+const MAX_DYNAMIC_SEGMENT_LENGTH = 60
+const MAX_FILENAME_LENGTH = 160
+
+/** Normalizes one bounded, filesystem-safe dynamic workbook filename segment. */
+export function normalizeTechnicalConfigurationBaselineFilenameSegment(
+  value: string,
+  fallback = ""
+): string {
+  const normalized = value
+    .replaceAll("Đ", "D")
+    .replaceAll("đ", "d")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, MAX_DYNAMIC_SEGMENT_LENGTH)
+    .replace(/_+$/g, "")
+
+  return normalized || fallback
+}
+
+/** Builds the current-data or blank-template baseline workbook filename. */
+export function buildTechnicalConfigurationBaselineWorkbookFilename({
+  intent,
+  deviceTypeName,
+  dossierName,
+  versionNumber,
+}: {
+  intent: TechnicalConfigurationBaselineDownloadIntent
+  deviceTypeName: string
+  dossierName: string
+  versionNumber: number
+}): string {
+  const deviceType = normalizeTechnicalConfigurationBaselineFilenameSegment(
+    deviceTypeName,
+    "Thiet_Bi"
+  )
+  const dossier = normalizeTechnicalConfigurationBaselineFilenameSegment(dossierName, "Ho_So")
+  const prefix = intent === "blank-template" ? "Mau_" : ""
+  const suffix = `_Phien_Ban_${versionNumber}.xlsx`
+  const filename = `${prefix}${deviceType}_${dossier}${suffix}`
+
+  if (filename.length <= MAX_FILENAME_LENGTH) return filename
+
+  const availableDossierLength = Math.max(
+    1,
+    MAX_FILENAME_LENGTH - prefix.length - deviceType.length - suffix.length - 1
+  )
+  return `${prefix}${deviceType}_${dossier.slice(0, availableDossierLength).replace(/_+$/g, "")}${suffix}`
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-import-utils.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-import-utils.ts
@@ -1,9 +1,18 @@
+import { TechnicalConfigurationRpcError } from "./technical-configuration-rpc"
+
 /** MIME type used for baseline workbook downloads. */
 export const BASELINE_WORKBOOK_MIME_TYPE =
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 /** Returns an actionable import error while preserving a stable fallback. */
 export function getBaselineImportErrorMessage(error: unknown, fallback: string): string {
+  if (
+    error instanceof TechnicalConfigurationRpcError &&
+    error.message === "template_mismatch" &&
+    error.details === "template metadata does not match the target"
+  ) {
+    return 'Workbook thuộc hồ sơ khác. Hãy dùng "Sao chép từ hồ sơ khác" thay vì nhập Excel.'
+  }
   if (!(error instanceof Error) || !error.message) return fallback
   return error.message
 }

--- a/src/lib/__tests__/technical-configuration-baseline-excel-v2-parse-identity.test.ts
+++ b/src/lib/__tests__/technical-configuration-baseline-excel-v2-parse-identity.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
+import * as parseContract from "@/lib/technical-configuration-baseline-excel-v2-parse-contract"
 import {
   CURRENT_DATA_GROUPS,
   createWorkbookSheet,
+  EXISTING_HIERARCHY,
   expectWorkbookV2Result,
   expectWorkbookIssue,
   METADATA,
@@ -10,6 +12,7 @@ import {
 } from "@/lib/__tests__/technical-configuration-baseline-excel-v2-parse-fixtures"
 import { createTechnicalConfigurationBaselineWorkbookV2Model } from "@/lib/technical-configuration-baseline-excel-v2-contract"
 import { createTechnicalConfigurationBaselineWorkbookV2 } from "@/lib/technical-configuration-baseline-excel-v2-export"
+import { parseTechnicalConfigurationBaselineWorkbookV2Rows } from "@/lib/technical-configuration-baseline-excel-v2-parse-rows"
 
 describe("technical configuration baseline XLSX v2 parser identity", () => {
   it("preserves authoritative titles when optional hidden parent hints are missing or tampered", async () => {
@@ -253,30 +256,12 @@ describe("technical configuration baseline XLSX v2 parser identity", () => {
     }
   })
 
-  it("rejects partial, foreign, duplicate, and code-mismatched hidden identity", async () => {
+  it("rejects partial, duplicate, and wrong-kind hidden identity", async () => {
     const cases = [
       {
         expected: { code: "partial_identity", row: 3 },
         mutate: (configuration: ReturnType<typeof createWorkbookSheet>) => {
           configuration.getCell("F3").value = null
-        },
-      },
-      {
-        expected: { code: "foreign_identity", row: 2, column: "main_section_id" },
-        mutate: (configuration: ReturnType<typeof createWorkbookSheet>) => {
-          configuration.getCell("C2").value = "foreign-section"
-        },
-      },
-      {
-        expected: { code: "changed_criterion_code", row: 3, column: "criterion_code" },
-        mutate: (configuration: ReturnType<typeof createWorkbookSheet>) => {
-          configuration.getCell("F3").value = "TC-999"
-        },
-      },
-      {
-        expected: { code: "foreign_identity", row: 3, column: "criterion_id" },
-        mutate: (configuration: ReturnType<typeof createWorkbookSheet>) => {
-          configuration.getCell("C3").value = "section-2"
         },
       },
       {
@@ -308,6 +293,79 @@ describe("technical configuration baseline XLSX v2 parser identity", () => {
       const configuration = createWorkbookSheet(workbook)
       testCase.mutate(configuration)
       await expectWorkbookIssue(workbook, testCase.expected)
+    }
+  })
+
+  it("defers hidden identity membership and criterion-code ownership to server preview", async () => {
+    const workbook = await createTechnicalConfigurationBaselineWorkbookV2(
+      createTechnicalConfigurationBaselineWorkbookV2Model({
+        intent: "current-data",
+        metadata: METADATA,
+        groups: CURRENT_DATA_GROUPS,
+      })
+    )
+    const configuration = createWorkbookSheet(workbook)
+    configuration.getCell("C2").value = "foreign-section"
+    configuration.getCell("E3").value = "foreign-criterion"
+    configuration.getCell("F3").value = "TC-999"
+
+    const result = await parseWorkbook(workbook)
+    expectWorkbookV2Result(result)
+
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          row: 2,
+          row_type: "GROUP",
+          group_id: "foreign-section",
+        }),
+        expect.objectContaining({
+          row: 3,
+          row_type: "CRITERION",
+          criterion_id: "foreign-criterion",
+          criterion_code: "TC-999",
+        }),
+      ])
+    )
+  })
+
+  it("does not attach criteria after an invalid subgroup to the previous valid subgroup", async () => {
+    const workbook = await createTechnicalConfigurationBaselineWorkbookV2(
+      createTechnicalConfigurationBaselineWorkbookV2Model({
+        intent: "current-data",
+        metadata: METADATA,
+        groups: CURRENT_DATA_GROUPS,
+      })
+    )
+    const configuration = createWorkbookSheet(workbook)
+    const invalidSubgroup = Array.from(
+      { length: 7 },
+      (_, index) => configuration.getRow(4).getCell(index + 1).value
+    )
+    invalidSubgroup[4] = "criterion-direct"
+    invalidSubgroup[5] = "TC-001"
+    configuration.spliceRows(5, 0, invalidSubgroup)
+    const throwIssues = vi
+      .spyOn(parseContract, "throwIfTechnicalConfigurationBaselineWorkbookV2Issues")
+      .mockImplementation(() => undefined)
+
+    try {
+      const rows = parseTechnicalConfigurationBaselineWorkbookV2Rows(
+        configuration,
+        EXISTING_HIERARCHY
+      )
+
+      expect(rows).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            row: 6,
+            criterion_id: "criterion-subgroup",
+            subgroup_order: 1,
+          }),
+        ])
+      )
+    } finally {
+      throwIssues.mockRestore()
     }
   })
 })

--- a/src/lib/__tests__/technical-configuration-baseline-excel-v2-roundtrip.test.ts
+++ b/src/lib/__tests__/technical-configuration-baseline-excel-v2-roundtrip.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CURRENT_DATA_GROUPS,
+  METADATA,
+  toUploadedFile,
+} from "@/lib/__tests__/technical-configuration-baseline-excel-v2-parse-fixtures"
+import { createTechnicalConfigurationBaselineWorkbookV2Model } from "@/lib/technical-configuration-baseline-excel-v2-contract"
+import {
+  createTechnicalConfigurationBaselineWorkbookV2,
+  serializeTechnicalConfigurationBaselineWorkbookV2,
+} from "@/lib/technical-configuration-baseline-excel-v2-export"
+import {
+  parseTechnicalConfigurationBaselineWorkbookFile,
+  parseTechnicalConfigurationBaselineWorkbookV2,
+  TechnicalConfigurationBaselineWorkbookV2Error,
+} from "@/lib/technical-configuration-baseline-excel-v2-parse"
+
+const emptyHierarchy = {
+  groups: [],
+  subgroups: [],
+  criteria: [],
+} as const
+
+describe("technical configuration baseline XLSX v2 round-trip", () => {
+  it("accepts real serialized current-workbook bytes without client membership authority", async () => {
+    const model = createTechnicalConfigurationBaselineWorkbookV2Model({
+      intent: "current-data",
+      metadata: METADATA,
+      groups: CURRENT_DATA_GROUPS,
+    })
+    const bytes = await serializeTechnicalConfigurationBaselineWorkbookV2(model)
+
+    const result = await parseTechnicalConfigurationBaselineWorkbookFile(
+      toUploadedFile(bytes, "current-baseline.xlsx"),
+      { existingHierarchy: emptyHierarchy }
+    )
+
+    expect(result.format).toBe("v2")
+    expect(result.rows).toHaveLength(5)
+  })
+
+  it("reports the structural root error without dependent missing-parent cascades", async () => {
+    const workbook = await createTechnicalConfigurationBaselineWorkbookV2(
+      createTechnicalConfigurationBaselineWorkbookV2Model({
+        intent: "current-data",
+        metadata: METADATA,
+        groups: CURRENT_DATA_GROUPS,
+      })
+    )
+    const configuration = workbook.getWorksheet("Nhập cấu hình")!
+    configuration.getCell("E2").value = "criterion-on-section"
+
+    try {
+      await parseTechnicalConfigurationBaselineWorkbookV2(workbook, {
+        existingHierarchy: emptyHierarchy,
+      })
+      throw new Error("Expected workbook validation to fail")
+    } catch (error: unknown) {
+      if (!(error instanceof TechnicalConfigurationBaselineWorkbookV2Error)) throw error
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: "wrong_identity_kind",
+          row: 2,
+        }),
+      ])
+    }
+  })
+})

--- a/src/lib/technical-configuration-baseline-excel-v2-parse-rows.ts
+++ b/src/lib/technical-configuration-baseline-excel-v2-parse-rows.ts
@@ -26,10 +26,6 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
 ): TechnicalConfigurationBaselineWorkbookV2ParsedRow[] {
   const issues: TechnicalConfigurationBaselineWorkbookV2Issue[] = []
   const rows: TechnicalConfigurationBaselineWorkbookV2ParsedRow[] = []
-  const groupsById = new Map(existingHierarchy.groups.map((group) => [group.id, group]))
-  const subgroupsById = new Map(
-    existingHierarchy.subgroups.map((subgroup) => [subgroup.id, subgroup])
-  )
   const criteriaById = new Map(
     existingHierarchy.criteria.map((criterion) => [criterion.id, criterion])
   )
@@ -41,6 +37,11 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
   let criterionOrder = 0
   let hasCurrentGroup = false
   let hasCurrentSubgroup = false
+  let suppressMissingParentCascade = false
+  const invalidateSubgroupBoundary = () => {
+    hasCurrentSubgroup = false
+    suppressMissingParentCascade = true
+  }
   const populatedRowNumbers: number[] = []
 
   worksheet.eachRow((_worksheetRow, rowNumber) => {
@@ -72,6 +73,13 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
         column: "content",
         message: "NỘI DUNG YÊU CẦU là bắt buộc cho mọi dòng có dữ liệu.",
       })
+      if (rowType === "GROUP") {
+        hasCurrentGroup = false
+        hasCurrentSubgroup = false
+        suppressMissingParentCascade = true
+      } else if (rowType === "SUBGROUP") {
+        invalidateSubgroupBoundary()
+      }
       continue
     }
 
@@ -82,15 +90,21 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
           row: rowNumber,
           message: "Dòng mục chính chỉ được mang main_section_id.",
         })
+        hasCurrentGroup = false
+        hasCurrentSubgroup = false
+        suppressMissingParentCascade = true
         continue
       }
-      if (groupId && (!groupsById.has(groupId) || seenGroupIds.has(groupId))) {
+      if (groupId && seenGroupIds.has(groupId)) {
         issues.push({
-          code: groupsById.has(groupId) ? "duplicate_identity" : "foreign_identity",
+          code: "duplicate_identity",
           row: rowNumber,
           column: "main_section_id",
-          message: "main_section_id không hợp lệ cho baseline đích.",
+          message: "main_section_id bị lặp trong workbook.",
         })
+        hasCurrentGroup = false
+        hasCurrentSubgroup = false
+        suppressMissingParentCascade = true
         continue
       }
 
@@ -99,6 +113,7 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
       criterionOrder = 0
       hasCurrentGroup = true
       hasCurrentSubgroup = false
+      suppressMissingParentCascade = false
       if (groupId) seenGroupIds.add(groupId)
       rows.push({
         row: rowNumber,
@@ -110,15 +125,6 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
       continue
     }
 
-    if (!hasCurrentGroup) {
-      issues.push({
-        code: rowType === "SUBGROUP" ? "subgroup_without_section" : "content_before_section",
-        row: rowNumber,
-        message: "Mọi nội dung phải đứng sau một mục chính.",
-      })
-      continue
-    }
-
     if (rowType === "SUBGROUP") {
       if (criterionId || criterionCode) {
         issues.push({
@@ -126,6 +132,7 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
           row: rowNumber,
           message: "Dòng nhóm con không được mang identity tiêu chí.",
         })
+        invalidateSubgroupBoundary()
         continue
       }
       if (groupId !== null && subgroupId === null) {
@@ -134,29 +141,34 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
           row: rowNumber,
           message: "main_section_id không được tồn tại khi subgroup_id bị thiếu.",
         })
+        invalidateSubgroupBoundary()
         continue
       }
-      const existingSubgroup = subgroupId ? subgroupsById.get(subgroupId) : undefined
-      if (
-        subgroupId &&
-        (!existingSubgroup ||
-          (groupId !== null && existingSubgroup.group_id !== groupId) ||
-          seenSubgroupIds.has(subgroupId))
-      ) {
+      if (subgroupId && seenSubgroupIds.has(subgroupId)) {
         issues.push({
-          code:
-            existingSubgroup && seenSubgroupIds.has(subgroupId)
-              ? "duplicate_identity"
-              : "foreign_identity",
+          code: "duplicate_identity",
           row: rowNumber,
           column: "subgroup_id",
-          message: "subgroup_id không hợp lệ cho baseline đích.",
+          message: "subgroup_id bị lặp trong workbook.",
         })
+        invalidateSubgroupBoundary()
+        continue
+      }
+      if (!hasCurrentGroup) {
+        if (!suppressMissingParentCascade) {
+          issues.push({
+            code: "subgroup_without_section",
+            row: rowNumber,
+            message: "Mọi nội dung phải đứng sau một mục chính.",
+          })
+        }
+        invalidateSubgroupBoundary()
         continue
       }
 
       subgroupOrder += 1
       hasCurrentSubgroup = true
+      suppressMissingParentCascade = false
       if (subgroupId) seenSubgroupIds.add(subgroupId)
       rows.push({
         row: rowNumber,
@@ -179,25 +191,12 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
     }
 
     const existingCriterion = criterionId ? criteriaById.get(criterionId) : undefined
-    if (
-      criterionId &&
-      (!existingCriterion ||
-        existingCriterion.criterion_code !== criterionCode ||
-        (groupId !== null && existingCriterion.group_id !== groupId) ||
-        (subgroupId !== null && existingCriterion.subgroup_id !== subgroupId) ||
-        seenCriterionIds.has(criterionId))
-    ) {
-      const code =
-        existingCriterion && existingCriterion.criterion_code !== criterionCode
-          ? "changed_criterion_code"
-          : existingCriterion && seenCriterionIds.has(criterionId)
-            ? "duplicate_identity"
-            : "foreign_identity"
+    if (criterionId && seenCriterionIds.has(criterionId)) {
       issues.push({
-        code,
+        code: "duplicate_identity",
         row: rowNumber,
-        column: code === "changed_criterion_code" ? "criterion_code" : "criterion_id",
-        message: "Identity tiêu chí không hợp lệ cho baseline đích.",
+        column: "criterion_id",
+        message: "criterion_id bị lặp trong workbook.",
       })
       continue
     }
@@ -207,6 +206,17 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
         row: rowNumber,
         message: "Tiêu chí mới không được mang một phần hidden identity.",
       })
+      continue
+    }
+    if (suppressMissingParentCascade) continue
+    if (!hasCurrentGroup) {
+      if (!suppressMissingParentCascade) {
+        issues.push({
+          code: "content_before_section",
+          row: rowNumber,
+          message: "Mọi nội dung phải đứng sau một mục chính.",
+        })
+      }
       continue
     }
 


### PR DESCRIPTION
## Summary

- add the target-side \`Sao chép từ hồ sơ khác\` workflow beside baseline creation and on the existing version bar
- reuse the three Phase 1 RPCs for bounded source search, authoritative preview, and atomic apply with stale/conflict recovery
- harden XLSX round-trip identity handling, structural cascade suppression, cross-dossier guidance, and normalized filenames

## Deployment boundary

- Phase 1 RPC schema is deployed and synced through migration \`20260819062043\` on live and Oracle \`qltbyt_test\`
- this PR contains no SQL or migration changes
- existing same-dossier \`Sao chép thành bản nháp\` behavior is unchanged

## Verification

- \`node scripts/npm-run.js run format:check\`
- \`node scripts/npm-run.js run verify:no-explicit-any\`
- \`node scripts/npm-run.js run verify:dedupe\`
- \`node scripts/npm-run.js run verify:ts-docstrings\`
- \`node scripts/npm-run.js run typecheck\`
- focused Vitest: 9 files, 53 tests passed
- \`node scripts/npm-run.js run react-doctor\`: 91/100, one non-blocking giant-component warning
- \`openspec validate harden-technical-configuration-baseline-copy-and-excel --strict\`
- post-implementation subagent review: no remaining actionable findings

## Acceptance note

The repository has no Playwright/browser harness. Browser-facing acceptance is covered by focused RTL integration tests plus real serialized XLSX byte round-trip tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross‑dossier baseline copy and hardens XLSX v2 identity handling and workbook filenames. Previously users could only copy within a dossier and downloads used generic names; now users can copy from any locked source dossier with an authoritative preview, and downloads use normalized device/dossier‑based names.

- UI: Adds “Sao chép từ hồ sơ khác” beside “Khởi tạo cấu hình cơ sở” and on the version bar; disables it during conflicts/locked states. Lists locked sources with paginated search, excludes the target dossier, and shows authoritative preview with copy/delete/preserved counts. Requires explicit confirmation when replacing an existing draft, blocks closing while preview/apply is pending, preserves recoverable server errors, and resets cleanly on cancel.
- Workflow: New hook coordinates source list, preview, and atomic apply. Refreshes preview on stale_preview/concurrent_write_retry and rebuilds after stale_revision/target_draft_changed by asking the editor for the latest dossier revision and target draft. Maintains a monotonic cached dossier revision and invalidates ["technical-configurations"]; closes even if optional UI refresh fails.
- RPCs: Reuses Phase 1 endpoints via `BASELINE_RPC_FUNCTIONS`, including bounded paging. Preserves the paired‑null target draft in preview and carries the exact preview fingerprint and replacement confirmation into apply.
- XLSX: Defers hidden‑ID membership and criterion‑code ownership checks to server preview, suppresses dependent missing‑parent cascades after structural errors, and prevents criteria from attaching to a prior subgroup after an invalid subgroup. Adds a real byte round‑trip test to avoid false identity errors.
- Filenames: Replaces generic names with `buildTechnicalConfigurationBaselineWorkbookFilename`, producing device/dossier‑based names (e.g., “May_loc_than_Ho_so_khu_A_Phien_Ban_N.xlsx” and “Mau_…”). Normalizes Vietnamese text, uses safe separators, applies fallbacks, caps dynamic segments at 60 chars, and caps the final name at 160 chars. Download actions now pass device/dossier names.
- Import guidance: Cross‑dossier workbooks are rejected; the client error directs users to “Sao chép từ hồ sơ khác”. Same‑dossier “Sao chép thành bản nháp” is unchanged.
- Deployment: No schema changes. Requires the Phase 1 RPC schema already deployed and synced (migration 20260819062043).

<sup>Written for commit a9d97b3c4f2895826db322551458310d261cbaec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

