### PR TITLE
fix: allow portable V2 blank hierarchy imports

### DIFF
--- a/docs/superpowers/plans/2026-08-21-portable-technical-configuration-blank-template.md
+++ b/docs/superpowers/plans/2026-08-21-portable-technical-configuration-blank-template.md
@@ -78,5 +78,5 @@ Expected: the new portable-import assertion fails with source dossier/version/re
 - [x] Run `src/app/api/rpc/__tests__/technical-configuration-baseline-import-migration.test.ts` to preserve the server-side metadata mismatch contract.
 - [x] Run `react-doctor`.
 - [x] Review the final diff and affected flows.
-- [ ] Commit without bypassing Lefthook.
-- [ ] Pull with rebase, push, and verify the branch is up to date with origin.
+- [x] Commit without bypassing Lefthook.
+- [x] Pull with rebase, push, and verify the branch is up to date with origin.

--- a/docs/superpowers/plans/2026-08-21-portable-technical-configuration-blank-template.md
+++ b/docs/superpowers/plans/2026-08-21-portable-technical-configuration-blank-template.md
@@ -1,0 +1,82 @@
+# Portable Technical Configuration Blank Template Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow a V2 blank-template workbook downloaded from one technical-configuration dossier to initialize a newly created dossier without weakening foreign-identity protection.
+
+**Architecture:** Keep the server contract unchanged. The existing pure hierarchy-import adapter will classify only V2 workbooks whose imported rows contain no group, subgroup, criterion, or criterion-code identity as portable content-only workbooks, then replace their dossier/version/revision metadata with the selected target draft. Workbooks containing any identity remain source-bound and continue through the existing server rejection path.
+
+**Tech Stack:** TypeScript, React Testing Library, Vitest, ExcelJS workbook codec
+
+---
+
+## Chunk 1: Lock The Portable V2 Contract
+
+### Task 1: Add byte-level and adapter regressions
+
+**Files:**
+
+- Modify: `src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import.test.tsx`
+- Create: `src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability.test.ts`
+
+- [x] Add the UI regression that expects a content-only V2 workbook to use target metadata.
+- [x] Add a real XLSX round-trip test that serializes a blank template from dossier A, enters new rows with no hidden identity, parses it against an empty target hierarchy, and verifies the resulting RPC payload uses target metadata.
+- [x] Add table-driven negative adapter assertions for mixed content-only rows plus each supported identity form: group ID, subgroup ID, and criterion ID/code.
+- [x] Assert every identity-bearing case preserves the source dossier/version/revision metadata.
+- [x] Run the focused tests and verify the portable case fails because source metadata is still forwarded.
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-import.test.tsx' \
+  'src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability.test.ts'
+```
+
+Expected: the new portable-import assertion fails with source dossier/version/revision metadata; all unrelated cases pass.
+
+## Chunk 2: Rebind Only Content-Only V2 Workbooks
+
+### Task 2: Implement the minimal pure adapter change
+
+**Files:**
+
+- Modify: `src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-import.ts`
+
+- [x] Add a private predicate that returns true only for V2 rows with all identity fields null.
+- [x] For that case only, build template metadata from the selected target draft while preserving template kind, version, and generated timestamp.
+- [x] Leave legacy V1 and any V2 workbook containing identity unchanged.
+- [x] Run the focused tests and verify they pass.
+
+## Chunk 3: Restore V2 Criterion-Title Round Trips
+
+### Task 3: Accept exported STT titles without trusting hidden title data
+
+**Files:**
+
+- Modify: `src/lib/technical-configuration-baseline-excel-v2-parse-rows.ts`
+
+- [x] Reproduce the two V2 round-trip failures caused by exported criterion titles in the STT column.
+- [x] Use hidden `criterion_title` only as a row-classification hint.
+- [x] Continue returning criterion titles from `existingHierarchy`; a new criterion with cleared identity must return a null title.
+- [x] Preserve unsupported-marker, wrong-identity-kind, and foreign-identity behavior.
+- [x] Run every `technical-configuration-baseline-excel-v2-*` test file and verify all pass.
+
+## Chunk 4: Verify And Land
+
+### Task 4: Run repository gates and publish the branch
+
+**Files:**
+
+- Verify all changed files.
+
+- [x] Run `format:check`.
+- [x] Run `verify:no-explicit-any`.
+- [x] Run `verify:dedupe`.
+- [x] Run `typecheck`.
+- [x] Run both focused Vitest files.
+- [x] Run `src/app/api/rpc/__tests__/technical-configuration-baseline-import-migration.test.ts` to preserve the server-side metadata mismatch contract.
+- [x] Run `react-doctor`.
+- [x] Review the final diff and affected flows.
+- [ ] Commit without bypassing Lefthook.
+- [ ] Pull with rebase, push, and verify the branch is up to date with origin.

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability-ui.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability-ui.test.tsx
@@ -1,0 +1,124 @@
+import "@testing-library/jest-dom"
+
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+
+import {
+  createHierarchyDraft,
+  createHierarchyImportFile,
+  createHierarchyPreview,
+  createV2ParseResult,
+  HierarchyImportHarness,
+} from "./technical-configuration-baseline-hierarchy-import-fixtures"
+
+const hierarchyImportRpc = vi.hoisted(() => ({
+  previewHierarchyImport: vi.fn(),
+  applyHierarchyImport: vi.fn(),
+}))
+
+const compatibleParser = vi.hoisted(() => ({
+  parseFile: vi.fn(),
+}))
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => hierarchyImportRpc,
+}))
+
+vi.mock("@/lib/technical-configuration-baseline-excel-v2-parse", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/technical-configuration-baseline-excel-v2-parse")>()
+  return {
+    ...actual,
+    parseTechnicalConfigurationBaselineWorkbookFile: compatibleParser.parseFile,
+  }
+})
+
+describe("technical configuration baseline blank-template portability UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hierarchyImportRpc.previewHierarchyImport.mockResolvedValue(createHierarchyPreview())
+    hierarchyImportRpc.applyHierarchyImport.mockResolvedValue({
+      data: createHierarchyDraft({ revision: 1 }),
+    })
+  })
+
+  it("rebinds content-only V2 rows to the selected empty target draft", async () => {
+    const user = userEvent.setup()
+    const parsed = createV2ParseResult()
+    parsed.metadata = {
+      ...parsed.metadata,
+      dossier_id: "source-dossier",
+      baseline_version_id: "source-draft",
+      baseline_revision: 2,
+    }
+    parsed.rows = [
+      {
+        row: 2,
+        row_type: "GROUP",
+        group_order: 1,
+        group_id: null,
+        group_name: "Yêu cầu chung",
+      },
+      {
+        row: 3,
+        row_type: "CRITERION",
+        group_order: 1,
+        subgroup_order: null,
+        criterion_order: 1,
+        criterion_id: null,
+        criterion_code: null,
+        criterion_title: null,
+        requirement_text: "Hoạt động ổn định ở 18-30°C",
+      },
+    ]
+    compatibleParser.parseFile.mockResolvedValueOnce(parsed)
+
+    const target = createHierarchyDraft({
+      id: "target-draft",
+      dossier_id: "target-dossier",
+      revision: 0,
+      groups: [],
+    })
+    render(<HierarchyImportHarness version={target} />)
+
+    await user.click(screen.getByRole("button", { name: "Nhập cấu hình phân cấp" }))
+    await user.upload(
+      screen.getByLabelText("Chọn workbook cấu hình phân cấp"),
+      createHierarchyImportFile("blank-template-from-source.xlsx")
+    )
+
+    await waitFor(() => {
+      expect(hierarchyImportRpc.previewHierarchyImport).toHaveBeenCalledWith({
+        p_baseline_version_id: "target-draft",
+        p_template_metadata: {
+          ...parsed.metadata,
+          dossier_id: "target-dossier",
+          baseline_version_id: "target-draft",
+          baseline_revision: 0,
+        },
+        p_rows: [
+          {
+            row: 2,
+            stt: "I",
+            content: "Yêu cầu chung",
+            group_id: null,
+            subgroup_id: null,
+            criterion_id: null,
+            criterion_code: null,
+          },
+          {
+            row: 3,
+            stt: null,
+            content: "Hoạt động ổn định ở 18-30°C",
+            group_id: null,
+            subgroup_id: null,
+            criterion_id: null,
+            criterion_code: null,
+          },
+        ],
+        p_expected_revision: 0,
+      })
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-blank-template-portability.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createHierarchyDraft,
+  createV2ParseResult,
+} from "./technical-configuration-baseline-hierarchy-import-fixtures"
+import { toTechnicalConfigurationBaselineHierarchyImportRpcArgs } from "@/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-import"
+import {
+  BASELINE_WORKBOOK_V2_CONFIGURATION_SHEET_NAME,
+  BASELINE_WORKBOOK_V2_TEMPLATE_KIND,
+  BASELINE_WORKBOOK_V2_TEMPLATE_VERSION,
+  createTechnicalConfigurationBaselineWorkbookV2Model,
+} from "@/lib/technical-configuration-baseline-excel-v2-contract"
+import { createTechnicalConfigurationBaselineWorkbookV2 } from "@/lib/technical-configuration-baseline-excel-v2-export"
+import {
+  parseTechnicalConfigurationBaselineWorkbookFile,
+  type TechnicalConfigurationBaselineWorkbookV2ParseResult,
+} from "@/lib/technical-configuration-baseline-excel-v2-parse"
+
+const SOURCE_METADATA_INPUT = {
+  dossier_id: "source-dossier",
+  baseline_version_id: "source-draft",
+  baseline_revision: 2,
+  generated_at: "2026-08-21T08:30:00.000Z",
+} as const
+
+const SOURCE_PARSED_METADATA = {
+  template_kind: BASELINE_WORKBOOK_V2_TEMPLATE_KIND,
+  template_version: BASELINE_WORKBOOK_V2_TEMPLATE_VERSION,
+  ...SOURCE_METADATA_INPUT,
+} as const
+
+const TARGET_DRAFT = createHierarchyDraft({
+  id: "target-draft",
+  dossier_id: "target-dossier",
+  revision: 0,
+  groups: [],
+})
+
+type SupportedIdentityField = "group_id" | "subgroup_id" | "criterion_id" | "criterion_code"
+
+function createContentOnlyV2ParseResult(): TechnicalConfigurationBaselineWorkbookV2ParseResult {
+  const parsed = createV2ParseResult()
+  parsed.metadata = SOURCE_PARSED_METADATA
+  parsed.rows = [
+    {
+      row: 2,
+      row_type: "GROUP",
+      group_order: 1,
+      group_id: null,
+      group_name: "Yêu cầu chung",
+    },
+    {
+      row: 3,
+      row_type: "SUBGROUP",
+      group_order: 1,
+      subgroup_order: 1,
+      subgroup_id: null,
+      subgroup_name: "Điều kiện vận hành",
+    },
+    {
+      row: 4,
+      row_type: "CRITERION",
+      group_order: 1,
+      subgroup_order: 1,
+      criterion_order: 1,
+      criterion_id: null,
+      criterion_code: null,
+      criterion_title: null,
+      requirement_text: "Hoạt động ổn định ở 18-30°C",
+    },
+  ]
+  return parsed
+}
+
+function createV2ParseResultWithIdentity(
+  identity: SupportedIdentityField
+): TechnicalConfigurationBaselineWorkbookV2ParseResult {
+  const parsed = createContentOnlyV2ParseResult()
+  parsed.rows = parsed.rows.map((row) => {
+    if (identity === "group_id" && row.row_type === "GROUP") {
+      return { ...row, group_id: "source-group" }
+    }
+    if (identity === "subgroup_id" && row.row_type === "SUBGROUP") {
+      return { ...row, subgroup_id: "source-subgroup" }
+    }
+    if (identity === "criterion_id" && row.row_type === "CRITERION") {
+      return { ...row, criterion_id: "source-criterion" }
+    }
+    if (identity === "criterion_code" && row.row_type === "CRITERION") {
+      return { ...row, criterion_code: "TC-SOURCE" }
+    }
+    return row
+  })
+  return parsed
+}
+
+function toUploadedFile(bytes: ArrayBuffer | Uint8Array): File {
+  const copy = new Uint8Array(bytes)
+  return {
+    name: "blank-template-from-source.xlsx",
+    size: copy.byteLength,
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    arrayBuffer: async () => copy.buffer.slice(copy.byteOffset, copy.byteOffset + copy.byteLength),
+  } as File
+}
+
+describe("technical configuration baseline blank-template portability", () => {
+  it("rebinds a real content-only V2 blank template to the selected target draft", async () => {
+    const workbook = await createTechnicalConfigurationBaselineWorkbookV2(
+      createTechnicalConfigurationBaselineWorkbookV2Model({
+        intent: "blank-template",
+        metadata: SOURCE_METADATA_INPUT,
+      })
+    )
+    const configuration = workbook.getWorksheet(BASELINE_WORKBOOK_V2_CONFIGURATION_SHEET_NAME)
+    expect(configuration).toBeDefined()
+    if (!configuration) {
+      throw new Error("Expected the V2 configuration worksheet")
+    }
+
+    configuration.getCell("A2").value = "I"
+    configuration.getCell("B2").value = "Yêu cầu chung"
+    configuration.getCell("B3").value = "Hoạt động ổn định ở 18-30°C"
+
+    const bytes = await workbook.xlsx.writeBuffer()
+    const parsed = await parseTechnicalConfigurationBaselineWorkbookFile(toUploadedFile(bytes), {
+      existingHierarchy: {
+        groups: [],
+        subgroups: [],
+        criteria: [],
+      },
+    })
+    expect(parsed.format).toBe("v2")
+    if (parsed.format !== "v2") {
+      throw new Error(`Expected XLSX v2 parse result, received ${parsed.format}`)
+    }
+
+    expect(parsed.metadata).toEqual(SOURCE_PARSED_METADATA)
+    expect(parsed.rows).toEqual([
+      {
+        row: 2,
+        row_type: "GROUP",
+        group_order: 1,
+        group_id: null,
+        group_name: "Yêu cầu chung",
+      },
+      {
+        row: 3,
+        row_type: "CRITERION",
+        group_order: 1,
+        subgroup_order: null,
+        criterion_order: 1,
+        criterion_id: null,
+        criterion_code: null,
+        criterion_title: null,
+        requirement_text: "Hoạt động ổn định ở 18-30°C",
+      },
+    ])
+
+    const args = toTechnicalConfigurationBaselineHierarchyImportRpcArgs(parsed, TARGET_DRAFT)
+
+    expect(args.p_template_metadata).toEqual({
+      template_kind: BASELINE_WORKBOOK_V2_TEMPLATE_KIND,
+      template_version: BASELINE_WORKBOOK_V2_TEMPLATE_VERSION,
+      dossier_id: "target-dossier",
+      baseline_version_id: "target-draft",
+      baseline_revision: 0,
+      generated_at: SOURCE_METADATA_INPUT.generated_at,
+    })
+  })
+
+  it.each([
+    { identity: "group_id" },
+    { identity: "subgroup_id" },
+    { identity: "criterion_id" },
+    { identity: "criterion_code" },
+  ] as const)("keeps source metadata when any row contains $identity", ({ identity }) => {
+    const parsed = createV2ParseResultWithIdentity(identity)
+
+    const args = toTechnicalConfigurationBaselineHierarchyImportRpcArgs(parsed, TARGET_DRAFT)
+
+    expect(args.p_template_metadata).toEqual(SOURCE_PARSED_METADATA)
+  })
+})

--- a/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-import.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-baseline-hierarchy-import.ts
@@ -93,6 +93,45 @@ function toV2Rows(
   })
 }
 
+function isPortableContentOnlyV2Workbook(
+  parsed: Extract<TechnicalConfigurationBaselineWorkbookCompatibleParseResult, { format: "v2" }>
+): boolean {
+  return parsed.rows.every((row) => {
+    if (row.row_type === "GROUP") {
+      return row.group_id === null
+    }
+    if (row.row_type === "SUBGROUP") {
+      return row.subgroup_id === null
+    }
+    return row.criterion_id === null && row.criterion_code === null
+  })
+}
+
+function toHierarchyImportTemplateMetadata(
+  parsed: TechnicalConfigurationBaselineWorkbookCompatibleParseResult,
+  version: TechnicalConfigurationBaselineDecodedDraft
+): TechnicalConfigurationBaselineHierarchyImportRpcArgs["p_template_metadata"] {
+  if (parsed.format !== "v2") {
+    return {
+      template_kind: BASELINE_WORKBOOK_V2_TEMPLATE_KIND,
+      template_version: BASELINE_WORKBOOK_V2_TEMPLATE_VERSION,
+      dossier_id: parsed.metadata.dossier_id,
+      baseline_version_id: parsed.metadata.baseline_version_id,
+      baseline_revision: parsed.metadata.baseline_revision,
+      generated_at: parsed.metadata.generated_at,
+    }
+  }
+  if (!isPortableContentOnlyV2Workbook(parsed)) {
+    return parsed.metadata
+  }
+  return {
+    ...parsed.metadata,
+    dossier_id: version.dossier_id,
+    baseline_version_id: version.id,
+    baseline_revision: version.revision,
+  }
+}
+
 function toLegacyRows(
   parsed: Extract<
     TechnicalConfigurationBaselineWorkbookCompatibleParseResult,
@@ -142,17 +181,7 @@ export function toTechnicalConfigurationBaselineHierarchyImportRpcArgs(
 ): TechnicalConfigurationBaselineHierarchyImportRpcArgs {
   return {
     p_baseline_version_id: version.id,
-    p_template_metadata:
-      parsed.format === "v2"
-        ? parsed.metadata
-        : {
-            template_kind: BASELINE_WORKBOOK_V2_TEMPLATE_KIND,
-            template_version: BASELINE_WORKBOOK_V2_TEMPLATE_VERSION,
-            dossier_id: parsed.metadata.dossier_id,
-            baseline_version_id: parsed.metadata.baseline_version_id,
-            baseline_revision: parsed.metadata.baseline_revision,
-            generated_at: parsed.metadata.generated_at,
-          },
+    p_template_metadata: toHierarchyImportTemplateMetadata(parsed, version),
     p_rows: parsed.format === "v2" ? toV2Rows(parsed) : toLegacyRows(parsed, version),
     p_expected_revision: version.revision,
   }

--- a/src/lib/technical-configuration-baseline-excel-v2-parse-rows.ts
+++ b/src/lib/technical-configuration-baseline-excel-v2-parse-rows.ts
@@ -14,10 +14,12 @@ const POSITIVE_INTEGER_MARKER_PATTERN = /^[1-9][0-9]*$/
 
 function classifyRowMarker(
   stt: string | null,
-  existingCriterionTitle: string | null
+  existingCriterionTitle: string | null,
+  criterionTitleHint: string | null
 ): "GROUP" | "SUBGROUP" | "CRITERION" | null {
   if (stt === null) return "CRITERION"
   if (existingCriterionTitle !== null && stt === existingCriterionTitle) return "CRITERION"
+  if (criterionTitleHint !== null) return "CRITERION"
   if (ROMAN_MARKER_PATTERN.test(stt)) return "GROUP"
   if (POSITIVE_INTEGER_MARKER_PATTERN.test(stt)) return "SUBGROUP"
   return null
@@ -57,11 +59,11 @@ export function parseTechnicalConfigurationBaselineWorkbookV2Rows(
     const values = BASELINE_WORKBOOK_V2_COLUMNS.map((_, index) =>
       toNullableTechnicalConfigurationBaselineWorkbookV2Text(worksheetRow.getCell(index + 1).value)
     )
-    const [stt, content, groupId, subgroupId, criterionId, criterionCode] = values
+    const [stt, content, groupId, subgroupId, criterionId, criterionCode, criterionTitle] = values
     if (values.every((value) => value === null)) continue
 
     const existingCriterion = criterionId ? criteriaById.get(criterionId) : undefined
-    const rowType = classifyRowMarker(stt, existingCriterion?.title ?? null)
+    const rowType = classifyRowMarker(stt, existingCriterion?.title ?? null, criterionTitle)
     if (!rowType) {
       issues.push({
         code: "unsupported_marker",


### PR DESCRIPTION
## Summary
- allow content-only V2 blank templates to initialize a different empty technical-configuration dossier by rebinding metadata to the selected target draft
- keep V2 workbooks with group, subgroup, criterion, or criterion-code identity source-bound; keep V1 and server contracts unchanged
- restore V2 criterion-title round trips while preserving authoritative hierarchy identity behavior

## Verification
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- portability and hierarchy import regressions: 15/15
- all V2 Excel tests: 36/36
- server hierarchy import contract: 8/8
- React Doctor: 100/100

## Database
- no migration, RPC signature change, or live database write


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables importing V2 blank technical-configuration templates across dossiers by rebinding workbook metadata to the selected target draft. Previously, content‑only V2 workbooks remained source‑bound and failed the server metadata check; now they import as new hierarchy content without weakening foreign‑identity protection.

- Behavior changes
  - Rebind only content‑only V2 workbooks: when every row has null group/subgroup/criterion/criterion‑code identity, replace `dossier_id`, `baseline_version_id`, and `baseline_revision` with the target draft while preserving template kind/version and `generated_at`.
  - Keep V2 workbooks with any identity source‑bound and on the existing server rejection path; V1 handling is unchanged.
  - Restore V2 criterion‑title round trips: use the hidden criterion title as a classification hint only; do not trust or import it as identity. New criteria with cleared identity return a null title.

- Review/rollout
  - Pure client‑side adapter and parser updates; server contract, RPC signatures, and database remain unchanged.
  - Added focused UI and byte‑level tests covering portable and negative identity cases.

<sup>Written for commit 3506b2d7faa207f53315c16f5be5003646f1d7f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

