### PR TITLE
feat(db-gate): add baseline maintenance phase

### DIFF
--- a/docs/runbooks/db-quality-gate-oracle.md
+++ b/docs/runbooks/db-quality-gate-oracle.md
@@ -1,0 +1,155 @@
+# Database Quality Gate - Oracle baseline operations
+
+Tai lieu nay chi danh cho Oracle test VM. Live Supabase luon read-only trong
+toan bo quy trinh nay. Khong dung Supabase CLI, khong tao cron/timer tren Codex
+VPS, va khong chay migration candidate truc tiep tren `qltbyt_test`.
+
+## Bien moi truong tren Codex VPS
+
+```bash
+export ORACLE_DATABASE_QUALITY_GATE_HOST=149.118.148.179
+export ORACLE_DATABASE_QUALITY_GATE_SSH_USER=ubuntu
+export ORACLE_DATABASE_QUALITY_GATE_SSH_KEY_PATH=/root/Oracle/ssh-key-2026-05-13.key
+export ORACLE_DATABASE_QUALITY_GATE_SSH_KNOWN_HOSTS_PATH=/root/Oracle/known_hosts
+export ORACLE_DATABASE_QUALITY_GATE_SSH_HOST_KEY_FINGERPRINT='<pinned SHA256 fingerprint>'
+```
+
+Khong commit key, token, `.env`, `known_hosts`, confirmation tam, hoac output co
+credential. Executor chi chap nhan evidence directory co dinh
+`/opt/supabase-test/quality-gate/evidence`.
+
+## Checkout read-only tren Oracle
+
+Repository la public, nen checkout dung HTTPS khong credential. Chay script tai
+exact commit da land:
+
+```bash
+ssh -i /root/Oracle/ssh-key-2026-05-13.key ubuntu@149.118.148.179
+bash -s -- '<exact-40-character-commit>' \
+  < scripts/db-quality-gate/oracle-checkout.sh
+```
+
+Checkout nam tai `/opt/supabase-test/quality-gate/repository`, detached HEAD,
+origin co dinh, credential helper rong, va permissions khong mo cho group/other.
+
+## Tao confirmation tu live read-only
+
+1. Dung Supabase MCP `list_migrations` va read-only `execute_sql`.
+2. Lay `version`, `name`, va SHA-256 cua `statements[1]`.
+3. Doi chieu SHA-256 voi canonical local migration:
+
+```bash
+node -e "const fs=require('fs'),c=require('crypto');const s=fs.readFileSync(process.argv[1],'utf8').replace(/\n$/,'');console.log(c.createHash('sha256').update(s).digest('hex'))" \
+  supabase/migrations/<local-file>.sql
+```
+
+4. Tao file tam ngoai repository, vi du `/tmp/confirmed-live.json`:
+
+```json
+[
+  {
+    "liveName": "migration_name_without_timestamp",
+    "liveVersion": "20260819062043",
+    "path": "supabase/migrations/20260819031200_migration_name_without_timestamp.sql",
+    "sha256": "<canonical-local-and-live-SQL-sha256>"
+  }
+]
+```
+
+Khong dua migration vao confirmation neu live read-back thieu, name khac, hoac
+SQL hash khac. Trong truong hop do, dung lai voi trang thai reconciliation
+required.
+
+## Baseline health va bootstrap
+
+Lenh `health` dung cho bootstrap metadata lan dau va recovery sau interruption.
+No chi publish healthy khi Oracle high-water, live name, SQL hash, invalid index
+count va unvalidated constraint count deu khop.
+
+```bash
+node scripts/npm-run.js run db:quality-gate:baseline -- \
+  --operation health \
+  --run-id phase5-health-<unique-id> \
+  --subject-commit "$(git rev-parse HEAD)" \
+  --confirmations /tmp/confirmed-live.json
+```
+
+Atomic state nam tai
+`/opt/supabase-test/quality-gate/baseline/current.json`. Maintenance ghi file
+tam mode `0600`, atomic rename, sau do dat mode `0400`. Healthy va high-water
+luon nam trong cung mot snapshot.
+
+## Incremental catch-up
+
+Chi chay sau khi tung migration trong confirmation da duoc xac nhan applied
+live bang read-only MCP:
+
+```bash
+node scripts/npm-run.js run db:quality-gate:baseline -- \
+  --operation catch-up \
+  --run-id phase5-catch-up-<unique-id> \
+  --subject-commit "$(git rev-parse HEAD)" \
+  --confirmations /tmp/confirmed-live.json
+```
+
+Thu tu fail-closed:
+
+1. acquire global Oracle lease lock;
+2. publish `healthy=false` voi recovery target;
+3. apply exact canonical local SQL vao `qltbyt_test`;
+4. ghi exact live migration metadata;
+5. verify health va high-water;
+6. atomic publish healthy snapshot;
+7. release lock.
+
+Neu buoc 3-6 loi, baseline giu `healthy=false`. Khong rerun migration mot cach
+mu quang; dung `health` neu DB da khop exact target, hoac full refresh.
+
+## Serialized full refresh
+
+Full refresh restore vao `dq_baseline_refresh_<run-id>`, verify day du, roi moi
+rename/swap voi `qltbyt_test`. Baseline khong bao gio duoc publish healthy khi
+staging dang restore.
+
+```bash
+node scripts/npm-run.js run db:quality-gate:baseline -- \
+  --operation full-refresh \
+  --run-id phase5-refresh-<unique-id> \
+  --subject-commit "$(git rev-parse HEAD)" \
+  --confirmations /tmp/confirmed-live.json \
+  --dump /opt/supabase-test/backups/<verified-dump>.dump
+```
+
+Dump phai nam trong `/opt/supabase-test/backups`, da qua `pg_restore --list` va
+SHA-256 verification. Confirmation phai bao gom moi migration can catch-up tu
+dump den confirmed-live high-water.
+
+## Evidence va invalidation
+
+```bash
+ssh -i /root/Oracle/ssh-key-2026-05-13.key ubuntu@149.118.148.179 \
+  "find /opt/supabase-test/quality-gate/evidence -mindepth 2 -maxdepth 2 -name report.json -printf '%m %p\n' | sort"
+```
+
+Baseline-forward report chi reusable khi `outcome=PASS`, report high-water khop,
+va `inputHashes.baselineState` khop atomic state hash hien tai. Catch-up, refresh
+hoac health generation moi se invalidate evidence cu.
+
+## Recovery va cleanup
+
+Kiem tra state, lock va database tam:
+
+```bash
+ssh -i /root/Oracle/ssh-key-2026-05-13.key ubuntu@149.118.148.179 '
+  set -eu
+  cat /opt/supabase-test/quality-gate/baseline/current.json
+  find /opt/supabase-test/quality-gate/locks -mindepth 1 -maxdepth 2 -print
+  docker exec supabase-db psql -X -U postgres -d postgres -tA \
+    -c "select datname from pg_database where datname like '\''dq_%'\'' order by datname"
+'
+```
+
+Chi claim aggregate PASS khi static va baseline-forward PASS tren cung exact
+commit, report day du doc duoc, `dq_*` count bang 0, va lock directory sach.
+Bootstrap/fresh replay van la deferred non-blocking maintenance, khong duoc dua
+tro lai blocking pre-live gate.

--- a/openspec/changes/add-database-quality-gate/tasks.md
+++ b/openspec/changes/add-database-quality-gate/tasks.md
@@ -151,18 +151,18 @@ baseline catch-up, timer, or live database work.
 
 **Purpose:** Maintain the restored baseline and reusable evidence safely.
 
-- [ ] 5.1 Implement atomic baseline health and migration high-water evidence.
-- [ ] 5.2 Implement incremental catch-up using only migrations read-back as
+- [x] 5.1 Implement atomic baseline health and migration high-water evidence.
+- [x] 5.2 Implement incremental catch-up using only migrations read-back as
       already applied live.
-- [ ] 5.3 Implement serialized full-refresh recovery without publishing a
+- [x] 5.3 Implement serialized full-refresh recovery without publishing a
       half-restored baseline as healthy.
-- [ ] 5.4 Invalidate baseline-forward evidence whenever the baseline high-water
+- [x] 5.4 Invalidate baseline-forward evidence whenever the baseline high-water
       changes.
-- [ ] 5.5 Add fault-injection tests for failed catch-up, interrupted refresh,
+- [x] 5.5 Add fault-injection tests for failed catch-up, interrupted refresh,
       unexplained drift, stale health, and recovery.
-- [ ] 5.6 Add an Oracle read-only repository checkout and credential handling
+- [x] 5.6 Add an Oracle read-only repository checkout and credential handling
       that commits no secret.
-- [ ] 5.7 Document manual baseline health, catch-up, refresh, evidence lookup,
+- [x] 5.7 Document manual baseline health, catch-up, refresh, evidence lookup,
       and recovery operations.
 
 **Review boundary:** Oracle test-environment operations only. The current Codex

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-doctor:verbose": "npx -y -p node@22 -p react-doctor@latest react-doctor . --verbose -y --project . --offline --scope changed --base origin/main",
     "react-doctor:score": "npx -y -p node@22 -p react-doctor@latest react-doctor . --score --project . --offline --scope full",
     "db:quality-gate": "node scripts/db-quality-gate/run-cli.cjs",
+    "db:quality-gate:baseline": "node scripts/db-quality-gate/run-baseline-maintenance.cjs",
     "db:types": "node scripts/gen-types.js",
     "db:push": "supabase db push",
     "db:pull": "supabase db pull",

