### PR TITLE
refactor(technical-configurations): use Shadcn Select for baseline criterion owner

### DIFF
--- a/docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md
+++ b/docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md
@@ -84,7 +84,7 @@ await selectCriterionOwnerOption(
 )
 ```
 
-- [ ] **Step 4: Chạy test xác nhận FAIL (đỏ)**
+- [x] **Step 4: Chạy test xác nhận FAIL (đỏ)**
 
 Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"`
 Expected: test "moves a criterion…" FAIL (native select không mở listbox qua ArrowDown → không tìm thấy `role="option"`); 2 test còn lại PASS.
@@ -102,17 +102,12 @@ Expected: test "moves a criterion…" FAIL (native select không mở listbox qu
 - Consumes: `Select, SelectContent, SelectItem, SelectTrigger, SelectValue` từ `@/components/ui/select`; `getTechnicalConfigurationBaselineCriterionOwnerValue` + type option từ `./TechnicalConfigurationBaselineHierarchyAuthoring` (không đổi).
 - Produces: cùng props API như cũ — caller không đổi gì.
 
-- [ ] **Step 1: Ghi nội dung mới cho file**
+- [x] **Step 1: Ghi nội dung mới cho file**
 
 ```tsx
 "use client"
 
 import type { TechnicalConfigurationBaselineEditorCriterionOwner } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
-
-import {
-  getTechnicalConfigurationBaselineCriterionOwnerValue,
-  type TechnicalConfigurationBaselineCriterionOwnerOption,
-} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
 
 import {
   Select,
@@ -121,6 +116,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerValue,
+  type TechnicalConfigurationBaselineCriterionOwnerOption,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
 
 type TechnicalConfigurationBaselineCriterionOwnerSelectProps = Readonly<{
   label: string
@@ -162,12 +162,12 @@ export function TechnicalConfigurationBaselineCriterionOwnerSelect({
 }
 ```
 
-- [ ] **Step 2: Chạy lại test Task 1 xác nhận PASS (xanh)**
+- [x] **Step 2: Chạy lại test Task 1 xác nhận PASS (xanh)**
 
 Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"`
 Expected: PASS 3/3 (assertion `combobox` ở test thứ 3 vẫn đúng vì Radix trigger có role `combobox`).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/app/\(app\)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"
@@ -182,12 +182,12 @@ git commit -m "refactor(technical-configurations): use shadcn select for baselin
 
 **Files:** không sửa thêm (chỉ chạy kiểm chứng).
 
-- [ ] **Step 1: Focused regression cho các test gián tiếp liên quan**
+- [x] **Step 1: Focused regression cho các test gián tiếp liên quan**
 
 Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section.test.tsx" "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx" "src/app/(app)/technical-configurations/__tests__/TechnicalConfigurationVersionBar.test.tsx"`
 Expected: PASS (2 file đầu render component qua editor; VersionBar là sanity check pattern Radix).
 
-- [ ] **Step 2: Chain gates theo đúng thứ tự AGENTS.md**
+- [x] **Step 2: Chain gates theo đúng thứ tự AGENTS.md**
 
 ```bash
 node scripts/npm-run.js run verify:no-explicit-any

--- a/docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md
+++ b/docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md
@@ -1,0 +1,207 @@
+# Baseline Criterion Owner Select → Shadcn Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thay native HTML `<select>` bằng Shadcn/Radix Select trong dropdown cột "Vị trí" của bảng "Bản nháp cấu hình cơ sở" mà không đổi props API.
+
+**Architecture:** Swap internals của đúng 1 component trung gian (`TechnicalConfigurationBaselineCriterionOwnerSelect`) — cả 2 caller (spreadsheet desktop + subgroup mobile) tự hưởng. Trigger giữ `h-9` để khớp density hàng với `Input`/`Textarea` kề bên. Portal của Radix khắc phục dropdown bị cắt trong container `overflow-x-auto`.
+
+**Tech Stack:** Next.js App Router, React 19, Radix Select (`@/components/ui/select`), Vitest + Testing Library + userEvent.
+
+**Spec:** Yêu cầu trực tiếp từ maintainer (session 2026-08-23): "đổi dropdown cột Vị trí từ native HTML sang Shadcn component"; đã chốt hướng giữ `h-9` compact. Không có spec file riêng.
+
+## Global Constraints
+
+- Không đổi props API: `label`, `owner`, `options`, `disabled`, `onMove` giữ nguyên tên và kiểu.
+- Không sửa caller: `TechnicalConfigurationBaselineSubgroupCriteria.tsx`, `TechnicalConfigurationCriteriaSpreadsheet.tsx`.
+- Không sửa `src/components/ui/select.tsx`.
+- Trigger height phải là `h-9` (không dùng mặc định `h-10`) để khớp hàng grid.
+- Accessible name giữ nguyên dạng "Chuyển …" qua `aria-label` trên trigger (test phụ thuộc vào nó).
+- File ≤450 dòng; không thêm comment trừ khi cần.
+- Verification chain bắt buộc trước commit: `verify:no-explicit-any` → `verify:dedupe` → `typecheck` → focused vitest → `react-doctor` (diff-only), tất cả qua `node scripts/npm-run.js`.
+- Lefthook không được bypass (`--no-verify` cấm).
+
+---
+
+### Task 1: Chuyển test sang tương tác Radix (bước đỏ TDD)
+
+**Files:**
+
+- Modify: `src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx:2,227-245`
+
+**Interfaces:**
+
+- Consumes: pattern jsdom đã có trong repo tại `__tests__/technical-configuration-baseline-tab-fixtures.tsx:218-228` (`act(focus)` + `{ArrowDown}` mở dropdown, click `role="option"`).
+- Produces: 2 helper test-local `openCriterionOwnerSelect`, `selectCriterionOwnerOption`.
+
+Lý do vỡ: test hiện dùng `user.selectOptions()` (chỉ hoạt động với native select). Option labels sinh bởi `getTechnicalConfigurationBaselineCriterionOwnerOptions` (`TechnicalConfigurationBaselineHierarchyAuthoring.ts:67-89`): `"I. Yêu cầu chung - Trực tiếp"`, `"I.1 Hạ tầng"`, `"I.2 Môi trường"`, `"II. Yêu cầu bổ sung - Trực tiếp"`.
+
+- [x] **Step 1: Sửa import thêm `act`**
+
+```tsx
+import { act, render, screen, within } from "@testing-library/react"
+```
+
+- [x] **Step 2: Thêm 2 helper sau khối `initialDraft` (trước `AuthoringHarness`)**
+
+```tsx
+type SelectUser = {
+  click: (element: Element) => Promise<void>
+  keyboard: (text: string) => Promise<void>
+}
+
+async function openCriterionOwnerSelect(user: SelectUser, name: string | RegExp) {
+  const trigger = screen.getByRole("combobox", { name })
+  act(() => trigger.focus())
+  await user.keyboard("{ArrowDown}")
+}
+
+async function selectCriterionOwnerOption(
+  user: SelectUser,
+  name: string | RegExp,
+  optionName: string
+) {
+  await openCriterionOwnerSelect(user, name)
+  await user.click(await screen.findByRole("option", { name: optionName }))
+}
+```
+
+- [x] **Step 3: Thay 2 lượt `selectOptions` trong test "moves a criterion between direct and subgroup owners without changing identity"**
+
+Thay block dòng 227–232:
+
+```tsx
+await selectCriterionOwnerOption(user, "Chuyển tiêu chí trực tiếp 1 của nhóm I", "I.1 Hạ tầng")
+```
+
+Thay block dòng 240–245:
+
+```tsx
+await selectCriterionOwnerOption(
+  user,
+  "Chuyển tiêu chí 2 của nhóm con 1, nhóm I",
+  "II. Yêu cầu bổ sung - Trực tiếp"
+)
+```
+
+- [ ] **Step 4: Chạy test xác nhận FAIL (đỏ)**
+
+Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"`
+Expected: test "moves a criterion…" FAIL (native select không mở listbox qua ArrowDown → không tìm thấy `role="option"`); 2 test còn lại PASS.
+
+---
+
+### Task 2: Swap sang Shadcn Select (bước xanh)
+
+**Files:**
+
+- Modify: `src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx` (toàn bộ body render, giữ nguyên type props)
+
+**Interfaces:**
+
+- Consumes: `Select, SelectContent, SelectItem, SelectTrigger, SelectValue` từ `@/components/ui/select`; `getTechnicalConfigurationBaselineCriterionOwnerValue` + type option từ `./TechnicalConfigurationBaselineHierarchyAuthoring` (không đổi).
+- Produces: cùng props API như cũ — caller không đổi gì.
+
+- [ ] **Step 1: Ghi nội dung mới cho file**
+
+```tsx
+"use client"
+
+import type { TechnicalConfigurationBaselineEditorCriterionOwner } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
+
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerValue,
+  type TechnicalConfigurationBaselineCriterionOwnerOption,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+type TechnicalConfigurationBaselineCriterionOwnerSelectProps = Readonly<{
+  label: string
+  owner: TechnicalConfigurationBaselineEditorCriterionOwner
+  options: readonly TechnicalConfigurationBaselineCriterionOwnerOption[]
+  disabled: boolean
+  onMove: (owner: TechnicalConfigurationBaselineEditorCriterionOwner) => void
+}>
+
+/** Selects a canonical direct or subgroup owner for one criterion. */
+export function TechnicalConfigurationBaselineCriterionOwnerSelect({
+  label,
+  owner,
+  options,
+  disabled,
+  onMove,
+}: TechnicalConfigurationBaselineCriterionOwnerSelectProps): React.JSX.Element {
+  return (
+    <Select
+      value={getTechnicalConfigurationBaselineCriterionOwnerValue(owner)}
+      disabled={disabled}
+      onValueChange={(value) => {
+        const target = options.find((option) => option.value === value)
+        if (target) onMove(target.owner)
+      }}
+    >
+      <SelectTrigger aria-label={label} className="h-9 w-full min-w-0 px-2">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+```
+
+- [ ] **Step 2: Chạy lại test Task 1 xác nhận PASS (xanh)**
+
+Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"`
+Expected: PASS 3/3 (assertion `combobox` ở test thứ 3 vẫn đúng vì Radix trigger có role `combobox`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(app\)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx"
+git commit -m "refactor(technical-configurations): use shadcn select for baseline criterion owner"
+```
+
+(Lefthook sẽ tự chạy Prettier + 2 gate diff-only.)
+
+---
+
+### Task 3: Regression + verification chain
+
+**Files:** không sửa thêm (chỉ chạy kiểm chứng).
+
+- [ ] **Step 1: Focused regression cho các test gián tiếp liên quan**
+
+Run: `node scripts/npm-run.js npx vitest run "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-group-section.test.tsx" "src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-tab-workflow.test.tsx" "src/app/(app)/technical-configurations/__tests__/TechnicalConfigurationVersionBar.test.tsx"`
+Expected: PASS (2 file đầu render component qua editor; VersionBar là sanity check pattern Radix).
+
+- [ ] **Step 2: Chain gates theo đúng thứ tự AGENTS.md**
+
+```bash
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run react-doctor
+```
+
+Expected: tất cả PASS.
+
+---
+
+## Self-review
+
+1. **Spec coverage:** swap UI ✓ · props giữ nguyên ✓ · `h-9` ✓ · portal chống cắt ✓ · test vỡ được cập nhật ✓ · verification chain ✓.
+2. **Placeholder scan:** không có TBD/TODO; mọi step đều có code/lệnh cụ thể.
+3. **Type consistency:** `SelectUser` khớp cách dùng `user.click/keyboard`; `option.value/label/owner` nhất quán giữa component và helper build options; tên helper thống nhất.

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-hierarchy-authoring-controls.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { render, screen, within } from "@testing-library/react"
+import { act, render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
@@ -72,6 +72,26 @@ const initialDraft: TechnicalConfigurationBaselineEditorDraft = {
       subgroups: [],
     },
   ],
+}
+
+type SelectUser = {
+  click: (element: Element) => Promise<void>
+  keyboard: (text: string) => Promise<void>
+}
+
+async function openCriterionOwnerSelect(user: SelectUser, name: string | RegExp) {
+  const trigger = screen.getByRole("combobox", { name })
+  act(() => trigger.focus())
+  await user.keyboard("{ArrowDown}")
+}
+
+async function selectCriterionOwnerOption(
+  user: SelectUser,
+  name: string | RegExp,
+  optionName: string
+) {
+  await openCriterionOwnerSelect(user, name)
+  await user.click(await screen.findByRole("option", { name: optionName }))
 }
 
 function AuthoringHarness(): React.JSX.Element {
@@ -224,12 +244,7 @@ describe("technical configuration baseline hierarchy authoring controls", () => 
     const user = userEvent.setup()
     render(<AuthoringHarness />)
 
-    await user.selectOptions(
-      screen.getByRole("combobox", {
-        name: "Chuyển tiêu chí trực tiếp 1 của nhóm I",
-      }),
-      "section-a:subgroup-a"
-    )
+    await selectCriterionOwnerOption(user, "Chuyển tiêu chí trực tiếp 1 của nhóm I", "I.1 Hạ tầng")
 
     const subgroup = screen.getByRole("region", {
       name: "Nhóm con 1 của nhóm I: Hạ tầng",
@@ -237,11 +252,10 @@ describe("technical configuration baseline hierarchy authoring controls", () => 
     expect(within(subgroup).getByDisplayValue("Nguồn điện ổn định")).toBeInTheDocument()
     expect(within(subgroup).getByText("TC-0001")).toBeInTheDocument()
 
-    await user.selectOptions(
-      within(subgroup).getByRole("combobox", {
-        name: "Chuyển tiêu chí 2 của nhóm con 1, nhóm I",
-      }),
-      "section-b:direct"
+    await selectCriterionOwnerOption(
+      user,
+      "Chuyển tiêu chí 2 của nhóm con 1, nhóm I",
+      "II. Yêu cầu bổ sung - Trực tiếp"
     )
 
     const secondSection = screen.getByRole("region", { name: "Nhóm tiêu chí II" })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
@@ -3,17 +3,17 @@
 import type { TechnicalConfigurationBaselineEditorCriterionOwner } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 
 import {
-  getTechnicalConfigurationBaselineCriterionOwnerValue,
-  type TechnicalConfigurationBaselineCriterionOwnerOption,
-} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
-
-import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+
+import {
+  getTechnicalConfigurationBaselineCriterionOwnerValue,
+  type TechnicalConfigurationBaselineCriterionOwnerOption,
+} from "./TechnicalConfigurationBaselineHierarchyAuthoring"
 
 type TechnicalConfigurationBaselineCriterionOwnerSelectProps = Readonly<{
   label: string

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineCriterionOwnerSelect.tsx
@@ -7,6 +7,14 @@ import {
   type TechnicalConfigurationBaselineCriterionOwnerOption,
 } from "./TechnicalConfigurationBaselineHierarchyAuthoring"
 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
 type TechnicalConfigurationBaselineCriterionOwnerSelectProps = Readonly<{
   label: string
   owner: TechnicalConfigurationBaselineEditorCriterionOwner
@@ -24,21 +32,24 @@ export function TechnicalConfigurationBaselineCriterionOwnerSelect({
   onMove,
 }: TechnicalConfigurationBaselineCriterionOwnerSelectProps): React.JSX.Element {
   return (
-    <select
-      aria-label={label}
-      className="h-9 w-full min-w-0 rounded-md border border-input bg-background px-2 text-sm"
+    <Select
       value={getTechnicalConfigurationBaselineCriterionOwnerValue(owner)}
       disabled={disabled}
-      onChange={(event) => {
-        const target = options.find((option) => option.value === event.target.value)
+      onValueChange={(value) => {
+        const target = options.find((option) => option.value === value)
         if (target) onMove(target.owner)
       }}
     >
-      {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+      <SelectTrigger aria-label={label} className="h-9 w-full min-w-0 px-2">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,15 +1,27 @@
-import '@testing-library/jest-dom/vitest'
-import { vi } from 'vitest'
+import "@testing-library/jest-dom/vitest"
+import { vi } from "vitest"
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
 
 type NextAfterTask = Promise<unknown> | (() => unknown | Promise<unknown>)
 
-vi.mock('next/server', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('next/server')>()
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>()
   return {
     ...actual,
     after: (task: NextAfterTask) => {
       setTimeout(() => {
-        if (typeof task === 'function') {
+        if (typeof task === "function") {
           void task()
           return
         }


### PR DESCRIPTION
## Mục tiêu
Đổi dropdown cột **Vị trí** trong bảng "Bản nháp cấu hình cơ sở" (tab Cấu hình cơ sở, /technical-configurations) từ native HTML `<select>` sang Shadcn/Radix Select.

## Thay đổi
- `TechnicalConfigurationBaselineCriterionOwnerSelect.tsx`: swap internals sang `Select/SelectTrigger/SelectContent/SelectItem`. Props API giữ nguyên → cả 2 caller (`TechnicalConfigurationBaselineSubgroupCriteria.tsx`, `TechnicalConfigurationCriteriaSpreadsheet.tsx`) không đổi.
- Trigger `h-9 w-full min-w-0` để giữ density hàng khớp Input/Textarea kề bên (mặc định h-10 sẽ lệch hàng).
- Portal của Radix khắc phục dropdown bị cắt trong container `overflow-x-auto`.
- Test: thay `user.selectOptions()` (native-only) bằng pattern Radix đã có trong repo (focus trigger + ArrowDown + click option).
- `vitest.setup.ts`: stub jsdom `scrollIntoView`/`hasPointerCapture`/`releasePointerCapture` — jsdom thiếu các API này khiến Radix Select văng lỗi khi mở content.
- Kèm plan file `docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md`.

## Verification
- TDD: đỏ (1 fail đúng lý do) → xanh 3/3 sau swap
- Regression: baseline-group-section + hierarchy-tab-workflow + VersionBar = 19/19 PASS
- Gates: verify:no-explicit-any ✓ · verify:dedupe ✓ · typecheck ✓ · react-doctor (no issues) ✓
- Lefthook pre-commit: prettier + dedupe + no-explicit-any ✓

## Ghi chú môi trường
node_modules trên VPS đang lệch lockfile (react 18.3.1 vs ^19.2.7, thiếu @heroui/react) khiến toàn bộ test .tsx đỏ sẵn trên HEAD; đã đồng bộ bằng `npm ci` — không ảnh hưởng repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the native owner dropdown in Technical Configurations with Shadcn/Radix `Select` to prevent clipping in scroll containers and match input density. Old behavior: HTML <select> inside a scrolling table. New behavior: Radix `Select` with a portal; no prop or caller changes.

- Swaps internals of `TechnicalConfigurationBaselineCriterionOwnerSelect.tsx` to `@/components/ui/select` (`Select`, `SelectTrigger`, `SelectContent`, `SelectItem`); props unchanged; callers unchanged.
- Styles trigger as `h-9 w-full min-w-0 px-2`; keeps `aria-label` and role `combobox` for accessibility.
- Updates tests to Radix interaction (focus trigger, ArrowDown, click option) with small helpers; removes `user.selectOptions()`.
- Stubs `scrollIntoView`, `hasPointerCapture`, `releasePointerCapture` in `vitest.setup.ts` to satisfy Radix under jsdom; no runtime impact.
- Adds `docs/superpowers/plans/2026-08-23-baseline-owner-select-shadcn.md`.
- No migration required.

<sup>Written for commit aa48165cda7d525163318abc1bea2442e2fad372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