--- a/scripts/__tests__/database-quality-gate-baseline-maintenance.test.ts
+++ b/scripts/__tests__/database-quality-gate-baseline-maintenance.test.ts
@@ -1,0 +1,443 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  fixtureWithStaticMetadata,
+  repositoryHead,
+} from "./database-quality-gate-static-test-support"
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type MigrationIdentity = {
+  path: string
+  sha256: string
+}
+
+type ConfirmedLiveMigration = MigrationIdentity & {
+  liveName: string
+  liveVersion: string
+}
+
+type BaselineState = {
+  checkedAt: string
+  confirmedMigrations: ConfirmedLiveMigration[]
+  generation: string
+  healthy: boolean
+  migrationHighWater: string
+  recovery?: {
+    kind: "catch-up" | "full-refresh"
+    runId: string
+    targetMigrationHighWater: string
+  }
+  schemaVersion: 1
+  sourceCommit: string
+}
+
+type DatabaseObservation = {
+  healthy: boolean
+  invalidIndexCount: number
+  migrationHighWater: string
+  migrationRecords: Array<{
+    liveName: string
+    liveVersion: string
+    sqlSha256: string
+  }>
+  unvalidatedConstraintCount: number
+}
+
+type MaintenanceResult = {
+  outcome: "INCOMPLETE" | "PASS"
+  state: BaselineState
+}
+
+type MaintenanceExecutor = {
+  acquireLock: (runId: string) => boolean
+  applyMigrations: (databaseName: string, migrations: ConfirmedLiveMigration[]) => boolean
+  createRefreshDatabase: (databaseName: string) => boolean
+  dropDatabase: (databaseName: string) => boolean
+  inspectDatabase: (databaseName: string) => DatabaseObservation | undefined
+  publishState: (state: BaselineState) => boolean
+  readState: () => BaselineState | undefined
+  releaseLock: (runId: string) => boolean
+  restoreDump: (databaseName: string, dumpPath: string) => boolean
+  swapBaseline: (databaseName: string, retiredDatabaseName: string) => boolean
+}
+
+type BaselineMaintenanceModule = {
+  baselineStateHash: (state: BaselineState) => string
+  isBaselineForwardEvidenceReusable: (
+    report: {
+      baselineMigrationHighWater: string
+      inputHashes: Record<string, string>
+      outcome: "INCOMPLETE" | "PASS"
+    },
+    state: BaselineState
+  ) => boolean
+  runBaselineCatchUp: (input: {
+    checkedAt: string
+    confirmedMigrations: ConfirmedLiveMigration[]
+    executor: MaintenanceExecutor
+    repositoryRoot: string
+    runId: string
+    sourceCommit: string
+  }) => MaintenanceResult
+  runBaselineFullRefresh: (input: {
+    checkedAt: string
+    confirmedMigrations: ConfirmedLiveMigration[]
+    dumpPath: string
+    executor: MaintenanceExecutor
+    repositoryRoot: string
+    runId: string
+    sourceCommit: string
+  }) => MaintenanceResult
+  runBaselineHealthRecovery: (input: {
+    checkedAt: string
+    confirmedMigrations: ConfirmedLiveMigration[]
+    executor: MaintenanceExecutor
+    runId: string
+    sourceCommit: string
+  }) => MaintenanceResult
+}
+
+const migration: ConfirmedLiveMigration = {
+  liveName: "confirmed_live_change",
+  liveVersion: "20260819062043",
+  path: "supabase/migrations/20260819031200_confirmed_live_change.sql",
+  sha256: "17db4fd369edb9244b9f91d9aeed145c3d04ad8ba6e95d06247f07a63527d11a",
+}
+
+function confirmedFixture() {
+  const repository = fixtureWithStaticMetadata({
+    path: migration.path,
+    sql: "SELECT 1;\n",
+  })
+
+  return {
+    repositoryRoot: repository.root,
+    sourceCommit: repositoryHead(repository.root),
+  }
+}
+
+function healthyState(): BaselineState {
+  return {
+    checkedAt: "2026-08-18T12:00:00Z",
+    confirmedMigrations: [],
+    generation: "phase4-baseline",
+    healthy: true,
+    migrationHighWater: "20260816044031",
+    schemaVersion: 1,
+    sourceCommit: "a".repeat(40),
+  }
+}
+
+class FakeMaintenanceExecutor implements MaintenanceExecutor {
+  currentState: BaselineState | undefined = healthyState()
+  failAt?: string
+  observations = new Map<string, DatabaseObservation>([
+    [
+      "qltbyt_test",
+      {
+        healthy: true,
+        invalidIndexCount: 0,
+        migrationHighWater: migration.liveVersion,
+        migrationRecords: [
+          {
+            liveName: migration.liveName,
+            liveVersion: migration.liveVersion,
+            sqlSha256: migration.sha256,
+          },
+        ],
+        unvalidatedConstraintCount: 0,
+      },
+    ],
+    [
+      "dq_baseline_refresh_phase5_refresh",
+      {
+        healthy: true,
+        invalidIndexCount: 0,
+        migrationHighWater: migration.liveVersion,
+        migrationRecords: [
+          {
+            liveName: migration.liveName,
+            liveVersion: migration.liveVersion,
+            sqlSha256: migration.sha256,
+          },
+        ],
+        unvalidatedConstraintCount: 0,
+      },
+    ],
+  ])
+  operations: string[] = []
+
+  acquireLock(runId: string): boolean {
+    return this.record(`acquire-lock:${runId}`)
+  }
+
+  releaseLock(runId: string): boolean {
+    return this.record(`release-lock:${runId}`)
+  }
+
+  readState(): BaselineState | undefined {
+    this.operations.push("read-state")
+    return this.currentState === undefined ? undefined : structuredClone(this.currentState)
+  }
+
+  publishState(state: BaselineState): boolean {
+    const status = state.healthy ? "healthy" : "unhealthy"
+    if (!this.record(`publish-state:${status}:${state.migrationHighWater}`)) {
+      return false
+    }
+    this.currentState = structuredClone(state)
+    return true
+  }
+
+  inspectDatabase(databaseName: string): DatabaseObservation | undefined {
+    if (!this.record(`inspect:${databaseName}`)) {
+      return undefined
+    }
+    return structuredClone(this.observations.get(databaseName))
+  }
+
+  applyMigrations(databaseName: string, migrations: ConfirmedLiveMigration[]): boolean {
+    return this.record(
+      `apply:${databaseName}:${migrations.map((item) => item.liveVersion).join(",")}`
+    )
+  }
+
+  createRefreshDatabase(databaseName: string): boolean {
+    return this.record(`create-refresh:${databaseName}`)
+  }
+
+  restoreDump(databaseName: string, dumpPath: string): boolean {
+    return this.record(`restore:${databaseName}:${dumpPath}`)
+  }
+
+  swapBaseline(databaseName: string, retiredDatabaseName: string): boolean {
+    return this.record(`swap:${databaseName}:${retiredDatabaseName}`)
+  }
+
+  dropDatabase(databaseName: string): boolean {
+    return this.record(`drop:${databaseName}`)
+  }
+
+  private record(operation: string): boolean {
+    this.operations.push(operation)
+    return this.failAt !== operation
+  }
+}
+
+describe("database quality gate Phase 5 baseline maintenance", () => {
+  it("publishes health and live high-water atomically after confirmed catch-up", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    const fixture = confirmedFixture()
+
+    const result = source.runBaselineCatchUp({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [migration],
+      executor,
+      repositoryRoot: fixture.repositoryRoot,
+      runId: "phase5-catch-up",
+      sourceCommit: fixture.sourceCommit,
+    })
+
+    expect(result.outcome).toBe("PASS")
+    expect(result.state).toMatchObject({
+      confirmedMigrations: [migration],
+      healthy: true,
+      migrationHighWater: migration.liveVersion,
+    })
+    expect(executor.operations.indexOf("publish-state:unhealthy:20260816044031")).toBeLessThan(
+      executor.operations.indexOf(`apply:qltbyt_test:${migration.liveVersion}`)
+    )
+    expect(executor.operations.indexOf("inspect:qltbyt_test")).toBeLessThan(
+      executor.operations.indexOf(`publish-state:healthy:${migration.liveVersion}`)
+    )
+    expect(executor.operations.at(-1)).toBe("release-lock:phase5-catch-up")
+  })
+
+  it("rejects a catch-up migration that is not confirmed by exact live identity", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    const fixture = confirmedFixture()
+
+    const result = source.runBaselineCatchUp({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [{ ...migration, sha256: "0".repeat(64) }],
+      executor,
+      repositoryRoot: fixture.repositoryRoot,
+      runId: "phase5-unconfirmed",
+      sourceCommit: fixture.sourceCommit,
+    })
+
+    expect(result.outcome).toBe("INCOMPLETE")
+    expect(executor.operations).not.toContain(`apply:qltbyt_test:${migration.liveVersion}`)
+  })
+
+  it("leaves the baseline unhealthy when catch-up is interrupted", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    const fixture = confirmedFixture()
+    executor.failAt = `apply:qltbyt_test:${migration.liveVersion}`
+
+    const result = source.runBaselineCatchUp({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [migration],
+      executor,
+      repositoryRoot: fixture.repositoryRoot,
+      runId: "phase5-interrupted",
+      sourceCommit: fixture.sourceCommit,
+    })
+
+    expect(result.outcome).toBe("INCOMPLETE")
+    expect(result.state.healthy).toBe(false)
+    expect(result.state.recovery).toMatchObject({
+      kind: "catch-up",
+      targetMigrationHighWater: migration.liveVersion,
+    })
+    expect(executor.operations.at(-1)).toBe("release-lock:phase5-interrupted")
+  })
+
+  it("serializes full refresh and never publishes a staging database as healthy", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    const fixture = confirmedFixture()
+
+    const result = source.runBaselineFullRefresh({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [migration],
+      dumpPath: "/opt/supabase-test/backups/20260815T150001Z.dump",
+      executor,
+      repositoryRoot: fixture.repositoryRoot,
+      runId: "phase5-refresh",
+      sourceCommit: fixture.sourceCommit,
+    })
+
+    expect(result.outcome).toBe("PASS")
+    expect(executor.operations[0]).toBe("acquire-lock:phase5-refresh")
+    expect(executor.operations.indexOf("publish-state:unhealthy:20260816044031")).toBeLessThan(
+      executor.operations.indexOf("create-refresh:dq_baseline_refresh_phase5_refresh")
+    )
+    expect(
+      executor.operations.indexOf(
+        "swap:dq_baseline_refresh_phase5_refresh:dq_baseline_retired_phase5_refresh"
+      )
+    ).toBeLessThan(executor.operations.indexOf(`publish-state:healthy:${migration.liveVersion}`))
+    expect(executor.operations.at(-1)).toBe("release-lock:phase5-refresh")
+  })
+
+  it("keeps interrupted refresh unhealthy and does not swap the baseline", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    const fixture = confirmedFixture()
+    executor.failAt =
+      "restore:dq_baseline_refresh_phase5_refresh:/opt/supabase-test/backups/20260815T150001Z.dump"
+
+    const result = source.runBaselineFullRefresh({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [migration],
+      dumpPath: "/opt/supabase-test/backups/20260815T150001Z.dump",
+      executor,
+      repositoryRoot: fixture.repositoryRoot,
+      runId: "phase5-refresh",
+      sourceCommit: fixture.sourceCommit,
+    })
+
+    expect(result.outcome).toBe("INCOMPLETE")
+    expect(result.state.healthy).toBe(false)
+    expect(executor.operations.some((operation) => operation.startsWith("swap:"))).toBe(false)
+  })
+
+  it("recovers only when health evidence matches the confirmed live target", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    executor.currentState = {
+      ...healthyState(),
+      healthy: false,
+      recovery: {
+        kind: "catch-up",
+        runId: "phase5-interrupted",
+        targetMigrationHighWater: migration.liveVersion,
+      },
+    }
+    executor.observations.get("qltbyt_test")!.invalidIndexCount = 1
+
+    const stale = source.runBaselineHealthRecovery({
+      checkedAt: "2026-08-19T11:00:00Z",
+      confirmedMigrations: [migration],
+      executor,
+      runId: "phase5-recovery-stale",
+      sourceCommit: "f".repeat(40),
+    })
+
+    expect(stale.outcome).toBe("INCOMPLETE")
+    expect(stale.state.healthy).toBe(false)
+
+    executor.observations.get("qltbyt_test")!.invalidIndexCount = 0
+    const recovered = source.runBaselineHealthRecovery({
+      checkedAt: "2026-08-19T11:05:00Z",
+      confirmedMigrations: [migration],
+      executor,
+      runId: "phase5-recovery",
+      sourceCommit: "f".repeat(40),
+    })
+
+    expect(recovered.outcome).toBe("PASS")
+    expect(recovered.state.healthy).toBe(true)
+    expect(recovered.state.migrationHighWater).toBe(migration.liveVersion)
+  })
+
+  it("bootstraps the first healthy snapshot only from confirmed live evidence", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const executor = new FakeMaintenanceExecutor()
+    executor.currentState = undefined
+
+    const result = source.runBaselineHealthRecovery({
+      checkedAt: "2026-08-19T11:10:00Z",
+      confirmedMigrations: [migration],
+      executor,
+      runId: "phase5-bootstrap",
+      sourceCommit: "f".repeat(40),
+    })
+
+    expect(result.outcome).toBe("PASS")
+    expect(result.state).toMatchObject({
+      confirmedMigrations: [migration],
+      generation: "phase5-bootstrap",
+      healthy: true,
+      migrationHighWater: migration.liveVersion,
+    })
+  })
+
+  it("invalidates baseline-forward evidence when generation or high-water changes", async () => {
+    const source =
+      await loadDatabaseQualityGateModule<BaselineMaintenanceModule>("baseline-maintenance")
+    const state = healthyState()
+    const report = {
+      baselineMigrationHighWater: state.migrationHighWater,
+      inputHashes: {
+        baselineState: source.baselineStateHash(state),
+      },
+      outcome: "PASS" as const,
+    }
+
+    expect(source.isBaselineForwardEvidenceReusable(report, state)).toBe(true)
+    expect(
+      source.isBaselineForwardEvidenceReusable(report, {
+        ...state,
+        generation: "new-generation",
+      })
+    ).toBe(false)
+    expect(
+      source.isBaselineForwardEvidenceReusable(report, {
+        ...state,
+        migrationHighWater: migration.liveVersion,
+      })
+    ).toBe(false)
+  })
+})

--- a/scripts/__tests__/database-quality-gate-baseline-state.test.ts
+++ b/scripts/__tests__/database-quality-gate-baseline-state.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type BaselineStateModule = {
+  parseBaselineState: (value: unknown) =>
+    | {
+        confirmedMigrations: Array<{ liveVersion: string }>
+        healthy: boolean
+        migrationHighWater: string
+      }
+    | undefined
+}
+
+const confirmation = {
+  liveName: "confirmed_live_change",
+  liveVersion: "20260819062043",
+  path: "supabase/migrations/20260819031200_confirmed_live_change.sql",
+  sha256: "a".repeat(64),
+}
+
+function healthyState() {
+  return {
+    checkedAt: "2026-08-19T11:00:00Z",
+    confirmedMigrations: [confirmation],
+    generation: "phase5-baseline",
+    healthy: true,
+    migrationHighWater: confirmation.liveVersion,
+    schemaVersion: 1,
+    sourceCommit: "b".repeat(40),
+  }
+}
+
+describe("database quality gate Phase 5 atomic baseline state", () => {
+  it("accepts one healthy snapshot whose high-water matches its confirmations", async () => {
+    const source = await loadDatabaseQualityGateModule<BaselineStateModule>("baseline-state")
+
+    expect(source.parseBaselineState(healthyState())).toMatchObject({
+      confirmedMigrations: [confirmation],
+      healthy: true,
+      migrationHighWater: confirmation.liveVersion,
+    })
+  })
+
+  it("rejects healthy state with stale high-water or an active recovery marker", async () => {
+    const source = await loadDatabaseQualityGateModule<BaselineStateModule>("baseline-state")
+
+    expect(
+      source.parseBaselineState({
+        ...healthyState(),
+        migrationHighWater: "20260816044031",
+      })
+    ).toBeUndefined()
+    expect(
+      source.parseBaselineState({
+        ...healthyState(),
+        recovery: {
+          kind: "catch-up",
+          runId: "interrupted",
+          targetMigrationHighWater: confirmation.liveVersion,
+        },
+      })
+    ).toBeUndefined()
+  })
+
+  it("accepts an unhealthy recovery snapshot but rejects unexplained unhealthy state", async () => {
+    const source = await loadDatabaseQualityGateModule<BaselineStateModule>("baseline-state")
+    const recovery = {
+      kind: "full-refresh",
+      runId: "phase5-refresh",
+      targetMigrationHighWater: confirmation.liveVersion,
+    }
+
+    expect(
+      source.parseBaselineState({
+        ...healthyState(),
+        healthy: false,
+        recovery,
+      })
+    ).toMatchObject({ healthy: false, recovery })
+    expect(
+      source.parseBaselineState({
+        ...healthyState(),
+        confirmedMigrations: [],
+        healthy: false,
+        migrationHighWater: "unavailable",
+      })
+    ).toBeUndefined()
+  })
+})

--- a/scripts/__tests__/database-quality-gate-oracle-baseline-maintenance-executor.test.ts
+++ b/scripts/__tests__/database-quality-gate-oracle-baseline-maintenance-executor.test.ts
@@ -39,6 +39,10 @@ type MaintenanceExecutorModule = {
   }
 }
 
+type BaselineSqlModule = {
+  BASELINE_OBSERVATION_QUERY: string
+}
+
 const migration = {
   content: "SELECT 1;",
   liveName: "confirmed_live_change",
@@ -48,6 +52,14 @@ const migration = {
 }
 
 describe("database quality gate Oracle baseline maintenance executor", () => {
+  it("normalizes migration SQL and excludes Supabase-managed schemas from health debt", async () => {
+    const source = await loadDatabaseQualityGateModule<BaselineSqlModule>("oracle-baseline-sql")
+
+    expect(source.BASELINE_OBSERVATION_QUERY).toContain("regexp_replace")
+    expect(source.BASELINE_OBSERVATION_QUERY).toContain("replace(COALESCE(statements[1], '')")
+    expect(source.BASELINE_OBSERVATION_QUERY).toContain("'realtime'")
+  })
+
   it("publishes one atomic state file without embedding credentials", async () => {
     const source = await loadDatabaseQualityGateModule<MaintenanceExecutorModule>(
       "oracle-baseline-maintenance-executor"

--- a/scripts/__tests__/database-quality-gate-oracle-baseline-maintenance-executor.test.ts
+++ b/scripts/__tests__/database-quality-gate-oracle-baseline-maintenance-executor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+
+import { commandRecorder, executorInput } from "./database-quality-gate-oracle-test-support"
+import type { CommandInput, CommandResult } from "./database-quality-gate-oracle-test-support"
+import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
+
+type MaintenanceExecutorModule = {
+  createOracleBaselineMaintenanceExecutor: (input: {
+    command: (input: CommandInput) => CommandResult
+    config: ReturnType<typeof executorInput>["config"]
+  }) => {
+    applyMigrations: (
+      databaseName: string,
+      migrations: Array<{
+        content: string
+        liveName: string
+        liveVersion: string
+        path: string
+        sha256: string
+      }>
+    ) => boolean
+    createRefreshDatabase: (databaseName: string) => boolean
+    publishState: (state: {
+      checkedAt: string
+      confirmedMigrations: Array<{
+        liveName: string
+        liveVersion: string
+        path: string
+        sha256: string
+      }>
+      generation: string
+      healthy: boolean
+      migrationHighWater: string
+      schemaVersion: 1
+      sourceCommit: string
+    }) => boolean
+    restoreDump: (databaseName: string, dumpPath: string) => boolean
+    swapBaseline: (databaseName: string, retiredDatabaseName: string) => boolean
+  }
+}
+
+const migration = {
+  content: "SELECT 1;",
+  liveName: "confirmed_live_change",
+  liveVersion: "20260819062043",
+  path: "supabase/migrations/20260819031200_confirmed_live_change.sql",
+  sha256: "17db4fd369edb9244b9f91d9aeed145c3d04ad8ba6e95d06247f07a63527d11a",
+}
+
+describe("database quality gate Oracle baseline maintenance executor", () => {
+  it("publishes one atomic state file without embedding credentials", async () => {
+    const source = await loadDatabaseQualityGateModule<MaintenanceExecutorModule>(
+      "oracle-baseline-maintenance-executor"
+    )
+    const recorder = commandRecorder()
+    const executor = source.createOracleBaselineMaintenanceExecutor(executorInput(recorder.command))
+
+    expect(
+      executor.publishState({
+        checkedAt: "2026-08-19T11:00:00Z",
+        confirmedMigrations: [migration],
+        generation: "phase5-state",
+        healthy: true,
+        migrationHighWater: migration.liveVersion,
+        schemaVersion: 1,
+        sourceCommit: "a".repeat(40),
+      })
+    ).toBe(true)
+
+    const command = recorder.commands.at(-1)
+    expect(command?.arguments.at(-1)).toContain("mv -f")
+    expect(command?.arguments.at(-1)).toContain("/baseline/current.json")
+    expect(command?.arguments.at(-1)).not.toContain("password")
+    expect(command?.input).toContain(`"migrationHighWater":"${migration.liveVersion}"`)
+  })
+
+  it("applies only exact confirmed content and records the live version separately", async () => {
+    const source = await loadDatabaseQualityGateModule<MaintenanceExecutorModule>(
+      "oracle-baseline-maintenance-executor"
+    )
+    const recorder = commandRecorder()
+    const executor = source.createOracleBaselineMaintenanceExecutor(executorInput(recorder.command))
+
+    expect(executor.applyMigrations("qltbyt_test", [migration])).toBe(true)
+    expect(
+      executor.applyMigrations("qltbyt_test", [{ ...migration, sha256: "0".repeat(64) }])
+    ).toBe(false)
+
+    const stdin = recorder.commands.map((command) => command.input ?? "").join("\n")
+    expect(stdin).toContain("SELECT 1;")
+    expect(stdin).toContain(migration.liveVersion)
+    expect(stdin).toContain(migration.liveName)
+  })
+
+  it("restores only into a fixed refresh database before an explicit swap", async () => {
+    const source = await loadDatabaseQualityGateModule<MaintenanceExecutorModule>(
+      "oracle-baseline-maintenance-executor"
+    )
+    const recorder = commandRecorder()
+    const executor = source.createOracleBaselineMaintenanceExecutor(executorInput(recorder.command))
+    const refreshDatabase = "dq_baseline_refresh_phase5"
+    const retiredDatabase = "dq_baseline_retired_phase5"
+
+    expect(executor.createRefreshDatabase(refreshDatabase)).toBe(true)
+    expect(
+      executor.restoreDump(refreshDatabase, "/opt/supabase-test/backups/20260815T150001Z.dump")
+    ).toBe(true)
+    expect(executor.swapBaseline(refreshDatabase, retiredDatabase)).toBe(true)
+
+    const commands = recorder.commands.map(
+      (command) => `${command.arguments.at(-1) ?? ""}\n${command.input ?? ""}`
+    )
+    expect(commands.join("\n")).toContain("TEMPLATE template0")
+    expect(commands.join("\n")).toContain("pg_restore --single-transaction --exit-on-error")
+    expect(commands.join("\n")).toContain('ALTER DATABASE "qltbyt_test" RENAME TO')
+    expect(commands.join("\n")).not.toContain("supabase db")
+  })
+})

--- a/scripts/__tests__/database-quality-gate-oracle-remote-executor.test.ts
+++ b/scripts/__tests__/database-quality-gate-oracle-remote-executor.test.ts
@@ -4,20 +4,9 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
+import { commandRecorder, executorInput } from "./database-quality-gate-oracle-test-support"
+import type { CommandInput, CommandResult } from "./database-quality-gate-oracle-test-support"
 import { loadDatabaseQualityGateModule } from "./database-quality-gate-test-support"
-
-type CommandInput = {
-  arguments: string[]
-  input?: string
-  timeoutMs: number
-}
-
-type CommandResult = {
-  exitCode: number
-  stderr: string
-  stdout: string
-  timedOut: boolean
-}
 
 type OracleRemoteExecutorModule = {
   createOracleRemoteExecutor: (input: {
@@ -74,84 +63,6 @@ type OracleRemoteContractModule = {
   ) => Record<string, unknown> | undefined
 }
 
-function commandRecorder() {
-  const commands: CommandInput[] = []
-
-  return {
-    command(input: CommandInput): CommandResult {
-      commands.push(input)
-      const remoteCommand = input.arguments.at(-1) ?? ""
-      const fullCommand = `${remoteCommand}\n${input.input ?? ""}`
-
-      if (remoteCommand.includes("df -Pk")) {
-        return {
-          exitCode: 0,
-          stderr: "",
-          stdout:
-            "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/vda1 100 10 90 10% /\n",
-          timedOut: false,
-        }
-      }
-      if (remoteCommand.includes("docker inspect")) {
-        return {
-          exitCode: 0,
-          stderr: "",
-          stdout: "true\n",
-          timedOut: false,
-        }
-      }
-      if (fullCommand.includes("baseline_exists")) {
-        return {
-          exitCode: 0,
-          stderr: "",
-          stdout: "true\n",
-          timedOut: false,
-        }
-      }
-      if (fullCommand.includes("schema_migrations")) {
-        return {
-          exitCode: 0,
-          stderr: "",
-          stdout: '["20270101000000"]\n',
-          timedOut: false,
-        }
-      }
-      if (fullCommand.includes("pg_database") && fullCommand.includes("left(datname")) {
-        return {
-          exitCode: 0,
-          stderr: "",
-          stdout: "dq_stale_run\n",
-          timedOut: false,
-        }
-      }
-
-      return {
-        exitCode: 0,
-        stderr: "",
-        stdout: "",
-        timedOut: false,
-      }
-    },
-    commands,
-  }
-}
-
-function executorInput(command: (input: CommandInput) => CommandResult) {
-  return {
-    command,
-    config: {
-      containerName: "supabase-db",
-      evidenceDirectory: "/opt/supabase-test/quality-gate/evidence",
-      host: "oracle.test",
-      minimumFreeDiskKilobytes: 64,
-      sshHostKeyFingerprint: "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      sshKeyPath: "/tmp/oracle-test.key",
-      sshKnownHostsPath: "/tmp/oracle-test.known_hosts",
-      sshUser: "ubuntu",
-    },
-  }
-}
-
 describe("database quality gate Oracle remote executor", () => {
   it("fails closed for unpinned Oracle configuration or an evidence-directory escape", async () => {
     const source =
@@ -206,7 +117,7 @@ describe("database quality gate Oracle remote executor", () => {
     )
 
     expect(preflight.status).toBe("ok")
-    expect(preflight.value?.baseline).toEqual({
+    expect(preflight.value?.baseline).toMatchObject({
       healthy: true,
       migrationVersions: ["20270101000000"],
     })

--- a/scripts/__tests__/database-quality-gate-oracle-test-support.ts
+++ b/scripts/__tests__/database-quality-gate-oracle-test-support.ts
@@ -1,0 +1,125 @@
+export type CommandInput = {
+  arguments: string[]
+  input?: string
+  timeoutMs: number
+}
+
+export type CommandResult = {
+  exitCode: number
+  stderr: string
+  stdout: string
+  timedOut: boolean
+}
+
+export function commandRecorder() {
+  const commands: CommandInput[] = []
+
+  return {
+    command(input: CommandInput): CommandResult {
+      commands.push(input)
+      const remoteCommand = input.arguments.at(-1) ?? ""
+      const fullCommand = `${remoteCommand}\n${input.input ?? ""}`
+
+      if (remoteCommand.includes("df -Pk")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout:
+            "Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/vda1 100 10 90 10% /\n",
+          timedOut: false,
+        }
+      }
+      if (remoteCommand.includes("docker inspect")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: "true\n",
+          timedOut: false,
+        }
+      }
+      if (fullCommand.includes("baseline_exists")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: "true\n",
+          timedOut: false,
+        }
+      }
+      if (remoteCommand.includes("/baseline/current.json")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: `${JSON.stringify({
+            checkedAt: "2026-08-19T11:00:00Z",
+            confirmedMigrations: [
+              {
+                liveName: "already_in_baseline",
+                liveVersion: "20270101000000",
+                path: "supabase/migrations/20270101000000_already_in_baseline.sql",
+                sha256: "a".repeat(64),
+              },
+            ],
+            generation: "phase5-baseline",
+            healthy: true,
+            migrationHighWater: "20270101000000",
+            schemaVersion: 1,
+            sourceCommit: "a".repeat(40),
+          })}\n`,
+          timedOut: false,
+        }
+      }
+      if (fullCommand.includes("schema_migrations")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: `${JSON.stringify({
+            healthy: true,
+            invalidIndexCount: 0,
+            migrationHighWater: "20270101000000",
+            migrationRecords: [
+              {
+                liveName: "already_in_baseline",
+                liveVersion: "20270101000000",
+                sqlSha256: "a".repeat(64),
+              },
+            ],
+            unvalidatedConstraintCount: 0,
+          })}\n`,
+          timedOut: false,
+        }
+      }
+      if (fullCommand.includes("pg_database") && fullCommand.includes("left(datname")) {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: "dq_stale_run\n",
+          timedOut: false,
+        }
+      }
+
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: "",
+        timedOut: false,
+      }
+    },
+    commands,
+  }
+}
+
+export function executorInput(command: (input: CommandInput) => CommandResult) {
+  return {
+    command,
+    config: {
+      containerName: "supabase-db",
+      evidenceDirectory: "/opt/supabase-test/quality-gate/evidence",
+      host: "oracle.test",
+      minimumFreeDiskKilobytes: 64,
+      sshHostKeyFingerprint: "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      sshKeyPath: "/tmp/oracle-test.key",
+      sshKnownHostsPath: "/tmp/oracle-test.known_hosts",
+      sshUser: "ubuntu",
+    },
+  }
+}

--- a/scripts/__tests__/database-quality-gate-phase-3-artifacts.test.ts
+++ b/scripts/__tests__/database-quality-gate-phase-3-artifacts.test.ts
@@ -122,17 +122,17 @@ describe("database quality gate Phase 3 artifacts", () => {
     expect(sqlTests).toBeDefined()
     expect(registeredPaths).toEqual(currentPaths)
     expect(classificationCount(sqlTests?.tests.map((test) => test.purpose) ?? [])).toEqual({
-      concurrency: 3,
+      concurrency: 4,
       invariant: 5,
       "live-acceptance": 1,
       performance: 3,
-      "phase-gate": 30,
+      "phase-gate": 31,
       smoke: 47,
     })
     expect(classificationCount(sqlTests?.tests.map((test) => test.safety) ?? [])).toEqual({
-      "default-safe": 64,
+      "default-safe": 65,
       "live-only": 1,
-      "opt-in": 24,
+      "opt-in": 25,
     })
   })
 
@@ -140,7 +140,7 @@ describe("database quality gate Phase 3 artifacts", () => {
     const expectedState = await loadDatabaseQualityGateModule<ExpectedStateModule>("expected-state")
     const selected = expectedState.selectDefaultSafeSqlTests(readJson(SQL_TESTS_PATH))
 
-    expect(selected).toHaveLength(64)
+    expect(selected).toHaveLength(65)
     expect(selected.map((test) => test.path)).not.toEqual(
       expect.arrayContaining([
         "supabase/tests/technical_configuration_baseline_document_urls_phase_gate.sql",

--- a/scripts/db-quality-gate/baseline-maintenance-cli.ts
+++ b/scripts/db-quality-gate/baseline-maintenance-cli.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs"
+
+import {
+  runBaselineCatchUp,
+  runBaselineFullRefresh,
+  runBaselineHealthRecovery,
+} from "./baseline-maintenance"
+import type { ConfirmedLiveMigration } from "./baseline-state"
+import { validConfirmation } from "./baseline-state"
+import { currentHeadCommit } from "./git-evidence"
+import { oracleBaselineMaintenanceExecutorFromEnvironment } from "./oracle-baseline-maintenance-executor"
+import { stableJsonStringify } from "./serialization"
+
+type Operation = "catch-up" | "full-refresh" | "health"
+
+type CommandOptions = {
+  checkedAt: string
+  confirmationsPath: string
+  dumpPath?: string
+  operation: Operation
+  runId: string
+  subjectCommit?: string
+}
+
+const OPTION_NAMES = new Set([
+  "--checked-at",
+  "--confirmations",
+  "--dump",
+  "--operation",
+  "--run-id",
+  "--subject-commit",
+])
+
+function parseOptions(args: string[]): CommandOptions | undefined {
+  const values = new Map<string, string>()
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index]
+    const value = args[index + 1]
+    if (!OPTION_NAMES.has(option) || value === undefined || values.has(option)) {
+      return undefined
+    }
+    values.set(option, value)
+  }
+  const operation = values.get("--operation")
+  const runId = values.get("--run-id")
+  const confirmationsPath = values.get("--confirmations")
+  if (
+    (operation !== "catch-up" && operation !== "full-refresh" && operation !== "health") ||
+    runId === undefined ||
+    confirmationsPath === undefined ||
+    !/^[a-z0-9][a-z0-9_-]*$/u.test(runId)
+  ) {
+    return undefined
+  }
+  const dumpPath = values.get("--dump")
+  if (operation === "full-refresh" && dumpPath === undefined) {
+    return undefined
+  }
+
+  return {
+    checkedAt: values.get("--checked-at") ?? new Date().toISOString(),
+    confirmationsPath,
+    dumpPath,
+    operation,
+    runId,
+    subjectCommit: values.get("--subject-commit"),
+  }
+}
+
+function readConfirmations(filePath: string): ConfirmedLiveMigration[] | undefined {
+  let value: unknown
+  try {
+    value = JSON.parse(readFileSync(filePath, "utf8")) as unknown
+  } catch {
+    return undefined
+  }
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => !isRecord(item))) {
+    return undefined
+  }
+  const confirmations: ConfirmedLiveMigration[] = []
+  for (const item of value) {
+    const confirmation = {
+      liveName: item.liveName,
+      liveVersion: item.liveVersion,
+      path: item.path,
+      sha256: item.sha256,
+    }
+    if (
+      typeof confirmation.liveName !== "string" ||
+      typeof confirmation.liveVersion !== "string" ||
+      typeof confirmation.path !== "string" ||
+      typeof confirmation.sha256 !== "string" ||
+      !validConfirmation(confirmation)
+    ) {
+      return undefined
+    }
+    confirmations.push(confirmation)
+  }
+  return confirmations
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Runs one explicitly requested baseline maintenance operation. */
+export function runBaselineMaintenanceCommand(
+  args: string[],
+  repositoryRoot = process.cwd()
+): { exitCode: 0 | 2; stdout: string } {
+  const options = parseOptions(args)
+  const confirmations =
+    options === undefined ? undefined : readConfirmations(options.confirmationsPath)
+  const executor = oracleBaselineMaintenanceExecutorFromEnvironment()
+  const subjectCommit = options?.subjectCommit ?? currentHeadCommit(repositoryRoot) ?? undefined
+  if (
+    options === undefined ||
+    confirmations === undefined ||
+    executor === undefined ||
+    subjectCommit === undefined
+  ) {
+    return {
+      exitCode: 2,
+      stdout: `${stableJsonStringify({
+        error: "Invalid or unavailable baseline maintenance inputs",
+        outcome: "INCOMPLETE",
+      })}\n`,
+    }
+  }
+
+  const common = {
+    checkedAt: options.checkedAt,
+    confirmedMigrations: confirmations,
+    executor,
+    runId: options.runId,
+    sourceCommit: subjectCommit,
+  }
+  const result =
+    options.operation === "health"
+      ? runBaselineHealthRecovery(common)
+      : options.operation === "catch-up"
+        ? runBaselineCatchUp({
+            ...common,
+            repositoryRoot,
+          })
+        : runBaselineFullRefresh({
+            ...common,
+            dumpPath: options.dumpPath as string,
+            repositoryRoot,
+          })
+
+  return {
+    exitCode: result.outcome === "PASS" ? 0 : 2,
+    stdout: `${stableJsonStringify(result)}\n`,
+  }
+}

--- a/scripts/db-quality-gate/baseline-maintenance.ts
+++ b/scripts/db-quality-gate/baseline-maintenance.ts
@@ -1,0 +1,320 @@
+import {
+  BASELINE_STATE_SCHEMA_VERSION,
+  compareConfirmedMigrations,
+  observationMatches,
+  ORACLE_BASELINE_DATABASE,
+  validConfirmation,
+} from "./baseline-state"
+import type {
+  BaselineRecovery,
+  BaselineState,
+  ConfirmedLiveMigration,
+  DatabaseObservation,
+} from "./baseline-state"
+import { readFileAtCommit } from "./git-evidence"
+import { canonicalizeMigrationContent, migrationContentSha256 } from "./migration-source"
+export { baselineStateHash, isBaselineForwardEvidenceReusable } from "./baseline-state"
+export type { BaselineState, ConfirmedLiveMigration } from "./baseline-state"
+
+export type ConfirmedMigrationInput = ConfirmedLiveMigration & {
+  content: string
+}
+
+export type BaselineMaintenanceExecutor = {
+  acquireLock: (runId: string) => boolean
+  applyMigrations: (databaseName: string, migrations: ConfirmedMigrationInput[]) => boolean
+  createRefreshDatabase: (databaseName: string) => boolean
+  dropDatabase: (databaseName: string) => boolean
+  inspectDatabase: (databaseName: string) => DatabaseObservation | undefined
+  publishState: (state: BaselineState) => boolean
+  readState: () => BaselineState | undefined
+  releaseLock: (runId: string) => boolean
+  restoreDump: (databaseName: string, dumpPath: string) => boolean
+  swapBaseline: (databaseName: string, retiredDatabaseName: string) => boolean
+}
+
+type MaintenanceResult = {
+  outcome: "INCOMPLETE" | "PASS"
+  state: BaselineState
+}
+
+type MaintenanceInput = {
+  checkedAt: string
+  confirmedMigrations: ConfirmedLiveMigration[]
+  executor: BaselineMaintenanceExecutor
+  runId: string
+  sourceCommit: string
+}
+
+type RepositoryMaintenanceInput = MaintenanceInput & {
+  repositoryRoot: string
+}
+
+function unavailableState(input: MaintenanceInput): BaselineState {
+  return {
+    checkedAt: input.checkedAt,
+    confirmedMigrations: [],
+    generation: input.runId,
+    healthy: false,
+    migrationHighWater: "unavailable",
+    schemaVersion: BASELINE_STATE_SCHEMA_VERSION,
+    sourceCommit: input.sourceCommit,
+  }
+}
+
+function unhealthyState(
+  current: BaselineState,
+  input: MaintenanceInput,
+  kind: BaselineRecovery["kind"],
+  targetMigrationHighWater: string
+): BaselineState {
+  return {
+    ...current,
+    checkedAt: input.checkedAt,
+    healthy: false,
+    recovery: {
+      kind,
+      runId: input.runId,
+      targetMigrationHighWater,
+    },
+    sourceCommit: input.sourceCommit,
+  }
+}
+
+function healthyState(
+  input: MaintenanceInput,
+  confirmedMigrations: ConfirmedLiveMigration[]
+): BaselineState {
+  return {
+    checkedAt: input.checkedAt,
+    confirmedMigrations: [...confirmedMigrations].sort(compareConfirmedMigrations),
+    generation: input.runId,
+    healthy: true,
+    migrationHighWater: confirmedMigrations.at(-1)?.liveVersion ?? "unavailable",
+    schemaVersion: BASELINE_STATE_SCHEMA_VERSION,
+    sourceCommit: input.sourceCommit,
+  }
+}
+
+function readConfirmedMigrationInputs(
+  input: RepositoryMaintenanceInput
+): ConfirmedMigrationInput[] | undefined {
+  const ordered = [...input.confirmedMigrations].sort(compareConfirmedMigrations)
+  const versions = new Set<string>()
+  const paths = new Set<string>()
+  const migrations: ConfirmedMigrationInput[] = []
+
+  for (const confirmation of ordered) {
+    if (
+      !validConfirmation(confirmation) ||
+      versions.has(confirmation.liveVersion) ||
+      paths.has(confirmation.path)
+    ) {
+      return undefined
+    }
+    const content = readFileAtCommit(input.repositoryRoot, input.sourceCommit, confirmation.path)
+    if (content === undefined || migrationContentSha256(content) !== confirmation.sha256) {
+      return undefined
+    }
+    versions.add(confirmation.liveVersion)
+    paths.add(confirmation.path)
+    migrations.push({
+      ...confirmation,
+      content: canonicalizeMigrationContent(content),
+    })
+  }
+
+  return migrations
+}
+
+function mergedConfirmations(
+  current: BaselineState,
+  additions: ConfirmedLiveMigration[]
+): ConfirmedLiveMigration[] | undefined {
+  const byPath = new Map(current.confirmedMigrations.map((item) => [item.path, item]))
+  for (const addition of additions) {
+    const existing = byPath.get(addition.path)
+    if (
+      existing !== undefined &&
+      (existing.sha256 !== addition.sha256 ||
+        existing.liveName !== addition.liveName ||
+        existing.liveVersion !== addition.liveVersion)
+    ) {
+      return undefined
+    }
+    byPath.set(addition.path, addition)
+  }
+
+  return [...byPath.values()].sort(compareConfirmedMigrations)
+}
+
+function lockedResult(
+  input: MaintenanceInput,
+  operation: () => MaintenanceResult
+): MaintenanceResult {
+  if (!input.executor.acquireLock(input.runId)) {
+    return {
+      outcome: "INCOMPLETE",
+      state: input.executor.readState() ?? unavailableState(input),
+    }
+  }
+
+  let result: MaintenanceResult
+  try {
+    result = operation()
+  } catch {
+    result = {
+      outcome: "INCOMPLETE",
+      state: input.executor.readState() ?? unavailableState(input),
+    }
+  }
+
+  if (!input.executor.releaseLock(input.runId)) {
+    return {
+      outcome: "INCOMPLETE",
+      state: result.state,
+    }
+  }
+  return result
+}
+
+/** Applies only exact local identities that were independently confirmed as applied live. */
+export function runBaselineCatchUp(input: RepositoryMaintenanceInput): MaintenanceResult {
+  return lockedResult(input, () => {
+    const current = input.executor.readState()
+    const migrations = readConfirmedMigrationInputs(input)
+    if (current === undefined || !current.healthy || migrations === undefined) {
+      return {
+        outcome: "INCOMPLETE",
+        state: current ?? unavailableState(input),
+      }
+    }
+    const confirmations = mergedConfirmations(current, migrations)
+    if (
+      confirmations === undefined ||
+      migrations.some((migration) => migration.liveVersion <= current.migrationHighWater)
+    ) {
+      return { outcome: "INCOMPLETE", state: current }
+    }
+
+    const targetHighWater = confirmations.at(-1)?.liveVersion ?? "unavailable"
+    const unhealthy = unhealthyState(current, input, "catch-up", targetHighWater)
+    if (!input.executor.publishState(unhealthy)) {
+      return { outcome: "INCOMPLETE", state: current }
+    }
+    if (
+      !input.executor.applyMigrations(ORACLE_BASELINE_DATABASE, migrations) ||
+      !observationMatches(input.executor.inspectDatabase(ORACLE_BASELINE_DATABASE), confirmations)
+    ) {
+      return { outcome: "INCOMPLETE", state: unhealthy }
+    }
+
+    const healthy = healthyState(input, confirmations)
+    return input.executor.publishState(healthy)
+      ? { outcome: "PASS", state: healthy }
+      : { outcome: "INCOMPLETE", state: unhealthy }
+  })
+}
+
+function refreshDatabaseName(kind: "refresh" | "retired", runId: string): string | undefined {
+  if (!/^[a-z0-9][a-z0-9_-]*$/u.test(runId)) {
+    return undefined
+  }
+  const normalized = runId.replaceAll("-", "_")
+  const value = `dq_baseline_${kind}_${normalized}`
+  return value.length <= 63 ? value : undefined
+}
+
+function validDumpPath(dumpPath: string): boolean {
+  return (
+    dumpPath.startsWith("/opt/supabase-test/backups/") &&
+    !dumpPath.split("/").includes("..") &&
+    dumpPath.endsWith(".dump")
+  )
+}
+
+/** Restores into a disposable database and swaps it in only after complete health verification. */
+export function runBaselineFullRefresh(
+  input: RepositoryMaintenanceInput & { dumpPath: string }
+): MaintenanceResult {
+  return lockedResult(input, () => {
+    const current = input.executor.readState()
+    const migrations = readConfirmedMigrationInputs(input)
+    const refreshDatabase = refreshDatabaseName("refresh", input.runId)
+    const retiredDatabase = refreshDatabaseName("retired", input.runId)
+    if (
+      current === undefined ||
+      migrations === undefined ||
+      refreshDatabase === undefined ||
+      retiredDatabase === undefined ||
+      !validDumpPath(input.dumpPath)
+    ) {
+      return {
+        outcome: "INCOMPLETE",
+        state: current ?? unavailableState(input),
+      }
+    }
+
+    const confirmations = [...migrations].sort(compareConfirmedMigrations)
+    const targetHighWater = confirmations.at(-1)?.liveVersion ?? "unavailable"
+    const unhealthy = unhealthyState(current, input, "full-refresh", targetHighWater)
+    if (
+      !input.executor.publishState(unhealthy) ||
+      !input.executor.createRefreshDatabase(refreshDatabase)
+    ) {
+      return { outcome: "INCOMPLETE", state: unhealthy }
+    }
+
+    let swapped = false
+    try {
+      if (
+        !input.executor.restoreDump(refreshDatabase, input.dumpPath) ||
+        !input.executor.applyMigrations(refreshDatabase, migrations) ||
+        !observationMatches(input.executor.inspectDatabase(refreshDatabase), confirmations) ||
+        !input.executor.swapBaseline(refreshDatabase, retiredDatabase)
+      ) {
+        return { outcome: "INCOMPLETE", state: unhealthy }
+      }
+      swapped = true
+      if (
+        !observationMatches(input.executor.inspectDatabase(ORACLE_BASELINE_DATABASE), confirmations)
+      ) {
+        return { outcome: "INCOMPLETE", state: unhealthy }
+      }
+      const healthy = healthyState(input, confirmations)
+      if (!input.executor.publishState(healthy)) {
+        return { outcome: "INCOMPLETE", state: unhealthy }
+      }
+      input.executor.dropDatabase(retiredDatabase)
+      return { outcome: "PASS", state: healthy }
+    } finally {
+      if (!swapped) {
+        input.executor.dropDatabase(refreshDatabase)
+      }
+    }
+  })
+}
+
+/** Republishes healthy state only after current Oracle facts match exact live confirmations. */
+export function runBaselineHealthRecovery(input: MaintenanceInput): MaintenanceResult {
+  return lockedResult(input, () => {
+    const current = input.executor.readState()
+    const confirmations = [...input.confirmedMigrations].sort(compareConfirmedMigrations)
+    if (
+      current?.healthy ||
+      confirmations.length === 0 ||
+      confirmations.some((confirmation) => !validConfirmation(confirmation)) ||
+      !observationMatches(input.executor.inspectDatabase(ORACLE_BASELINE_DATABASE), confirmations)
+    ) {
+      return {
+        outcome: "INCOMPLETE",
+        state: current ?? unavailableState(input),
+      }
+    }
+
+    const healthy = healthyState(input, confirmations)
+    return input.executor.publishState(healthy)
+      ? { outcome: "PASS", state: healthy }
+      : { outcome: "INCOMPLETE", state: current ?? unavailableState(input) }
+  })
+}

--- a/scripts/db-quality-gate/baseline-state.ts
+++ b/scripts/db-quality-gate/baseline-state.ts
@@ -1,0 +1,256 @@
+import path from "node:path"
+
+import { compareStrings, stableJsonSha256 } from "./serialization"
+import type { MigrationIdentity } from "./types"
+
+/** Version of the persisted Oracle baseline state contract. */
+export const BASELINE_STATE_SCHEMA_VERSION = 1 as const
+/** Persistent Oracle database used as the baseline-forward source. */
+export const ORACLE_BASELINE_DATABASE = "qltbyt_test"
+
+export type ConfirmedLiveMigration = MigrationIdentity & {
+  liveName: string
+  liveVersion: string
+}
+
+export type BaselineRecovery = {
+  kind: "catch-up" | "full-refresh"
+  runId: string
+  targetMigrationHighWater: string
+}
+
+export type BaselineState = {
+  checkedAt: string
+  confirmedMigrations: ConfirmedLiveMigration[]
+  generation: string
+  healthy: boolean
+  migrationHighWater: string
+  recovery?: BaselineRecovery
+  schemaVersion: typeof BASELINE_STATE_SCHEMA_VERSION
+  sourceCommit: string
+}
+
+export type DatabaseObservation = {
+  healthy: boolean
+  invalidIndexCount: number
+  migrationHighWater: string
+  migrationRecords: Array<{
+    liveName: string
+    liveVersion: string
+    sqlSha256: string
+  }>
+  unvalidatedConstraintCount: number
+}
+
+/** Parses database health facts without trusting remote JSON shape. */
+export function parseDatabaseObservation(value: unknown): DatabaseObservation | undefined {
+  if (
+    !isRecord(value) ||
+    value.healthy !== true ||
+    !Number.isSafeInteger(value.invalidIndexCount) ||
+    typeof value.migrationHighWater !== "string" ||
+    !/^(?:\d{14}|unavailable)$/u.test(value.migrationHighWater) ||
+    !Array.isArray(value.migrationRecords) ||
+    !Number.isSafeInteger(value.unvalidatedConstraintCount)
+  ) {
+    return undefined
+  }
+  const migrationRecords: DatabaseObservation["migrationRecords"] = []
+  for (const record of value.migrationRecords) {
+    if (
+      !isRecord(record) ||
+      typeof record.liveName !== "string" ||
+      typeof record.liveVersion !== "string" ||
+      !/^\d{14}$/u.test(record.liveVersion) ||
+      typeof record.sqlSha256 !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(record.sqlSha256)
+    ) {
+      return undefined
+    }
+    migrationRecords.push({
+      liveName: record.liveName,
+      liveVersion: record.liveVersion,
+      sqlSha256: record.sqlSha256,
+    })
+  }
+
+  return {
+    healthy: true,
+    invalidIndexCount: value.invalidIndexCount as number,
+    migrationHighWater: value.migrationHighWater,
+    migrationRecords,
+    unvalidatedConstraintCount: value.unvalidatedConstraintCount as number,
+  }
+}
+
+/** Orders confirmed migrations by their live migration version. */
+export function compareConfirmedMigrations(
+  left: ConfirmedLiveMigration,
+  right: ConfirmedLiveMigration
+): number {
+  return (
+    compareStrings(left.liveVersion, right.liveVersion) ||
+    compareStrings(left.path, right.path) ||
+    compareStrings(left.sha256, right.sha256)
+  )
+}
+
+function normalizedState(state: BaselineState): BaselineState {
+  const normalized: BaselineState = {
+    ...state,
+    confirmedMigrations: [...state.confirmedMigrations].sort(compareConfirmedMigrations),
+  }
+  if (normalized.recovery === undefined) {
+    delete normalized.recovery
+  }
+  return normalized
+}
+
+/** Hashes the atomic baseline snapshot used to invalidate reusable dynamic evidence. */
+export function baselineStateHash(state: BaselineState): string {
+  return stableJsonSha256(normalizedState(state))
+}
+
+/** Allows reuse only when both high-water and the complete atomic baseline snapshot still match. */
+export function isBaselineForwardEvidenceReusable(
+  report: {
+    baselineMigrationHighWater: string
+    inputHashes: Record<string, string>
+    outcome: "INCOMPLETE" | "PASS"
+  },
+  state: BaselineState
+): boolean {
+  return (
+    report.outcome === "PASS" &&
+    report.baselineMigrationHighWater === state.migrationHighWater &&
+    report.inputHashes.baselineState === baselineStateHash(state)
+  )
+}
+
+function migrationName(filePath: string): string | undefined {
+  return /^\d{14}_(.+)\.sql$/u.exec(path.posix.basename(filePath))?.[1]
+}
+
+/** Checks that a live migration confirmation has a complete, safe identity. */
+export function validConfirmation(confirmation: ConfirmedLiveMigration): boolean {
+  return (
+    /^\d{14}$/u.test(confirmation.liveVersion) &&
+    /^[a-z0-9_]+$/u.test(confirmation.liveName) &&
+    /^[a-f0-9]{64}$/u.test(confirmation.sha256) &&
+    /^supabase\/migrations\/\d{14}_.+\.sql$/u.test(confirmation.path) &&
+    migrationName(confirmation.path) === confirmation.liveName
+  )
+}
+
+/** Checks whether an Oracle database observation matches confirmed migration state. */
+export function observationMatches(
+  observation: DatabaseObservation | undefined,
+  confirmations: ConfirmedLiveMigration[]
+): boolean {
+  if (
+    observation === undefined ||
+    !observation.healthy ||
+    observation.invalidIndexCount !== 0 ||
+    observation.unvalidatedConstraintCount !== 0 ||
+    observation.migrationHighWater !== confirmations.at(-1)?.liveVersion
+  ) {
+    return false
+  }
+  const records = new Map(
+    observation.migrationRecords.map((record) => [record.liveVersion, record])
+  )
+
+  return confirmations.every((confirmation) => {
+    const record = records.get(confirmation.liveVersion)
+    return record?.liveName === confirmation.liveName && record.sqlSha256 === confirmation.sha256
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseConfirmation(value: unknown): ConfirmedLiveMigration | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+  const confirmation = {
+    liveName: value.liveName,
+    liveVersion: value.liveVersion,
+    path: value.path,
+    sha256: value.sha256,
+  }
+  return typeof confirmation.liveName === "string" &&
+    typeof confirmation.liveVersion === "string" &&
+    typeof confirmation.path === "string" &&
+    typeof confirmation.sha256 === "string" &&
+    validConfirmation(confirmation as ConfirmedLiveMigration)
+    ? (confirmation as ConfirmedLiveMigration)
+    : undefined
+}
+
+/** Parses the one atomic baseline snapshot and rejects contradictory or stale shapes. */
+export function parseBaselineState(value: unknown): BaselineState | undefined {
+  if (!isRecord(value) || !Array.isArray(value.confirmedMigrations)) {
+    return undefined
+  }
+  const confirmations = value.confirmedMigrations.map(parseConfirmation)
+  if (confirmations.some((confirmation) => confirmation === undefined)) {
+    return undefined
+  }
+  const recovery = value.recovery
+  const parsedRecovery: BaselineRecovery | undefined =
+    recovery === undefined
+      ? undefined
+      : isRecord(recovery) &&
+          (recovery.kind === "catch-up" || recovery.kind === "full-refresh") &&
+          typeof recovery.runId === "string" &&
+          /^[a-z0-9][a-z0-9_-]*$/u.test(recovery.runId) &&
+          typeof recovery.targetMigrationHighWater === "string" &&
+          /^\d{14}$/u.test(recovery.targetMigrationHighWater)
+        ? {
+            kind: recovery.kind,
+            runId: recovery.runId,
+            targetMigrationHighWater: recovery.targetMigrationHighWater,
+          }
+        : undefined
+  if (recovery !== undefined && parsedRecovery === undefined) {
+    return undefined
+  }
+  if (
+    value.schemaVersion !== BASELINE_STATE_SCHEMA_VERSION ||
+    typeof value.checkedAt !== "string" ||
+    Number.isNaN(Date.parse(value.checkedAt)) ||
+    typeof value.generation !== "string" ||
+    !/^[a-z0-9][a-z0-9_-]*$/u.test(value.generation) ||
+    typeof value.healthy !== "boolean" ||
+    typeof value.migrationHighWater !== "string" ||
+    !/^(?:\d{14}|unavailable)$/u.test(value.migrationHighWater) ||
+    typeof value.sourceCommit !== "string" ||
+    !/^[a-f0-9]{40}$/u.test(value.sourceCommit) ||
+    (value.healthy && parsedRecovery !== undefined) ||
+    (!value.healthy && value.migrationHighWater === "unavailable" && parsedRecovery === undefined)
+  ) {
+    return undefined
+  }
+  const confirmedMigrations = confirmations as ConfirmedLiveMigration[]
+  if (
+    value.healthy &&
+    (confirmedMigrations.length === 0 ||
+      confirmedMigrations.sort(compareConfirmedMigrations).at(-1)?.liveVersion !==
+        value.migrationHighWater)
+  ) {
+    return undefined
+  }
+
+  return normalizedState({
+    checkedAt: value.checkedAt,
+    confirmedMigrations,
+    generation: value.generation,
+    healthy: value.healthy,
+    migrationHighWater: value.migrationHighWater,
+    recovery: parsedRecovery,
+    schemaVersion: BASELINE_STATE_SCHEMA_VERSION,
+    sourceCommit: value.sourceCommit,
+  })
+}

--- a/scripts/db-quality-gate/dynamic-lane-types.ts
+++ b/scripts/db-quality-gate/dynamic-lane-types.ts
@@ -29,7 +29,10 @@ export type OracleExecutorResult<T> =
 export type OracleDynamicPreflight = {
   baseline: {
     healthy: boolean
+    migrationHighWater?: string
+    migrationIdentities?: MigrationIdentity[]
     migrationVersions: string[]
+    stateHash?: string
   }
   executorEnvironment: Record<string, string>
 }

--- a/scripts/db-quality-gate/dynamic-lane.ts
+++ b/scripts/db-quality-gate/dynamic-lane.ts
@@ -45,6 +45,7 @@ function pendingMigrations(
   state: ReturnType<typeof createDynamicRunState>,
   migrationIdentities: MigrationIdentity[],
   appliedMigrationIdentities: MigrationIdentity[],
+  baselineMigrationIdentities: MigrationIdentity[],
   observedVersions: string[]
 ): MigrationIdentity[] | undefined {
   for (const identity of migrationIdentities) {
@@ -58,7 +59,9 @@ function pendingMigrations(
     }
   }
 
-  const appliedVersions = new Set<string>()
+  const baselineIdentities = new Set(
+    baselineMigrationIdentities.map((identity) => `${identity.path}\u0000${identity.sha256}`)
+  )
   for (const identity of appliedMigrationIdentities) {
     const version = migrationVersion(identity)
     if (version === undefined) {
@@ -68,10 +71,18 @@ function pendingMigrations(
       state.incomplete = true
       return undefined
     }
-    appliedVersions.add(version)
   }
 
-  if ([...appliedVersions].some((version) => !observedVersions.includes(version))) {
+  if (
+    appliedMigrationIdentities.some((identity) => {
+      const version = migrationVersion(identity)
+      return (
+        version !== undefined &&
+        !observedVersions.includes(version) &&
+        !baselineIdentities.has(`${identity.path}\u0000${identity.sha256}`)
+      )
+    })
+  ) {
     addDynamicFinding(state, "dynamic.baseline.migration-evidence", ORACLE_BASELINE_DATABASE, {
       baseline: ORACLE_BASELINE_DATABASE,
     })
@@ -82,7 +93,11 @@ function pendingMigrations(
   const observed = new Set(observedVersions)
   return migrationIdentities.filter((identity) => {
     const version = migrationVersion(identity)
-    return version !== undefined && !observed.has(version)
+    return (
+      version !== undefined &&
+      !observed.has(version) &&
+      !baselineIdentities.has(`${identity.path}\u0000${identity.sha256}`)
+    )
   })
 }
 
@@ -161,9 +176,10 @@ export function runOracleDynamicLane(input: OracleDynamicLaneInput): GateReport 
       } else {
         state.preflightComplete = true
         state.executorEnvironment = preflight.value.executorEnvironment
-        state.baselineMigrationHighWater = baselineMigrationHighWater(
-          preflight.value.baseline.migrationVersions
-        )
+        state.baselineMigrationHighWater =
+          preflight.value.baseline.migrationHighWater ??
+          baselineMigrationHighWater(preflight.value.baseline.migrationVersions)
+        state.catalogInputHashes.baselineState = preflight.value.baseline.stateHash ?? "unavailable"
         databaseName = createDisposableDatabaseName({
           lane: input.lane,
           runId: input.runId,
@@ -191,6 +207,7 @@ export function runOracleDynamicLane(input: OracleDynamicLaneInput): GateReport 
               state,
               artifacts.migrationIdentities,
               artifacts.appliedMigrationIdentities,
+              preflight.value.baseline.migrationIdentities ?? [],
               preflight.value.baseline.migrationVersions
             )
           : undefined
@@ -215,6 +232,7 @@ export function runOracleDynamicLane(input: OracleDynamicLaneInput): GateReport 
             canContinue = false
           } else {
             state.catalogInputHashes = {
+              baselineState: state.catalogInputHashes.baselineState,
               catalogBaselineAccess: collectAccessFingerprint(baselineCatalogs.value.access),
               catalogBaselineApplication: collectApplicationFingerprint(
                 baselineCatalogs.value.application

--- a/scripts/db-quality-gate/oracle-baseline-maintenance-executor.ts
+++ b/scripts/db-quality-gate/oracle-baseline-maintenance-executor.ts
@@ -1,0 +1,233 @@
+import { parseBaselineState, parseDatabaseObservation, validConfirmation } from "./baseline-state"
+import type { BaselineState, DatabaseObservation } from "./baseline-state"
+import type { BaselineMaintenanceExecutor, ConfirmedMigrationInput } from "./baseline-maintenance"
+import { migrationContentSha256 } from "./migration-source"
+import { BASELINE_OBSERVATION_QUERY } from "./oracle-baseline-sql"
+import { createOracleRemoteClient, oracleStatePath } from "./oracle-remote-client"
+import {
+  defaultOracleRemoteCommand,
+  oracleRemoteExecutorConfigFromEnvironment,
+  quotedIdentifier,
+  shellQuote,
+} from "./oracle-remote-contract"
+import type { OracleRemoteExecutorInput } from "./oracle-remote-contract"
+import { createOracleRemoteExecutor } from "./oracle-remote-executor"
+import { stableJsonStringify } from "./serialization"
+
+const BASELINE_DATABASE = "qltbyt_test"
+const DATABASE_ADMIN_ROLE = "supabase_admin"
+
+function validMaintenanceDatabase(databaseName: string): boolean {
+  return (
+    databaseName === BASELINE_DATABASE ||
+    /^dq_baseline_(?:refresh|retired)_[a-z0-9_]+$/u.test(databaseName)
+  )
+}
+
+function validDumpPath(dumpPath: string): boolean {
+  return (
+    dumpPath.startsWith("/opt/supabase-test/backups/") &&
+    !dumpPath.split("/").includes("..") &&
+    dumpPath.endsWith(".dump")
+  )
+}
+
+function metadataStatement(migration: ConfirmedMigrationInput): string | undefined {
+  if (
+    !validConfirmation(migration) ||
+    migrationContentSha256(migration.content) !== migration.sha256
+  ) {
+    return undefined
+  }
+  const delimiter = `$dq_${migration.sha256.slice(0, 16)}$`
+  if (migration.content.includes(delimiter)) {
+    return undefined
+  }
+
+  return `INSERT INTO supabase_migrations.schema_migrations(version, statements, name)
+VALUES (
+  '${migration.liveVersion}',
+  ARRAY[${delimiter}${migration.content}${delimiter}],
+  '${migration.liveName}'
+);`
+}
+
+function parseStateText(value: string): BaselineState | undefined {
+  try {
+    return parseBaselineState(JSON.parse(value) as unknown)
+  } catch {
+    return undefined
+  }
+}
+
+/** Creates the Oracle-write adapter used only by explicit Phase 5 maintenance commands. */
+export function createOracleBaselineMaintenanceExecutor(
+  input: OracleRemoteExecutorInput
+): BaselineMaintenanceExecutor {
+  const dynamicExecutor = createOracleRemoteExecutor(input)
+  const { config } = input
+  const { readJson, remote, sql } = createOracleRemoteClient(input)
+
+  function inspectDatabase(databaseName: string): DatabaseObservation | undefined {
+    if (!validMaintenanceDatabase(databaseName)) {
+      return undefined
+    }
+    const result = readJson(databaseName, BASELINE_OBSERVATION_QUERY)
+    return result.status === "ok" ? parseDatabaseObservation(result.value) : undefined
+  }
+
+  function dropDatabase(databaseName: string): boolean {
+    if (!/^dq_baseline_(?:refresh|retired)_[a-z0-9_]+$/u.test(databaseName)) {
+      return false
+    }
+    const result = sql(
+      "postgres",
+      `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${databaseName}' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS ${quotedIdentifier(databaseName)};`,
+      "cleanup",
+      DATABASE_ADMIN_ROLE
+    )
+    return result.status === "ok"
+  }
+
+  return {
+    acquireLock(runId) {
+      return dynamicExecutor.acquireLock(runId).status === "ok"
+    },
+
+    releaseLock(runId) {
+      return dynamicExecutor.releaseLock(runId).status === "ok"
+    },
+
+    readState() {
+      const result = remote(`cat ${shellQuote(oracleStatePath(config))}`)
+      return result.status === "ok" ? parseStateText(result.value) : undefined
+    },
+
+    publishState(state) {
+      const statePath = oracleStatePath(config)
+      const stateDirectory = statePath.slice(0, statePath.lastIndexOf("/"))
+      const temporaryPath = `${stateDirectory}/.current.${state.generation}.tmp`
+      const result = remote(
+        `set -eu
+umask 077
+state_directory=${shellQuote(stateDirectory)}
+state_path=${shellQuote(statePath)}
+temporary_path=${shellQuote(temporaryPath)}
+mkdir -p "$state_directory"
+cat > "$temporary_path"
+chmod 600 "$temporary_path"
+mv -f "$temporary_path" "$state_path"
+chmod 400 "$state_path"`,
+        `${stableJsonStringify(state)}\n`,
+        "unavailable"
+      )
+      return result.status === "ok"
+    },
+
+    inspectDatabase,
+
+    applyMigrations(databaseName, migrations) {
+      if (!validMaintenanceDatabase(databaseName)) {
+        return false
+      }
+      for (const migration of migrations) {
+        const metadata = metadataStatement(migration)
+        if (metadata === undefined) {
+          return false
+        }
+        const applied = sql(databaseName, migration.content, "failed")
+        if (applied.status === "error") {
+          return false
+        }
+        const recorded = sql(databaseName, metadata, "failed")
+        if (recorded.status === "error") {
+          return false
+        }
+      }
+      return true
+    },
+
+    createRefreshDatabase(databaseName) {
+      if (!/^dq_baseline_refresh_[a-z0-9_]+$/u.test(databaseName)) {
+        return false
+      }
+      return (
+        sql(
+          "postgres",
+          `CREATE DATABASE ${quotedIdentifier(databaseName)} TEMPLATE template0;`,
+          "unavailable",
+          DATABASE_ADMIN_ROLE
+        ).status === "ok"
+      )
+    },
+
+    restoreDump(databaseName, dumpPath) {
+      if (!/^dq_baseline_refresh_[a-z0-9_]+$/u.test(databaseName) || !validDumpPath(dumpPath)) {
+        return false
+      }
+      const extensionSql = sql(
+        BASELINE_DATABASE,
+        `SELECT COALESCE(string_agg(
+  format(
+    'CREATE SCHEMA IF NOT EXISTS %I; CREATE EXTENSION IF NOT EXISTS %I WITH SCHEMA %I;',
+    n.nspname,
+    e.extname,
+    n.nspname
+  ),
+  E'\\n'
+), '')
+FROM pg_extension e
+JOIN pg_namespace n ON n.oid = e.extnamespace
+WHERE e.extname <> 'plpgsql';`,
+        "unavailable"
+      )
+      if (
+        extensionSql.status === "error" ||
+        sql(databaseName, extensionSql.value, "unavailable").status === "error" ||
+        sql(databaseName, "DROP SCHEMA IF EXISTS public CASCADE;", "unavailable").status === "error"
+      ) {
+        return false
+      }
+      const restored = remote(
+        `docker exec -i ${config.containerName} pg_restore --single-transaction --exit-on-error --no-owner --no-privileges -U postgres -d ${shellQuote(databaseName)} < ${shellQuote(dumpPath)}`,
+        undefined,
+        "failed"
+      )
+      return restored.status === "ok"
+    },
+
+    swapBaseline(databaseName, retiredDatabaseName) {
+      if (
+        !/^dq_baseline_refresh_[a-z0-9_]+$/u.test(databaseName) ||
+        !/^dq_baseline_retired_[a-z0-9_]+$/u.test(retiredDatabaseName)
+      ) {
+        return false
+      }
+      const result = sql(
+        "postgres",
+        `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ('${BASELINE_DATABASE}', '${databaseName}') AND pid <> pg_backend_pid();
+ALTER DATABASE ${quotedIdentifier(BASELINE_DATABASE)} RENAME TO ${quotedIdentifier(retiredDatabaseName)};
+ALTER DATABASE ${quotedIdentifier(databaseName)} RENAME TO ${quotedIdentifier(BASELINE_DATABASE)};`,
+        "interrupted",
+        DATABASE_ADMIN_ROLE
+      )
+      return result.status === "ok"
+    },
+
+    dropDatabase,
+  }
+}
+
+/** Loads the strict Oracle configuration without exposing credentials in arguments or output. */
+export function oracleBaselineMaintenanceExecutorFromEnvironment(
+  environment: NodeJS.ProcessEnv = process.env
+): BaselineMaintenanceExecutor | undefined {
+  const config = oracleRemoteExecutorConfigFromEnvironment(environment)
+  return config === undefined
+    ? undefined
+    : createOracleBaselineMaintenanceExecutor({
+        command: defaultOracleRemoteCommand,
+        config,
+      })
+}

--- a/scripts/db-quality-gate/oracle-baseline-sql.ts
+++ b/scripts/db-quality-gate/oracle-baseline-sql.ts
@@ -1,0 +1,41 @@
+/** Reads the migration and structural health evidence required by baseline state. */
+export const BASELINE_OBSERVATION_QUERY = `
+SELECT json_build_object(
+  'healthy', true,
+  'invalidIndexCount', (
+    SELECT count(*)::int
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE NOT i.indisvalid
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+  ),
+  'migrationHighWater', COALESCE(
+    (SELECT max(version) FROM supabase_migrations.schema_migrations),
+    'unavailable'
+  ),
+  'migrationRecords', COALESCE(
+    (
+      SELECT json_agg(
+        json_build_object(
+          'liveName', COALESCE(name, ''),
+          'liveVersion', version,
+          'sqlSha256', encode(
+            extensions.digest(convert_to(COALESCE(statements[1], ''), 'UTF8'), 'sha256'
+          ), 'hex')
+        )
+        ORDER BY version
+      )
+      FROM supabase_migrations.schema_migrations
+    ),
+    '[]'::json
+  ),
+  'unvalidatedConstraintCount', (
+    SELECT count(*)::int
+    FROM pg_constraint c
+    JOIN pg_namespace n ON n.oid = c.connamespace
+    WHERE NOT c.convalidated
+      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+  )
+)::text;
+`

--- a/scripts/db-quality-gate/oracle-baseline-sql.ts
+++ b/scripts/db-quality-gate/oracle-baseline-sql.ts
@@ -8,7 +8,22 @@ SELECT json_build_object(
     JOIN pg_class c ON c.oid = i.indexrelid
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE NOT i.indisvalid
-      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND n.nspname NOT IN (
+        'auth',
+        'extensions',
+        'graphql',
+        'graphql_public',
+        'information_schema',
+        'net',
+        'pg_catalog',
+        'pgsodium',
+        'pgsodium_masks',
+        'realtime',
+        'storage',
+        'supabase_functions',
+        'supabase_migrations',
+        'vault'
+      )
   ),
   'migrationHighWater', COALESCE(
     (SELECT max(version) FROM supabase_migrations.schema_migrations),
@@ -21,8 +36,19 @@ SELECT json_build_object(
           'liveName', COALESCE(name, ''),
           'liveVersion', version,
           'sqlSha256', encode(
-            extensions.digest(convert_to(COALESCE(statements[1], ''), 'UTF8'), 'sha256'
-          ), 'hex')
+            extensions.digest(
+              convert_to(
+                regexp_replace(
+                  replace(COALESCE(statements[1], ''), E'\r\n', E'\n'),
+                  E'\n$',
+                  ''
+                ),
+                'UTF8'
+              ),
+              'sha256'
+            ),
+            'hex'
+          )
         )
         ORDER BY version
       )
@@ -35,7 +61,22 @@ SELECT json_build_object(
     FROM pg_constraint c
     JOIN pg_namespace n ON n.oid = c.connamespace
     WHERE NOT c.convalidated
-      AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND n.nspname NOT IN (
+        'auth',
+        'extensions',
+        'graphql',
+        'graphql_public',
+        'information_schema',
+        'net',
+        'pg_catalog',
+        'pgsodium',
+        'pgsodium_masks',
+        'realtime',
+        'storage',
+        'supabase_functions',
+        'supabase_migrations',
+        'vault'
+      )
   )
 )::text;
 `

--- a/scripts/db-quality-gate/oracle-checkout.sh
+++ b/scripts/db-quality-gate/oracle-checkout.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly REPOSITORY_URL="https://github.com/thienchi2109/qltbyt-nam-phong"
+readonly CHECKOUT_ROOT="/opt/supabase-test/quality-gate/repository"
+
+commit="${1:-}"
+if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'Usage: %s <exact-40-character-commit>\n' "$0" >&2
+  exit 2
+fi
+
+umask 077
+mkdir -p "$(dirname "$CHECKOUT_ROOT")"
+
+if [[ ! -d "$CHECKOUT_ROOT/.git" ]]; then
+  git -c credential.helper= clone --filter=blob:none --no-checkout \
+    "$REPOSITORY_URL" "$CHECKOUT_ROOT"
+fi
+
+current_origin="$(git -C "$CHECKOUT_ROOT" remote get-url origin)"
+if [[ "$current_origin" != "$REPOSITORY_URL" ]]; then
+  printf 'Unexpected Oracle checkout origin: %s\n' "$current_origin" >&2
+  exit 2
+fi
+
+git -C "$CHECKOUT_ROOT" config --local credential.helper ""
+git -C "$CHECKOUT_ROOT" -c credential.helper= fetch --depth=1 origin "$commit"
+git -C "$CHECKOUT_ROOT" checkout --detach --force FETCH_HEAD
+
+checked_out_commit="$(git -C "$CHECKOUT_ROOT" rev-parse HEAD)"
+if [[ "$checked_out_commit" != "$commit" ]]; then
+  printf 'Oracle checkout mismatch: expected %s, got %s\n' "$commit" "$checked_out_commit" >&2
+  exit 2
+fi
+
+chmod -R go-rwx "$CHECKOUT_ROOT"
+printf '%s\n' "$checked_out_commit"

--- a/scripts/db-quality-gate/oracle-remote-client.ts
+++ b/scripts/db-quality-gate/oracle-remote-client.ts
@@ -1,0 +1,120 @@
+import { shellQuote } from "./oracle-remote-contract"
+import type {
+  OracleRemoteExecutorConfig,
+  OracleRemoteExecutorInput,
+} from "./oracle-remote-contract"
+import type { DynamicFailureKind, OracleExecutorResult } from "./dynamic-lane-types"
+
+const DEFAULT_TIMEOUT_MS = 120_000
+
+/** Builds a typed fail-closed Oracle executor error result. */
+export function oracleErrorResult<T>(
+  kind: DynamicFailureKind,
+  error: string
+): OracleExecutorResult<T> {
+  return {
+    error,
+    kind,
+    status: "error",
+  }
+}
+
+function parseJsonOutput(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value.trim()) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+export type OracleRemoteClient = {
+  readJson: (databaseName: string, statement: string) => OracleExecutorResult<unknown>
+  remote: (
+    remoteCommand: string,
+    inputText?: string,
+    failureKind?: DynamicFailureKind
+  ) => OracleExecutorResult<string>
+  sql: (
+    databaseName: string,
+    statement: string,
+    failureKind: DynamicFailureKind,
+    role?: string
+  ) => OracleExecutorResult<string>
+}
+
+/** Creates the shared argument-safe SSH and psql transport for Oracle-only executors. */
+export function createOracleRemoteClient(input: OracleRemoteExecutorInput): OracleRemoteClient {
+  const { command, config } = input
+
+  function remote(
+    remoteCommand: string,
+    inputText?: string,
+    failureKind: DynamicFailureKind = "unavailable"
+  ): OracleExecutorResult<string> {
+    const result = command({
+      arguments: [
+        "-i",
+        config.sshKeyPath,
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=15",
+        "-o",
+        "GlobalKnownHostsFile=/dev/null",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        `UserKnownHostsFile=${config.sshKnownHostsPath}`,
+        `${config.sshUser}@${config.host}`,
+        remoteCommand,
+      ],
+      input: inputText,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    })
+    if (result.timedOut) {
+      return oracleErrorResult("timeout", "Oracle SSH command timed out")
+    }
+    if (result.exitCode !== 0) {
+      return oracleErrorResult(failureKind, result.stderr.trim() || "Oracle SSH command failed")
+    }
+
+    return {
+      status: "ok",
+      value: result.stdout,
+    }
+  }
+
+  function sql(
+    databaseName: string,
+    statement: string,
+    failureKind: DynamicFailureKind,
+    role = "postgres"
+  ): OracleExecutorResult<string> {
+    const remoteCommand = `docker exec -i ${config.containerName} psql -X -v ON_ERROR_STOP=1 -U ${role} -d ${shellQuote(databaseName)} -tA`
+    const result = remote(remoteCommand, statement)
+    if (result.status === "ok" || failureKind !== "failed" || result.kind !== "unavailable") {
+      return result
+    }
+
+    const health = remote(remoteCommand, "SELECT 1;")
+    return health.status === "ok" ? oracleErrorResult("failed", result.error) : health
+  }
+
+  function readJson(databaseName: string, statement: string): OracleExecutorResult<unknown> {
+    const result = sql(databaseName, statement, "unavailable")
+    if (result.status === "error") {
+      return result
+    }
+    const value = parseJsonOutput(result.value)
+    return value === undefined
+      ? oracleErrorResult("unavailable", "Oracle catalog query returned invalid JSON")
+      : { status: "ok", value }
+  }
+
+  return { readJson, remote, sql }
+}
+
+/** Returns the fixed atomic baseline-state path adjacent to immutable evidence. */
+export function oracleStatePath(config: OracleRemoteExecutorConfig): string {
+  return `${config.evidenceDirectory}/../baseline/current.json`
+}

--- a/scripts/db-quality-gate/oracle-remote-executor.ts
+++ b/scripts/db-quality-gate/oracle-remote-executor.ts
@@ -11,7 +11,19 @@ import {
   validDisposableDatabase,
   validRunId,
 } from "./oracle-remote-contract"
+import {
+  createOracleRemoteClient,
+  oracleErrorResult as errorResult,
+  oracleStatePath,
+} from "./oracle-remote-client"
 import { hasPsqlMetaCommand, rollbackRequiredSqlTestBody } from "./oracle-remote-sql"
+import { BASELINE_OBSERVATION_QUERY } from "./oracle-baseline-sql"
+import {
+  baselineStateHash,
+  observationMatches,
+  parseBaselineState,
+  parseDatabaseObservation,
+} from "./baseline-state"
 import type {
   DynamicFailureKind,
   OracleDynamicExecutor,
@@ -28,25 +40,8 @@ export type {
 
 const BASELINE_DATABASE = "qltbyt_test"
 const DATABASE_ADMIN_ROLE = "supabase_admin"
-const DEFAULT_TIMEOUT_MS = 120_000
 const GLOBAL_LOCK_NAME = "dynamic-lane.lock"
 const LOCK_LEASE_SECONDS = 30 * 60
-
-function errorResult<T>(kind: DynamicFailureKind, error: string): OracleExecutorResult<T> {
-  return {
-    error,
-    kind,
-    status: "error",
-  }
-}
-
-function parseJsonOutput(value: string): unknown | undefined {
-  try {
-    return JSON.parse(value.trim()) as unknown
-  } catch {
-    return undefined
-  }
-}
 
 /** Creates the production SSH/Docker executor only when strict Oracle-only configuration exists. */
 export function oracleRemoteExecutorFromEnvironment(
@@ -65,72 +60,8 @@ export function oracleRemoteExecutorFromEnvironment(
 export function createOracleRemoteExecutor(
   input: OracleRemoteExecutorInput
 ): OracleDynamicExecutor {
-  const { command, config } = input
-
-  function remote(
-    remoteCommand: string,
-    inputText?: string,
-    failureKind: DynamicFailureKind = "unavailable"
-  ): OracleExecutorResult<string> {
-    const result = command({
-      arguments: [
-        "-i",
-        config.sshKeyPath,
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "ConnectTimeout=15",
-        "-o",
-        "GlobalKnownHostsFile=/dev/null",
-        "-o",
-        "StrictHostKeyChecking=yes",
-        "-o",
-        `UserKnownHostsFile=${config.sshKnownHostsPath}`,
-        `${config.sshUser}@${config.host}`,
-        remoteCommand,
-      ],
-      input: inputText,
-      timeoutMs: DEFAULT_TIMEOUT_MS,
-    })
-    if (result.timedOut) {
-      return errorResult("timeout", "Oracle SSH command timed out")
-    }
-    if (result.exitCode !== 0) {
-      return errorResult(failureKind, result.stderr.trim() || "Oracle SSH command failed")
-    }
-
-    return {
-      status: "ok",
-      value: result.stdout,
-    }
-  }
-
-  function sql(
-    databaseName: string,
-    statement: string,
-    failureKind: DynamicFailureKind,
-    role = "postgres"
-  ): OracleExecutorResult<string> {
-    const remoteCommand = `docker exec -i ${config.containerName} psql -X -v ON_ERROR_STOP=1 -U ${role} -d ${shellQuote(databaseName)} -tA`
-    const result = remote(remoteCommand, statement)
-    if (result.status === "ok" || failureKind !== "failed" || result.kind !== "unavailable") {
-      return result
-    }
-
-    const health = remote(remoteCommand, "SELECT 1;")
-    return health.status === "ok" ? errorResult("failed", result.error) : health
-  }
-
-  function readJson(databaseName: string, statement: string): OracleExecutorResult<unknown> {
-    const result = sql(databaseName, statement, "unavailable")
-    if (result.status === "error") {
-      return result
-    }
-    const value = parseJsonOutput(result.value)
-    return value === undefined
-      ? errorResult("unavailable", "Oracle catalog query returned invalid JSON")
-      : { status: "ok", value }
-  }
+  const { config } = input
+  const { readJson, remote, sql } = createOracleRemoteClient(input)
 
   return {
     preflight() {
@@ -170,18 +101,31 @@ export function createOracleRemoteExecutor(
         return errorResult("stale-environment", "Restored Oracle baseline is missing")
       }
 
-      const versions = readJson(
-        BASELINE_DATABASE,
-        "SELECT COALESCE(json_agg(version ORDER BY version), '[]'::json)::text FROM supabase_migrations.schema_migrations;"
-      )
-      if (versions.status === "error") {
-        return versions
+      const stateResult = remote(`cat ${shellQuote(oracleStatePath(config))}`)
+      if (stateResult.status === "error") {
+        return errorResult("stale-environment", "Oracle baseline state evidence is unavailable")
       }
+      let rawState: unknown
+      try {
+        rawState = JSON.parse(stateResult.value) as unknown
+      } catch {
+        return errorResult("stale-environment", "Oracle baseline state evidence is invalid")
+      }
+      const baselineState = parseBaselineState(rawState)
+      if (baselineState === undefined || !baselineState.healthy) {
+        return errorResult("stale-environment", "Oracle baseline is not published as healthy")
+      }
+
+      const observationResult = readJson(BASELINE_DATABASE, BASELINE_OBSERVATION_QUERY)
+      if (observationResult.status === "error") {
+        return observationResult
+      }
+      const observation = parseDatabaseObservation(observationResult.value)
       if (
-        !Array.isArray(versions.value) ||
-        versions.value.some((version) => typeof version !== "string")
+        observation === undefined ||
+        !observationMatches(observation, baselineState.confirmedMigrations)
       ) {
-        return errorResult("stale-environment", "Oracle baseline migration evidence is invalid")
+        return errorResult("stale-environment", "Oracle baseline health evidence is stale")
       }
 
       return {
@@ -189,7 +133,13 @@ export function createOracleRemoteExecutor(
         value: {
           baseline: {
             healthy: true,
-            migrationVersions: versions.value,
+            migrationHighWater: baselineState.migrationHighWater,
+            migrationIdentities: baselineState.confirmedMigrations.map(({ path, sha256 }) => ({
+              path,
+              sha256,
+            })),
+            migrationVersions: observation.migrationRecords.map((record) => record.liveVersion),
+            stateHash: baselineStateHash(baselineState),
           },
           executorEnvironment: {
             execution: "oracle-disposable",

--- a/scripts/db-quality-gate/run-baseline-maintenance.cjs
+++ b/scripts/db-quality-gate/run-baseline-maintenance.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const { mkdtempSync, rmSync } = require("node:fs")
+const { tmpdir } = require("node:os")
+const path = require("node:path")
+
+const esbuild = require("esbuild")
+
+const temporaryDirectory = mkdtempSync(path.join(tmpdir(), "db-quality-gate-baseline-"))
+const bundledCommandPath = path.join(temporaryDirectory, "command.cjs")
+
+try {
+  esbuild.buildSync({
+    bundle: true,
+    entryPoints: [path.join(__dirname, "baseline-maintenance-cli.ts")],
+    format: "cjs",
+    logLevel: "silent",
+    outfile: bundledCommandPath,
+    platform: "node",
+    target: "node20",
+  })
+
+  const { runBaselineMaintenanceCommand } = require(bundledCommandPath)
+  const result = runBaselineMaintenanceCommand(process.argv.slice(2))
+
+  process.stdout.write(result.stdout)
+  process.exitCode = result.exitCode
+} finally {
+  rmSync(temporaryDirectory, { force: true, recursive: true })
+}


### PR DESCRIPTION
## Summary
- add atomic Oracle baseline health/high-water state and live-confirmed catch-up
- add serialized full-refresh recovery, evidence invalidation, and fault-injection coverage
- add secret-safe exact-commit Oracle checkout plus Vietnamese operations runbook

## Contract
- blocking lanes remain `static` and `baseline-forward` only
- bootstrap/fresh replay remains deferred and non-blocking
- no Codex VPS timer and no live Supabase writes or Supabase CLI

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- 28 DB Quality Gate test files / 179 tests
- React Doctor 100/100
- OpenSpec strict validation
- oracle-checkout.sh bash syntax

## Before merge
- run exact-commit static and baseline-forward against the Oracle test VM
- require both lanes PASS for the same commit and verify clean Oracle cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 5 baseline maintenance and normalizes Oracle baseline health so dynamic lanes verify a single atomic snapshot. Previously lanes trusted migration versions only; now they validate the published state (health + high‑water + identities) and reuse evidence only when the state hash matches.

- Implements atomic baseline state, incremental catch‑up from live‑confirmed migrations, serialized full‑refresh, and health recovery. Adds `db:quality-gate:baseline` CLI, a secret‑safe exact‑commit checkout script, and an Oracle write executor. Baseline health now normalizes SQL for hashing (CRLF→LF, trims trailing newline) and excludes Supabase‑managed schemas from invalid index/constraint counts. Dynamic preflight reads `baseline/current.json`, validates live facts, and returns `migrationHighWater`, `migrationIdentities`, and a `stateHash`; baseline‑forward evidence is invalidated when generation or high‑water changes.

**Review focus**
- `baseline-state.ts` contract: state shape, hashing, confirmation validation, observation matching.
- `baseline-maintenance.ts` workflows: lock → publish unhealthy → apply/restore → verify → publish healthy.
- Oracle adapters: `oracle-baseline-maintenance-executor.ts`, `oracle-remote-client.ts`, and preflight changes in `oracle-remote-executor.ts`.
- Dynamic lane: excludes baseline‑confirmed identities from pending and carries the `baselineState` input hash.
- Health normalization query in `oracle-baseline-sql.ts` aligns hashes with canonical local SQL.

**Rollout**
- Oracle VM only. Use `scripts/db-quality-gate/oracle-checkout.sh` to checkout the exact landed commit, then run `npm run db:quality-gate:baseline` with `--operation health|catch-up|full-refresh`. Require both static and baseline‑forward lanes PASS on the same commit; verify no `dq_*` databases or locks remain. Evidence from earlier baseline‑forward runs will be invalidated on any baseline generation or high‑water change.

<sup>Written for commit 5b6179e1175e274a27b293dea750da8a95034b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

