### PR TITLE
feat(db): add Phase 6 pre-live quality gate checkpoint A

### DIFF
--- a/docs/runbooks/db-quality-gate-oracle.md
+++ b/docs/runbooks/db-quality-gate-oracle.md
@@ -135,6 +135,52 @@ Baseline-forward report chi reusable khi `outcome=PASS`, report high-water khop,
 va `inputHashes.baselineState` khop atomic state hash hien tai. Catch-up, refresh
 hoac health generation moi se invalidate evidence cu.
 
+## Handoff xin phep live apply qua Supabase MCP
+
+Checklist nay la ranh gioi bat buoc giua pre-live PASS va live write. PASS khong
+phai la permission va khong duoc tu dong kich hoat bat ky live write nao.
+
+1. Refresh public `origin/main`, resolve exact landed SHA, va xac nhan
+   `subjectCommit == HEAD == origin/main`. PR-head, feature-branch HEAD, SHA
+   chua land, hoac `origin/main` stale deu khong du dieu kien.
+2. Chay fresh static tren immutable `landed-parent..landed-SHA` va
+   baseline-forward tren cung exact landed SHA. Khong reuse evidence cua PR
+   head. Ca hai report phai co `outcome=PASS`,
+   `requiredChecksComplete=true`, `evidenceAvailable=true`, va
+   `subjectCommit=<exact-landed-SHA>`.
+3. Hoan tat read-only live va baseline comparisons. Chi tiep tuc khi project,
+   migration order/high-water, baseline state, va moi immutable input hash deu
+   healthy va khop.
+4. Load moi report tu immutable Oracle run ID, recompute va verify `digest`, sau
+   do trinh bay day du payload evidence:
+
+```yaml
+landedSha: <exact-40-character-landed-SHA>
+static:
+  evidenceId: oracle:<static-run-id>/report.json
+  digest: <verified-static-report-digest>
+baselineForward:
+  evidenceId: oracle:<baseline-forward-run-id>/report.json
+  digest: <verified-baseline-forward-report-digest>
+```
+
+5. Gui mot permission request moi, gan voi dung `landedSha`, project
+   `cdthersvldpnlbvpufrr`, exact migration path/name, va hai cap
+   `evidenceId`/`digest` tren. Permission phai la cau tra loi affirmative ro
+   rang cho exact live apply hien tai; permission cu, blanket, im lang, mo ho,
+   hoac permission cho target/operation khac deu khong hop le.
+6. Chi sau khi nhan permission hop le, operator moi apply dung migration da
+   duoc review qua Supabase MCP. Khong dung Supabase CLI, khong nhung apply
+   command vao gate/tooling, va khong batch them migration hay live write ngoai
+   permission.
+7. Ngay sau apply, operator dung read-only Supabase MCP de capture observation
+   cho Task 6.5 voi `schemaVersion=1`, `source=supabase-mcp`,
+   `projectRef=cdthersvldpnlbvpufrr`, `capturedAt`, canonical
+   `migrationPath`, `liveVersion`, `liveName`, va non-empty `statements[]`.
+   Persist raw observation va normalized digest-bearing read-back record duoi
+   mot immutable Oracle run ID. Chua co read-back match thi chua duoc bat dau
+   reconciliation hoac claim live apply da verified.
+
 ## Recovery va cleanup
 
 Kiem tra state, lock va database tam:

--- a/openspec/changes/add-database-quality-gate/tasks.md
+++ b/openspec/changes/add-database-quality-gate/tasks.md
@@ -172,13 +172,13 @@ VPS has no scheduled role.
 
 **Purpose:** Enforce the permission boundary and post-apply recovery contract.
 
-- [ ] 6.1 Implement exact landed-SHA evidence checks; reject PR-head-only PASS
+- [x] 6.1 Implement exact landed-SHA evidence checks; reject PR-head-only PASS
       after squash merge.
-- [ ] 6.2 Implement read-only pre-live migration high-water, baseline health,
+- [x] 6.2 Implement read-only pre-live migration high-water, baseline health,
       report digest, and invalidation-key comparison.
-- [ ] 6.3 Prove that PASS only permits asking for explicit permission and cannot
+- [x] 6.3 Prove that PASS only permits asking for explicit permission and cannot
       invoke a live write.
-- [ ] 6.4 Document the exact-operation Supabase MCP apply handoff without
+- [x] 6.4 Document the exact-operation Supabase MCP apply handoff without
       embedding live credentials or an automatic apply command.
 - [ ] 6.5 Implement read-back evidence ingestion and canonical SQL-hash
       verification.

--- a/scripts/__tests__/database-quality-gate-oracle-evidence-store.test.ts
+++ b/scripts/__tests__/database-quality-gate-oracle-evidence-store.test.ts
@@ -1,0 +1,149 @@
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  createOracleEvidenceStore,
+  ORACLE_REPORT_ARTIFACT,
+} from "../db-quality-gate/oracle-evidence-store"
+import type { OracleRemoteClient } from "../db-quality-gate/oracle-remote-client"
+import { BASELINE_RUN_ID, STATIC_RUN_ID } from "./database-quality-gate-pre-live-test-support"
+import {
+  cleanupFixtureRepositories,
+  createFixtureRepository,
+} from "./database-quality-gate-test-support"
+
+const CONFIG = {
+  containerName: "supabase-db",
+  evidenceDirectory: "/opt/supabase-test/quality-gate/evidence",
+  host: "oracle.test",
+  minimumFreeDiskKilobytes: 64,
+  sshHostKeyFingerprint: "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  sshKeyPath: "/tmp/oracle-test.key",
+  sshKnownHostsPath: "/tmp/oracle-test.known-hosts",
+  sshUser: "ubuntu",
+}
+
+function localShellClient(): OracleRemoteClient {
+  return {
+    readJson: () => ({ status: "ok", value: {} }),
+    remote: (command, input) => {
+      const result = spawnSync("sh", ["-c", command], {
+        encoding: "utf8",
+        input,
+      })
+      return result.status === 0
+        ? { status: "ok", value: result.stdout }
+        : {
+            error: result.stderr.trim() || "local shell failed",
+            kind: "unavailable",
+            status: "error",
+          }
+    },
+    sql: () => ({ status: "ok", value: "" }),
+  }
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("Oracle immutable evidence store", () => {
+  it("rejects path-like artifact names before invoking the Oracle client", () => {
+    const calls: string[] = []
+    const client: OracleRemoteClient = {
+      readJson: () => ({ status: "ok", value: {} }),
+      remote: (command) => {
+        calls.push(command)
+        return { status: "ok", value: "" }
+      },
+      sql: () => ({ status: "ok", value: "" }),
+    }
+    const store = createOracleEvidenceStore({ client, config: CONFIG })
+
+    const result = store.readArtifact({
+      artifactName: "../../fabricated.json",
+      runId: BASELINE_RUN_ID,
+    })
+
+    expect(result.status).toBe("error")
+    expect(calls).toEqual([])
+  })
+
+  it("publishes immutable artifacts from a restrictive temporary file without clobbering", () => {
+    const calls: Array<{ command: string; input?: string }> = []
+    const client: OracleRemoteClient = {
+      readJson: () => ({ status: "ok", value: {} }),
+      remote: (command, input) => {
+        calls.push({ command, input })
+        return { status: "ok", value: "" }
+      },
+      sql: () => ({ status: "ok", value: "" }),
+    }
+    const store = createOracleEvidenceStore({ client, config: CONFIG })
+
+    const result = store.persistArtifact({
+      artifactName: ORACLE_REPORT_ARTIFACT,
+      content: "{}\n",
+      runId: STATIC_RUN_ID,
+    })
+
+    expect(result.status).toBe("ok")
+    expect(calls).toHaveLength(1)
+    expect(calls[0].command).toContain('cat > "$temporary_path"')
+    expect(calls[0].command).toContain('ln "$temporary_path" "$artifact_path"')
+    expect(calls[0].command).not.toContain("cat > '/opt/supabase-test/quality-gate/evidence")
+  })
+
+  it("rejects path-like run IDs before invoking the Oracle client", () => {
+    const calls: string[] = []
+    const client: OracleRemoteClient = {
+      readJson: () => ({ status: "ok", value: {} }),
+      remote: (command) => {
+        calls.push(command)
+        return { status: "ok", value: "" }
+      },
+      sql: () => ({ status: "ok", value: "" }),
+    }
+    const store = createOracleEvidenceStore({ client, config: CONFIG })
+
+    const result = store.persistArtifact({
+      artifactName: ORACLE_REPORT_ARTIFACT,
+      content: "{}\n",
+      runId: "../escape",
+    })
+
+    expect(result.status).toBe("error")
+    expect(calls).toEqual([])
+  })
+
+  it("preserves the first immutable artifact when a duplicate publication is attempted", () => {
+    const repository = createFixtureRepository({})
+    const evidenceDirectory = repository.path("evidence")
+    const store = createOracleEvidenceStore({
+      client: localShellClient(),
+      config: {
+        ...CONFIG,
+        evidenceDirectory,
+      },
+    })
+    const artifact = {
+      artifactName: ORACLE_REPORT_ARTIFACT,
+      runId: STATIC_RUN_ID,
+    }
+
+    const first = store.persistArtifact({
+      ...artifact,
+      content: "first\n",
+    })
+    const second = store.persistArtifact({
+      ...artifact,
+      content: "second\n",
+    })
+
+    expect(first.status).toBe("ok")
+    expect(second.status).toBe("error")
+    expect(
+      readFileSync(repository.path("evidence", STATIC_RUN_ID, ORACLE_REPORT_ARTIFACT), "utf8")
+    ).toBe("first\n")
+  })
+})

--- a/scripts/__tests__/database-quality-gate-pre-live-cli.test.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live-cli.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import type { OracleEvidenceStore } from "../db-quality-gate/oracle-evidence-store"
+import type { PreLiveEvidenceDependencies } from "../db-quality-gate/pre-live"
+import type { GateReport } from "../db-quality-gate/types"
+import {
+  BASELINE_RUN_ID,
+  createLandedRepository,
+  dependencies,
+  FakeEvidenceStore,
+  gateReport,
+  STATIC_RUN_ID,
+  storeBaselineReport,
+} from "./database-quality-gate-pre-live-test-support"
+import {
+  cleanupFixtureRepositories,
+  loadDatabaseQualityGateModule,
+} from "./database-quality-gate-test-support"
+
+type CommandModule = {
+  runDatabaseQualityGateCommand: (
+    args: string[],
+    dependencies?: {
+      evidenceStore?: () => OracleEvidenceStore | undefined
+      preLiveDependencies?: Omit<PreLiveEvidenceDependencies, "evidenceStore">
+      repositoryRoot?: string
+    }
+  ) => {
+    exitCode: 0 | 1 | 2
+    stdout: string
+  }
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("database quality gate pre-live CLI", () => {
+  it("dispatches exact landed evidence through the production pre-live command path", async () => {
+    const command = await loadDatabaseQualityGateModule<CommandModule>("cli")
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const baselineReport = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, baselineReport)
+    const injected = dependencies(store, headCommit)
+    const { evidenceStore: _, ...preLiveDependencies } = injected
+
+    const result = command.runDatabaseQualityGateCommand(
+      [
+        "--lane",
+        "pre-live",
+        "--run-id",
+        "phase-6a-pre-live-cli",
+        "--subject-commit",
+        headCommit,
+        "--baseline-forward-run-id",
+        BASELINE_RUN_ID,
+        "--baseline-forward-digest",
+        baselineReport.digest,
+        "--static-run-id",
+        STATIC_RUN_ID,
+        "--live-observation",
+        "fixture-live-observation.json",
+      ],
+      {
+        evidenceStore: () => store,
+        preLiveDependencies,
+        repositoryRoot: repository.root,
+      }
+    )
+    const report = JSON.parse(result.stdout) as GateReport
+
+    expect(result.exitCode).toBe(0)
+    expect(report).toMatchObject({
+      findings: [
+        expect.objectContaining({
+          classification: "WARNING",
+          evidence: { nextAction: "request-explicit-permission" },
+          ruleId: "prelive.permission.explicit-required",
+        }),
+      ],
+      lane: "pre-live",
+      outcome: "PASS",
+      requiredChecksComplete: true,
+      subjectCommit: headCommit,
+    })
+  })
+
+  it.each(["--permission", "--permission-granted", "--approve", "--apply", "--write-live"])(
+    "rejects the unsupported %s state input",
+    async (option) => {
+      const command = await loadDatabaseQualityGateModule<CommandModule>("cli")
+
+      const result = command.runDatabaseQualityGateCommand([
+        "--lane",
+        "pre-live",
+        "--run-id",
+        "phase-6a-no-write",
+        option,
+        "true",
+      ])
+
+      expect(result.exitCode).toBe(2)
+      expect(result.stdout).not.toContain("write")
+      expect(result.stdout).not.toContain("permissionGranted")
+    }
+  )
+
+  it("rejects caller-supplied evaluation time for pre-live", async () => {
+    const command = await loadDatabaseQualityGateModule<CommandModule>("cli")
+
+    const result = command.runDatabaseQualityGateCommand([
+      "--lane",
+      "pre-live",
+      "--run-id",
+      "phase-6a-trusted-clock",
+      "--created-at",
+      "2020-01-01T00:00:00.000Z",
+    ])
+
+    expect(result.exitCode).toBe(2)
+    expect(result.stdout).not.toContain("2020-01-01")
+  })
+})

--- a/scripts/__tests__/database-quality-gate-pre-live-inputs.test.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live-inputs.test.ts
@@ -1,0 +1,147 @@
+import { readFileSync, writeFileSync } from "node:fs"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { baselineStateHash, type BaselineState } from "../db-quality-gate/baseline-state"
+import { readDynamicInputArtifacts } from "../db-quality-gate/dynamic-lane-inputs"
+import {
+  createDynamicRunState,
+  finalizeDynamicLaneReport,
+} from "../db-quality-gate/dynamic-lane-report"
+import { recomputeBaselineForwardInputHashes } from "../db-quality-gate/pre-live-inputs"
+import { runPreLiveEvidenceCheck } from "../db-quality-gate/pre-live"
+import { stableJsonStringify } from "../db-quality-gate/serialization"
+import { runStaticLaneForLandedCommit } from "../db-quality-gate/static-lane"
+import type { MigrationIdentity } from "../db-quality-gate/types"
+import {
+  createDynamicFixture,
+  FakeOracleDynamicExecutor,
+} from "./database-quality-gate-dynamic-test-support"
+import {
+  BASELINE_RUN_ID,
+  CREATED_AT,
+  dependencies,
+  FakeEvidenceStore,
+  git,
+  preLiveInput,
+  storeBaselineReport,
+} from "./database-quality-gate-pre-live-test-support"
+import { cleanupFixtureRepositories } from "./database-quality-gate-test-support"
+import { commitWorkingTree } from "./database-quality-gate-static-test-support"
+
+const CANDIDATE_PATH = "supabase/migrations/20270201000000_candidate.sql"
+
+function baselineStateForFixture(repositoryRoot: string, sourceCommit: string): BaselineState {
+  const lock = JSON.parse(
+    readFileSync(`${repositoryRoot}/supabase/applied-migrations.lock.json`, "utf8")
+  ) as { legacy: MigrationIdentity[] }
+  const identity = lock.legacy[0]
+  const match = /^supabase\/migrations\/(\d{14})_(.+)\.sql$/u.exec(identity?.path ?? "")
+  if (identity === undefined || match === null) {
+    throw new Error("Dynamic fixture baseline migration identity is unavailable")
+  }
+
+  return {
+    checkedAt: CREATED_AT,
+    confirmedMigrations: [
+      {
+        ...identity,
+        liveName: match[2],
+        liveVersion: match[1],
+      },
+    ],
+    generation: "phase6a-input-reconciliation",
+    healthy: true,
+    migrationHighWater: match[1],
+    schemaVersion: 1,
+    sourceCommit,
+  }
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("database quality gate pre-live landed input reconciliation", () => {
+  it("accepts real static and baseline-forward producers with lane-specific hash semantics", () => {
+    const fixture = createDynamicFixture()
+    writeFileSync(
+      fixture.repository.path(...CANDIDATE_PATH.split("/")),
+      [
+        "-- migration",
+        "BEGIN;",
+        "CREATE TABLE public.candidate_only (id bigint PRIMARY KEY);",
+        "REVOKE ALL ON TABLE public.candidate_only FROM anon, authenticated, public;",
+        "COMMIT;",
+        "",
+      ].join("\n")
+    )
+    const subjectCommit = commitWorkingTree(
+      fixture.repository.root,
+      "land safe baseline-forward candidate"
+    )
+    const baselineState = baselineStateForFixture(fixture.repository.root, subjectCommit)
+    const staticReport = runStaticLaneForLandedCommit({
+      createdAt: CREATED_AT,
+      landedParentCommit: git(fixture.repository.root, "rev-parse", "HEAD^"),
+      repositoryRoot: fixture.repository.root,
+      runId: "phase-6a-static",
+      subjectCommit,
+    })
+    const executor = new FakeOracleDynamicExecutor()
+    const dynamicInput = {
+      createdAt: CREATED_AT,
+      executor,
+      lane: "baseline-forward" as const,
+      repositoryRoot: fixture.repository.root,
+      runId: BASELINE_RUN_ID,
+      subjectCommit,
+    }
+    const dynamicState = createDynamicRunState()
+    const artifacts = readDynamicInputArtifacts(dynamicInput, dynamicState)
+    if (artifacts === undefined) {
+      throw new Error("Dynamic fixture inputs must be readable")
+    }
+    dynamicState.baselineMigrationHighWater = baselineState.migrationHighWater
+    dynamicState.catalogInputHashes.baselineState = baselineStateHash(baselineState)
+    const baselineReport = finalizeDynamicLaneReport(
+      dynamicInput,
+      dynamicState,
+      artifacts.migrationIdentities,
+      true,
+      {
+        invariants: artifacts.invariants,
+        sqlTests: artifacts.sqlTestRegistry,
+      }
+    )
+    const store = new FakeEvidenceStore()
+    store.baselineStateContent = `${stableJsonStringify(baselineState)}\n`
+    storeBaselineReport(store, baselineReport)
+
+    const result = runPreLiveEvidenceCheck(
+      {
+        ...preLiveInput(subjectCommit),
+        baselineForwardDigest: baselineReport.digest,
+        repositoryRoot: fixture.repository.root,
+      },
+      dependencies(store, subjectCommit, {
+        readLiveObservation: () => ({
+          capturedAt: "2026-08-23T07:29:00.000Z",
+          migrations: [
+            {
+              name: baselineState.confirmedMigrations[0].liveName,
+              version: baselineState.migrationHighWater,
+            },
+          ],
+          projectRef: "cdthersvldpnlbvpufrr",
+          schemaVersion: 1,
+          source: "supabase-mcp",
+        }),
+        recomputeBaselineForwardInputHashes,
+        runStatic: () => staticReport,
+      })
+    )
+
+    expect(baselineReport.outcome).toBe("PASS")
+    expect(staticReport.outcome, JSON.stringify(staticReport, null, 2)).toBe("PASS")
+    expect(result.outcome, JSON.stringify(result, null, 2)).toBe("PASS")
+  })
+})

--- a/scripts/__tests__/database-quality-gate-pre-live-live-state.test.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live-live-state.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  evaluateLiveMigrationState,
+  parseLiveMigrationObservation,
+} from "../db-quality-gate/pre-live-live-state"
+import type { BaselineState } from "../db-quality-gate/baseline-state"
+import type { AppliedMigrationLock } from "../db-quality-gate/registries"
+
+const CREATED_AT = "2026-08-23T07:30:00.000Z"
+const LIVE_VERSION = "20260819062043"
+
+const baselineState: BaselineState = {
+  checkedAt: CREATED_AT,
+  confirmedMigrations: [],
+  generation: "phase5-baseline",
+  healthy: true,
+  migrationHighWater: LIVE_VERSION,
+  schemaVersion: 1,
+  sourceCommit: "a".repeat(40),
+}
+
+const appliedLock: AppliedMigrationLock = {
+  applied: [
+    {
+      path: `supabase/migrations/${LIVE_VERSION}_candidate.sql`,
+      sha256: "a".repeat(64),
+    },
+  ],
+  cutover: {
+    commit: "b".repeat(40),
+    legacyInventorySha256: "c".repeat(64),
+    migrationRoot: "supabase/migrations",
+  },
+  legacy: [],
+  schemaVersion: 1,
+}
+
+function observation(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    capturedAt: "2026-08-23T07:29:00.000Z",
+    migrations: [{ name: "candidate", version: LIVE_VERSION }],
+    projectRef: "cdthersvldpnlbvpufrr",
+    schemaVersion: 1,
+    source: "supabase-mcp",
+    ...overrides,
+  }
+}
+
+describe("database quality gate pre-live live state", () => {
+  it("parses and hashes a fresh read-only observation deterministically", () => {
+    const parsed = parseLiveMigrationObservation(observation(), CREATED_AT)
+
+    expect(parsed).toMatchObject({
+      capturedAt: "2026-08-23T07:29:00.000Z",
+      migrations: [{ name: "candidate", version: LIVE_VERSION }],
+      projectRef: "cdthersvldpnlbvpufrr",
+    })
+    expect(parsed?.inputHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it.each([
+    ["wrong project", { projectRef: "another-project" }],
+    ["stale capture", { capturedAt: "2026-08-23T07:14:59.999Z" }],
+    ["future capture", { capturedAt: "2026-08-23T07:32:00.001Z" }],
+    [
+      "duplicate versions",
+      {
+        migrations: [
+          { name: "candidate", version: LIVE_VERSION },
+          { name: "duplicate", version: LIVE_VERSION },
+        ],
+      },
+    ],
+    [
+      "unordered versions",
+      {
+        migrations: [
+          { name: "later", version: "20260820000000" },
+          { name: "candidate", version: LIVE_VERSION },
+        ],
+      },
+    ],
+    ["malformed migration", { migrations: [{ name: "", version: "20260819" }] }],
+    ["unknown property", { permissionGranted: true }],
+  ])("rejects %s evidence", (_name, overrides) => {
+    expect(parseLiveMigrationObservation(observation(overrides), CREATED_AT)).toBeUndefined()
+  })
+
+  it("marks live high-water ahead of the published baseline as blocking", () => {
+    const parsed = parseLiveMigrationObservation(
+      observation({
+        migrations: [
+          { name: "candidate", version: LIVE_VERSION },
+          { name: "newer", version: "20260820000000" },
+        ],
+      }),
+      CREATED_AT
+    )
+
+    const result = evaluateLiveMigrationState({
+      appliedLock,
+      baselineState,
+      observation: parsed,
+    })
+
+    expect(result).toMatchObject({
+      liveMigrationHighWater: "20260820000000",
+      status: "baseline-behind",
+    })
+  })
+
+  it("rejects an applied-lock entry missing from the live observation", () => {
+    const parsed = parseLiveMigrationObservation(observation({ migrations: [] }), CREATED_AT)
+
+    expect(
+      evaluateLiveMigrationState({
+        appliedLock,
+        baselineState,
+        observation: parsed,
+      })
+    ).toMatchObject({ status: "invalid" })
+  })
+})

--- a/scripts/__tests__/database-quality-gate-pre-live-static.test.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live-static.test.ts
@@ -1,0 +1,118 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { reportDigest } from "../db-quality-gate/contract"
+import { ORACLE_REPORT_ARTIFACT } from "../db-quality-gate/oracle-evidence-store"
+import { runPreLiveEvidenceCheck } from "../db-quality-gate/pre-live"
+import { runStaticLaneForLandedCommit } from "../db-quality-gate/static-lane"
+import type { GateReport } from "../db-quality-gate/types"
+import {
+  BASELINE_RUN_ID,
+  CREATED_AT,
+  createLandedRepository,
+  dependencies,
+  FakeEvidenceStore,
+  gateReport,
+  git,
+  preLiveInput as input,
+  STATIC_RUN_ID,
+  storeBaselineReport,
+} from "./database-quality-gate-pre-live-test-support"
+import { cleanupFixtureRepositories } from "./database-quality-gate-test-support"
+import {
+  commitWorkingTree,
+  fixtureWithStaticMetadata,
+  repositoryHead,
+} from "./database-quality-gate-static-test-support"
+
+function expectIncomplete(result: GateReport) {
+  expect(result.outcome).toBe("INCOMPLETE")
+  expect(result.requiredChecksComplete).toBe(false)
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("database quality gate pre-live landed static evidence", () => {
+  it("accepts exact landed evidence and persists finalized static before reading baseline-forward", () => {
+    const { headCommit, parentCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const baselineReport = gateReport("baseline-forward", headCommit)
+    const staticReport = gateReport("static", headCommit, { digest: "caller-supplied" })
+    storeBaselineReport(store, baselineReport)
+    let receivedParent: string | undefined
+    const request = {
+      ...input(headCommit),
+      baselineForwardDigest: baselineReport.digest,
+      repositoryRoot: repository.root,
+    }
+
+    const result = runPreLiveEvidenceCheck(
+      request,
+      dependencies(store, headCommit, {
+        runStatic: (staticInput) => {
+          receivedParent = staticInput.landedParentCommit
+          return staticReport
+        },
+      })
+    )
+
+    expect(result.outcome).toBe("PASS")
+    expect(receivedParent).toBe(parentCommit)
+    expect(store.operations).toEqual([
+      `persist:${STATIC_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`,
+      "read:baseline-state",
+      `read:${BASELINE_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`,
+    ])
+    const persisted = JSON.parse(
+      store.artifacts.get(`${STATIC_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`) ?? "{}"
+    ) as GateReport
+    expect(persisted.digest).toBe(reportDigest(persisted))
+    expect(result.inputHashes).toMatchObject({
+      baselineForwardReport: baselineReport.digest,
+      staticReport: persisted.digest,
+    })
+  })
+
+  it("runs static over the exact first-parent diff after origin/main equals HEAD", () => {
+    const repository = fixtureWithStaticMetadata()
+    const parentCommit = repositoryHead(repository.root)
+    const migrationPath = "supabase/migrations/20260823073000_unsafe_search.sql"
+    mkdirSync(repository.path("supabase", "migrations"), { recursive: true })
+    writeFileSync(
+      repository.path(migrationPath),
+      "SELECT * FROM public.items WHERE name ILIKE p_search || '%';\n"
+    )
+    const headCommit = commitWorkingTree(repository.root, "land unsafe migration")
+    git(repository.root, "update-ref", "refs/remotes/origin/main", headCommit)
+
+    const result = runStaticLaneForLandedCommit({
+      createdAt: CREATED_AT,
+      landedParentCommit: parentCommit,
+      repositoryRoot: repository.root,
+      runId: STATIC_RUN_ID,
+      subjectCommit: headCommit,
+    })
+
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "migration.ilike-sanitization",
+      })
+    )
+  })
+
+  it("rejects an arbitrary trusted static base that is not the landed first parent", () => {
+    const { headCommit, repository } = createLandedRepository()
+
+    const result = runStaticLaneForLandedCommit({
+      createdAt: CREATED_AT,
+      landedParentCommit: headCommit,
+      repositoryRoot: repository.root,
+      runId: STATIC_RUN_ID,
+      subjectCommit: headCommit,
+    })
+
+    expectIncomplete(result)
+  })
+})

--- a/scripts/__tests__/database-quality-gate-pre-live-test-support.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live-test-support.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from "node:child_process"
+import { writeFileSync } from "node:fs"
+
+import { baselineStateHash } from "../db-quality-gate/baseline-state"
+import { finalizeReport } from "../db-quality-gate/contract"
+import type { OracleExecutorResult } from "../db-quality-gate/dynamic-lane-types"
+import { ORACLE_REPORT_ARTIFACT } from "../db-quality-gate/oracle-evidence-store"
+import type { OracleEvidenceStore } from "../db-quality-gate/oracle-evidence-store"
+import type { PreLiveEvidenceDependencies, PreLiveEvidenceInput } from "../db-quality-gate/pre-live"
+import type { AppliedMigrationLock } from "../db-quality-gate/registries"
+import { stableJsonStringify } from "../db-quality-gate/serialization"
+import type { BaselineState } from "../db-quality-gate/baseline-state"
+import type { GateReport, MigrationIdentity } from "../db-quality-gate/types"
+import {
+  createFixtureRepository,
+  type FixtureRepository,
+} from "./database-quality-gate-test-support"
+import { commitWorkingTree } from "./database-quality-gate-static-test-support"
+
+export const CREATED_AT = "2026-08-23T07:30:00Z"
+export const PRE_LIVE_RUN_ID = "phase-6a-pre-live"
+export const STATIC_RUN_ID = "phase-6a-static"
+export const BASELINE_RUN_ID = "phase-5-baseline-forward"
+
+const MIGRATION_IDENTITIES: MigrationIdentity[] = [
+  {
+    path: "supabase/migrations/20260819062043_candidate.sql",
+    sha256: "a".repeat(64),
+  },
+]
+
+const PUBLISHED_BASELINE_STATE: BaselineState = {
+  checkedAt: CREATED_AT,
+  confirmedMigrations: [
+    {
+      liveName: "candidate",
+      liveVersion: "20260819062043",
+      path: MIGRATION_IDENTITIES[0].path,
+      sha256: MIGRATION_IDENTITIES[0].sha256,
+    },
+  ],
+  generation: "phase5-baseline",
+  healthy: true,
+  migrationHighWater: "20260819062043",
+  schemaVersion: 1,
+  sourceCommit: "a".repeat(40),
+}
+
+const SHARED_INPUT_HASHES = {
+  invariants: "invariants-hash",
+  migration: "migration-hash",
+  sqlTests: "sql-tests-hash",
+}
+
+const PUBLISHED_APPLIED_LOCK: AppliedMigrationLock = {
+  applied: [],
+  cutover: {
+    commit: "b".repeat(40),
+    legacyInventorySha256: "c".repeat(64),
+    migrationRoot: "supabase/migrations",
+  },
+  legacy: [],
+  schemaVersion: 1,
+}
+
+const LIVE_OBSERVATION = {
+  capturedAt: "2026-08-23T07:29:00.000Z",
+  migrations: [{ name: "candidate", version: "20260819062043" }],
+  projectRef: "cdthersvldpnlbvpufrr",
+  schemaVersion: 1,
+  source: "supabase-mcp",
+}
+
+type ArtifactInput = {
+  artifactName: string
+  runId: string
+}
+
+type PersistArtifactInput = ArtifactInput & {
+  content: string
+}
+
+export class FakeEvidenceStore implements OracleEvidenceStore {
+  readonly artifacts = new Map<string, string>()
+  readonly operations: string[] = []
+  readonly readFailures = new Set<string>()
+  baselineStateContent = `${stableJsonStringify(PUBLISHED_BASELINE_STATE)}\n`
+  persistFailure = false
+
+  readBaselineState(): OracleExecutorResult<string> {
+    this.operations.push("read:baseline-state")
+    return { status: "ok", value: this.baselineStateContent }
+  }
+
+  readArtifact(input: ArtifactInput): OracleExecutorResult<string> {
+    this.operations.push(`read:${input.runId}/${input.artifactName}`)
+    const key = this.key(input)
+    if (this.readFailures.has(key)) {
+      return {
+        error: "Oracle evidence is unreadable",
+        kind: "unavailable",
+        status: "error",
+      }
+    }
+    const value = this.artifacts.get(key)
+    return value === undefined
+      ? {
+          error: "Unknown immutable Oracle run ID",
+          kind: "unavailable",
+          status: "error",
+        }
+      : { status: "ok", value }
+  }
+
+  persistArtifact(input: PersistArtifactInput): OracleExecutorResult<{ evidenceId: string }> {
+    this.operations.push(`persist:${input.runId}/${input.artifactName}`)
+    if (this.persistFailure) {
+      return {
+        error: "Oracle evidence persistence failed",
+        kind: "unavailable",
+        status: "error",
+      }
+    }
+    const key = this.key(input)
+    if (this.artifacts.has(key)) {
+      return {
+        error: "Immutable Oracle evidence already exists",
+        kind: "unavailable",
+        status: "error",
+      }
+    }
+    this.artifacts.set(key, input.content)
+    return { status: "ok", value: { evidenceId: `oracle:${key}` } }
+  }
+
+  private key(input: ArtifactInput): string {
+    return `${input.runId}/${input.artifactName}`
+  }
+}
+
+export function git(repositoryRoot: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }).trim()
+}
+
+export function createLandedRepository(): {
+  headCommit: string
+  parentCommit: string
+  repository: FixtureRepository
+} {
+  const repository = createFixtureRepository({ "README.md": "parent\n" })
+  git(repository.root, "init", "--quiet")
+  git(repository.root, "config", "user.email", "gate@example.test")
+  git(repository.root, "config", "user.name", "Database Quality Gate")
+  const parentCommit = commitWorkingTree(repository.root, "parent")
+  writeFileSync(repository.path("candidate.txt"), "landed\n")
+  const headCommit = commitWorkingTree(repository.root, "landed squash commit")
+  git(repository.root, "branch", "-M", "main")
+  const origin = createFixtureRepository({})
+  git(origin.root, "init", "--quiet", "--bare")
+  git(repository.root, "remote", "add", "origin", origin.root)
+  git(repository.root, "push", "--quiet", "--set-upstream", "origin", "main")
+
+  return { headCommit, parentCommit, repository }
+}
+
+export function gateReport(
+  lane: GateReport["lane"],
+  subjectCommit: string,
+  overrides: Partial<GateReport> = {}
+): GateReport {
+  return finalizeReport({
+    baselineMigrationHighWater: "20260819062043",
+    createdAt: CREATED_AT,
+    digest: "",
+    evidenceAvailable: true,
+    executorEnvironment: { oracle: "fixture" },
+    findings: [],
+    inputHashes:
+      lane === "baseline-forward"
+        ? {
+            baselineState: baselineStateHash(PUBLISHED_BASELINE_STATE),
+            ...SHARED_INPUT_HASHES,
+          }
+        : SHARED_INPUT_HASHES,
+    lane,
+    migrationIdentities: MIGRATION_IDENTITIES,
+    outcome: "PASS",
+    requiredChecksComplete: true,
+    runId: lane === "static" ? STATIC_RUN_ID : BASELINE_RUN_ID,
+    schemaVersion: 1,
+    subjectCommit,
+    ...overrides,
+  })
+}
+
+export function dependencies(
+  store: FakeEvidenceStore,
+  headCommit: string,
+  overrides: Partial<PreLiveEvidenceDependencies> = {}
+): PreLiveEvidenceDependencies {
+  return {
+    clock: () => CREATED_AT,
+    evidenceStore: store,
+    readAppliedMigrationLock: overrides.readAppliedMigrationLock ?? (() => PUBLISHED_APPLIED_LOCK),
+    readLiveObservation: overrides.readLiveObservation ?? (() => LIVE_OBSERVATION),
+    recomputeBaselineForwardInputHashes:
+      overrides.recomputeBaselineForwardInputHashes ?? (() => SHARED_INPUT_HASHES),
+    refreshOriginMain: overrides.refreshOriginMain ?? (() => headCommit),
+    runStatic: overrides.runStatic ?? ((input) => gateReport("static", input.subjectCommit)),
+  }
+}
+
+export function preLiveInput(headCommit: string): PreLiveEvidenceInput {
+  return {
+    baselineForwardDigest: "",
+    baselineForwardRunId: BASELINE_RUN_ID,
+    liveObservationPath: "fixture-live-observation.json",
+    repositoryRoot: "",
+    runId: PRE_LIVE_RUN_ID,
+    staticRunId: STATIC_RUN_ID,
+    subjectCommit: headCommit,
+  }
+}
+
+export function storeBaselineReport(store: FakeEvidenceStore, report: GateReport) {
+  store.artifacts.set(`${report.runId}/${ORACLE_REPORT_ARTIFACT}`, `${JSON.stringify(report)}\n`)
+}

--- a/scripts/__tests__/database-quality-gate-pre-live.test.ts
+++ b/scripts/__tests__/database-quality-gate-pre-live.test.ts
@@ -1,0 +1,377 @@
+import { writeFileSync } from "node:fs"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createFindingFingerprint, finalizeReport, reportDigest } from "../db-quality-gate/contract"
+import { ORACLE_REPORT_ARTIFACT } from "../db-quality-gate/oracle-evidence-store"
+import {
+  runPreLiveEvidenceCheck,
+  type PreLiveEvidenceDependencies,
+} from "../db-quality-gate/pre-live"
+import { refreshPublicOriginMain } from "../db-quality-gate/git-evidence"
+import type { GateReport } from "../db-quality-gate/types"
+import {
+  BASELINE_RUN_ID,
+  createLandedRepository,
+  dependencies,
+  FakeEvidenceStore,
+  gateReport,
+  git,
+  preLiveInput as input,
+  STATIC_RUN_ID,
+  storeBaselineReport,
+} from "./database-quality-gate-pre-live-test-support"
+import { cleanupFixtureRepositories } from "./database-quality-gate-test-support"
+import { commitWorkingTree } from "./database-quality-gate-static-test-support"
+
+function expectIncomplete(result: GateReport) {
+  expect(result.outcome).toBe("INCOMPLETE")
+  expect(result.requiredChecksComplete).toBe(false)
+}
+
+afterEach(cleanupFixtureRepositories)
+
+describe("database quality gate pre-live landed evidence", () => {
+  it("rejects PR-head-only baseline-forward evidence after a squash merge", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const prHeadReport = gateReport("baseline-forward", "b".repeat(40))
+    storeBaselineReport(store, prHeadReport)
+    const request = {
+      ...input(headCommit),
+      baselineForwardDigest: prHeadReport.digest,
+      repositoryRoot: repository.root,
+    }
+
+    const result = runPreLiveEvidenceCheck(request, dependencies(store, headCommit))
+
+    expectIncomplete(result)
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "prelive/evidence-not-landed",
+      })
+    )
+  })
+
+  it.each([
+    ["feature-branch HEAD", "feature"],
+    ["subject commit different from HEAD", "subject"],
+    ["unavailable refreshed origin/main", "unavailable"],
+    ["stale refreshed origin/main", "stale"],
+  ] as const)("rejects %s", (_name, scenario) => {
+    const { headCommit, parentCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+    let subjectCommit = headCommit
+    let refreshOriginMain: PreLiveEvidenceDependencies["refreshOriginMain"]
+
+    if (scenario === "feature") {
+      git(repository.root, "checkout", "--quiet", "-b", "feature")
+      writeFileSync(repository.path("feature.txt"), "feature\n")
+      subjectCommit = commitWorkingTree(repository.root, "feature commit")
+    } else if (scenario === "subject") {
+      subjectCommit = parentCommit
+    } else if (scenario === "unavailable") {
+      refreshOriginMain = () => undefined
+    } else {
+      refreshOriginMain = () => parentCommit
+    }
+
+    const request = {
+      ...input(subjectCommit),
+      baselineForwardDigest: report.digest,
+      repositoryRoot: repository.root,
+    }
+    const result = runPreLiveEvidenceCheck(
+      request,
+      dependencies(store, headCommit, { refreshOriginMain })
+    )
+
+    expectIncomplete(result)
+  })
+
+  it("rejects a local origin instead of weakening the production public HTTPS boundary", () => {
+    const { repository } = createLandedRepository()
+
+    expect(refreshPublicOriginMain(repository.root)).toBeUndefined()
+  })
+
+  it.each([
+    ["unknown run ID", () => undefined],
+    ["unreadable report", () => "unreadable"],
+    ["invalid JSON", () => "{not-json"],
+    ["wrong lane", (headCommit: string) => gateReport("static", headCommit)],
+    [
+      "non-PASS outcome",
+      (headCommit: string) => gateReport("baseline-forward", headCommit, { outcome: "FAILED" }),
+    ],
+    [
+      "explicit INCOMPLETE outcome",
+      (headCommit: string) => gateReport("baseline-forward", headCommit, { outcome: "INCOMPLETE" }),
+    ],
+    [
+      "incomplete required checks",
+      (headCommit: string) =>
+        gateReport("baseline-forward", headCommit, { requiredChecksComplete: false }),
+    ],
+    [
+      "unavailable evidence",
+      (headCommit: string) =>
+        gateReport("baseline-forward", headCommit, { evidenceAvailable: false }),
+    ],
+    [
+      "recomputed digest mismatch",
+      (headCommit: string) => {
+        const report = gateReport("baseline-forward", headCommit)
+        return { ...report, executorEnvironment: { oracle: "tampered" } }
+      },
+    ],
+    [
+      "wrong embedded run ID",
+      (headCommit: string) =>
+        gateReport("baseline-forward", headCommit, { runId: "different-oracle-run" }),
+    ],
+    [
+      "structurally malformed report fields",
+      (headCommit: string) => ({
+        ...gateReport("baseline-forward", headCommit),
+        findings: {},
+      }),
+    ],
+  ])("rejects %s", (_name, reportFactory) => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = reportFactory(headCommit)
+    if (report === "unreadable") {
+      store.readFailures.add(`${BASELINE_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`)
+    } else if (report !== undefined) {
+      store.artifacts.set(
+        `${BASELINE_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`,
+        typeof report === "string" ? report : `${JSON.stringify(report)}\n`
+      )
+    }
+    const expectedDigest =
+      typeof report === "object" && report !== null ? report.digest : "a".repeat(64)
+    const request = {
+      ...input(headCommit),
+      baselineForwardDigest: expectedDigest,
+      repositoryRoot: repository.root,
+    }
+
+    const result = runPreLiveEvidenceCheck(request, dependencies(store, headCommit))
+
+    expectIncomplete(result)
+  })
+
+  it("rejects a digest-valid PASS report with an unresolved blocking finding", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const evidence = { reason: "fabricated PASS" }
+    const report = gateReport("baseline-forward", headCommit, {
+      findings: [
+        {
+          classification: "BLOCKING",
+          evidence,
+          fingerprint: createFindingFingerprint({
+            evidence,
+            ruleId: "dynamic.fabricated-blocker",
+            subject: headCommit,
+          }),
+          ruleId: "dynamic.fabricated-blocker",
+        },
+      ],
+      outcome: "PASS",
+    })
+    storeBaselineReport(store, report)
+
+    const result = runPreLiveEvidenceCheck(
+      {
+        ...input(headCommit),
+        baselineForwardDigest: report.digest,
+        repositoryRoot: repository.root,
+      },
+      dependencies(store, headCommit)
+    )
+
+    expectIncomplete(result)
+  })
+
+  it("rejects an expected digest mismatch on an otherwise self-consistent report", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+
+    const result = runPreLiveEvidenceCheck(
+      {
+        ...input(headCommit),
+        baselineForwardDigest: "b".repeat(64),
+        repositoryRoot: repository.root,
+      },
+      dependencies(store, headCommit)
+    )
+
+    expectIncomplete(result)
+  })
+
+  it.each(["baselineState", "migration", "invariants", "sqlTests"] as const)(
+    "rejects stale or fabricated %s immutable evidence",
+    (hashName) => {
+      const { headCommit, repository } = createLandedRepository()
+      const store = new FakeEvidenceStore()
+      const validReport = gateReport("baseline-forward", headCommit)
+      const report = finalizeReport({
+        ...validReport,
+        inputHashes: {
+          ...validReport.inputHashes,
+          [hashName]: "stale-or-fabricated",
+        },
+      })
+      storeBaselineReport(store, report)
+
+      const result = runPreLiveEvidenceCheck(
+        {
+          ...input(headCommit),
+          baselineForwardDigest: report.digest,
+          repositoryRoot: repository.root,
+        },
+        dependencies(store, headCommit)
+      )
+
+      expectIncomplete(result)
+    }
+  )
+
+  it("rejects arbitrary caller-supplied local report paths", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+    const request = {
+      ...input(headCommit),
+      baselineForwardDigest: report.digest,
+      baselineForwardReportPath: "/tmp/fabricated-report.json",
+      repositoryRoot: repository.root,
+    }
+
+    const result = runPreLiveEvidenceCheck(request, dependencies(store, headCommit))
+
+    expectIncomplete(result)
+    expect(store.operations).not.toContain(`read:${BASELINE_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`)
+  })
+
+  it("rejects every unknown input property rather than guessing report-path key names", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+    const request = {
+      ...input(headCommit),
+      baselineForwardDigest: report.digest,
+      baselineForwardReportFile: "/tmp/fabricated-report.json",
+      repositoryRoot: repository.root,
+    }
+
+    const result = runPreLiveEvidenceCheck(request, dependencies(store, headCommit))
+
+    expectIncomplete(result)
+    expect(store.operations).toEqual([])
+  })
+
+  it("does not read baseline-forward evidence when fresh static is non-PASS", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+
+    const result = runPreLiveEvidenceCheck(
+      { ...input(headCommit), repositoryRoot: repository.root },
+      dependencies(store, headCommit, {
+        runStatic: () => gateReport("static", headCommit, { outcome: "FAILED" }),
+      })
+    )
+
+    expectIncomplete(result)
+    expect(store.operations).toEqual([])
+  })
+
+  it("does not read baseline-forward evidence when static Oracle persistence fails", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    store.persistFailure = true
+
+    const result = runPreLiveEvidenceCheck(
+      { ...input(headCommit), repositoryRoot: repository.root },
+      dependencies(store, headCommit)
+    )
+
+    expectIncomplete(result)
+    expect(store.operations).toEqual([`persist:${STATIC_RUN_ID}/${ORACLE_REPORT_ARTIFACT}`])
+  })
+
+  it("returns INCOMPLETE for a wrong-project live observation", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+
+    const result = runPreLiveEvidenceCheck(
+      {
+        ...input(headCommit),
+        baselineForwardDigest: report.digest,
+        repositoryRoot: repository.root,
+      },
+      dependencies(store, headCommit, {
+        readLiveObservation: () => ({
+          capturedAt: "2026-08-23T07:29:00.000Z",
+          migrations: [{ name: "candidate", version: "20260819062043" }],
+          projectRef: "wrong-project",
+          schemaVersion: 1,
+          source: "supabase-mcp",
+        }),
+      })
+    )
+
+    expectIncomplete(result)
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({ ruleId: "prelive/evidence-invalid" })
+    )
+  })
+
+  it("returns a blocking failure when live migration high-water is ahead of Oracle", () => {
+    const { headCommit, repository } = createLandedRepository()
+    const store = new FakeEvidenceStore()
+    const report = gateReport("baseline-forward", headCommit)
+    storeBaselineReport(store, report)
+
+    const result = runPreLiveEvidenceCheck(
+      {
+        ...input(headCommit),
+        baselineForwardDigest: report.digest,
+        repositoryRoot: repository.root,
+      },
+      dependencies(store, headCommit, {
+        readLiveObservation: () => ({
+          capturedAt: "2026-08-23T07:29:00.000Z",
+          migrations: [
+            { name: "candidate", version: "20260819062043" },
+            { name: "newer", version: "20260820000000" },
+          ],
+          projectRef: "cdthersvldpnlbvpufrr",
+          schemaVersion: 1,
+          source: "supabase-mcp",
+        }),
+      })
+    )
+
+    expect(result.outcome).toBe("FAILED")
+    expect(result.requiredChecksComplete).toBe(true)
+    expect(result.inputHashes.liveObservation).toMatch(/^[a-f0-9]{64}$/u)
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        classification: "BLOCKING",
+        ruleId: "prelive/baseline-behind-live",
+      })
+    )
+  })
+})

--- a/scripts/db-quality-gate/cli.ts
+++ b/scripts/db-quality-gate/cli.ts
@@ -1,12 +1,21 @@
 import { aggregateOutcome, finalizeReport, outcomeExitCode, serializeReport } from "./contract"
 import { runOracleDynamicLane } from "./dynamic-lane"
 import { currentHeadCommit } from "./git-evidence"
+import { createOracleEvidenceStore } from "./oracle-evidence-store"
+import { createOracleRemoteClient } from "./oracle-remote-client"
+import {
+  defaultOracleRemoteCommand,
+  oracleRemoteExecutorConfigFromEnvironment,
+} from "./oracle-remote-contract"
 import { oracleRemoteExecutorFromEnvironment } from "./oracle-remote-executor"
+import { runPreLiveEvidenceCheck } from "./pre-live"
 import { stableJsonStringify } from "./serialization"
 import { runStaticLane } from "./static-lane"
 import { GATE_LANES, GATE_SCHEMA_VERSION } from "./types"
-import type { GateLane, GateReport } from "./types"
 import type { OracleDynamicExecutor } from "./dynamic-lane"
+import type { OracleEvidenceStore } from "./oracle-evidence-store"
+import type { PreLiveEvidenceDependencies } from "./pre-live"
+import type { GateLane, GateReport } from "./types"
 
 type CommandExecution = {
   exitCode: 0 | 1 | 2
@@ -14,18 +23,33 @@ type CommandExecution = {
 }
 
 type CommandOptions = {
+  baselineForwardDigest?: string
+  baselineForwardRunId?: string
   createdAt: string
   lane: GateLane
+  liveObservationPath?: string
   runId: string
+  staticRunId?: string
   subjectCommit?: string
 }
 
 type CommandDependencies = {
   dynamicExecutor?: () => OracleDynamicExecutor | undefined
+  evidenceStore?: () => OracleEvidenceStore | undefined
+  preLiveDependencies?: Omit<PreLiveEvidenceDependencies, "evidenceStore">
   repositoryRoot?: string
 }
 
-const OPTION_NAMES = new Set(["--created-at", "--lane", "--run-id", "--subject-commit"])
+const OPTION_NAMES = new Set([
+  "--baseline-forward-digest",
+  "--baseline-forward-run-id",
+  "--created-at",
+  "--lane",
+  "--live-observation",
+  "--run-id",
+  "--static-run-id",
+  "--subject-commit",
+])
 
 function errorExecution(error: string): CommandExecution {
   return {
@@ -54,11 +78,30 @@ function parseOptions(args: string[]): CommandOptions | undefined {
   }
 
   return {
+    baselineForwardDigest: values.get("--baseline-forward-digest"),
+    baselineForwardRunId: values.get("--baseline-forward-run-id"),
     createdAt: values.get("--created-at") ?? new Date().toISOString(),
     lane: lane as GateLane,
+    liveObservationPath: values.get("--live-observation"),
     runId: values.get("--run-id") ?? "local-contract",
+    staticRunId: values.get("--static-run-id"),
     subjectCommit: values.get("--subject-commit"),
   }
+}
+
+function oracleEvidenceStoreFromEnvironment(): OracleEvidenceStore | undefined {
+  const config = oracleRemoteExecutorConfigFromEnvironment(process.env)
+  if (config === undefined) {
+    return undefined
+  }
+
+  return createOracleEvidenceStore({
+    client: createOracleRemoteClient({
+      command: defaultOracleRemoteCommand,
+      config,
+    }),
+    config,
+  })
 }
 
 /** Runs one local gate lane and fails closed whenever its required executor or evidence is unavailable. */
@@ -76,6 +119,9 @@ export function runDatabaseQualityGateCommand(
   }
   if (options.lane !== "static" && !args.includes("--run-id")) {
     return errorExecution("Dynamic Oracle lanes require an explicit --run-id")
+  }
+  if (options.lane === "pre-live" && args.includes("--created-at")) {
+    return errorExecution("Pre-live requires a trusted internal clock")
   }
   const repositoryRoot = dependencies.repositoryRoot ?? process.cwd()
   const subjectCommit = currentHeadCommit(repositoryRoot)
@@ -122,6 +168,46 @@ export function runDatabaseQualityGateCommand(
         }
       } catch {
         return errorExecution("Dynamic Oracle lane execution failed")
+      }
+    }
+  }
+
+  if (options.lane === "pre-live") {
+    if (
+      options.baselineForwardDigest === undefined ||
+      options.baselineForwardRunId === undefined ||
+      options.liveObservationPath === undefined ||
+      options.staticRunId === undefined ||
+      options.subjectCommit === undefined
+    ) {
+      return errorExecution("Pre-live requires exact landed evidence identifiers")
+    }
+
+    const evidenceStore = dependencies.evidenceStore?.() ?? oracleEvidenceStoreFromEnvironment()
+    if (evidenceStore !== undefined) {
+      try {
+        const report = runPreLiveEvidenceCheck(
+          {
+            baselineForwardDigest: options.baselineForwardDigest,
+            baselineForwardRunId: options.baselineForwardRunId,
+            liveObservationPath: options.liveObservationPath,
+            repositoryRoot,
+            runId: options.runId,
+            staticRunId: options.staticRunId,
+            subjectCommit: options.subjectCommit,
+          },
+          {
+            clock: () => new Date().toISOString(),
+            ...dependencies.preLiveDependencies,
+            evidenceStore,
+          }
+        )
+        return {
+          exitCode: outcomeExitCode(report.outcome),
+          stdout: serializeReport(report),
+        }
+      } catch {
+        return errorExecution("Pre-live lane execution failed")
       }
     }
   }

--- a/scripts/db-quality-gate/dynamic-input-hashes.ts
+++ b/scripts/db-quality-gate/dynamic-input-hashes.ts
@@ -1,0 +1,21 @@
+import { stableJsonSha256 } from "./serialization"
+import type { MigrationIdentity } from "./types"
+
+export type DynamicImmutableInputHashes = {
+  invariants: string
+  migration: string
+  sqlTests: string
+}
+
+/** Hashes the immutable repository inputs with baseline-forward lane semantics. */
+export function dynamicImmutableInputHashes(input: {
+  invariants: unknown
+  migrationIdentities: MigrationIdentity[]
+  sqlTestRegistry: unknown
+}): DynamicImmutableInputHashes {
+  return {
+    invariants: stableJsonSha256(input.invariants),
+    migration: stableJsonSha256(input.migrationIdentities),
+    sqlTests: stableJsonSha256(input.sqlTestRegistry),
+  }
+}

--- a/scripts/db-quality-gate/dynamic-lane-inputs.ts
+++ b/scripts/db-quality-gate/dynamic-lane-inputs.ts
@@ -13,6 +13,11 @@ const INVARIANTS_PATH = "supabase/db-quality-gate-invariants.json"
 const SQL_TESTS_PATH = "supabase/db-quality-gate-tests.json"
 const APPLIED_LOCK_PATH = "supabase/applied-migrations.lock.json"
 
+export type DynamicRepositoryInput = Pick<
+  OracleDynamicLaneInput,
+  "repositoryRoot" | "subjectCommit"
+>
+
 /** Immutable source artifacts selected from one resolved subject commit. */
 export type DynamicInputArtifacts = {
   appliedMigrationIdentities: MigrationIdentity[]
@@ -29,7 +34,7 @@ export type DynamicInputArtifacts = {
 }
 
 function committedRepositoryFile(
-  input: OracleDynamicLaneInput,
+  input: DynamicRepositoryInput,
   relativePath: string,
   allowedPrefix: string
 ): string | undefined {
@@ -45,7 +50,7 @@ function committedRepositoryFile(
 }
 
 function readCommittedJsonArtifact(
-  input: OracleDynamicLaneInput,
+  input: DynamicRepositoryInput,
   relativePath: string
 ): unknown | undefined {
   const content = committedRepositoryFile(input, relativePath, "supabase/")
@@ -82,7 +87,7 @@ function postCutoverMigrations(
 
 /** Loads validation registry inputs from Git objects without consulting the mutable worktree. */
 export function readDynamicInputArtifacts(
-  input: OracleDynamicLaneInput,
+  input: DynamicRepositoryInput,
   state: DynamicRunState
 ): DynamicInputArtifacts | undefined {
   const source = inspectCanonicalMigrationSourceAtCommit({
@@ -170,7 +175,7 @@ export function readDynamicInputArtifacts(
 
 /** Reads one registered SQL test body from the immutable subject commit. */
 export function readCommittedSqlTest(
-  input: OracleDynamicLaneInput,
+  input: DynamicRepositoryInput,
   relativePath: string
 ): string | undefined {
   return committedRepositoryFile(input, relativePath, "supabase/tests/")
@@ -178,7 +183,7 @@ export function readCommittedSqlTest(
 
 /** Reads candidate migration contents from the immutable subject commit. */
 export function readCommittedMigrationInputs(
-  input: OracleDynamicLaneInput,
+  input: DynamicRepositoryInput,
   migrationIdentities: MigrationIdentity[],
   state: DynamicRunState
 ):

--- a/scripts/db-quality-gate/dynamic-lane-report.ts
+++ b/scripts/db-quality-gate/dynamic-lane-report.ts
@@ -1,4 +1,5 @@
 import { aggregateOutcome, createFindingFingerprint, finalizeReport } from "./contract"
+import { dynamicImmutableInputHashes } from "./dynamic-input-hashes"
 import { stableJsonSha256 } from "./serialization"
 import { GATE_SCHEMA_VERSION } from "./types"
 import type { GateFinding, GateReport, MigrationIdentity } from "./types"
@@ -84,6 +85,11 @@ export function finalizeDynamicLaneReport(
     findings: state.findings,
     requiredChecksComplete,
   })
+  const immutableInputHashes = dynamicImmutableInputHashes({
+    invariants: artifacts.invariants ?? null,
+    migrationIdentities,
+    sqlTestRegistry: artifacts.sqlTests ?? null,
+  })
 
   return finalizeReport({
     baselineMigrationHighWater: state.baselineMigrationHighWater,
@@ -95,9 +101,7 @@ export function finalizeDynamicLaneReport(
     inputHashes: {
       ...state.catalogInputHashes,
       harness: stableJsonSha256({ lane: input.lane, version: "phase-4" }),
-      invariants: stableJsonSha256(artifacts.invariants ?? null),
-      migration: stableJsonSha256(migrationIdentities),
-      sqlTests: stableJsonSha256(artifacts.sqlTests ?? null),
+      ...immutableInputHashes,
     },
     lane: input.lane,
     migrationIdentities,

--- a/scripts/db-quality-gate/git-evidence.ts
+++ b/scripts/db-quality-gate/git-evidence.ts
@@ -2,10 +2,27 @@ import { execFileSync } from "node:child_process"
 
 const MAX_GIT_EVIDENCE_OUTPUT_BYTES = 4 * 1024 * 1024
 
-function gitOutput(repositoryRoot: string, args: string[]): string | undefined {
+type GitOutputOptions = {
+  credentialFree?: boolean
+}
+
+function gitOutput(
+  repositoryRoot: string,
+  args: string[],
+  options: GitOutputOptions = {}
+): string | undefined {
   try {
     return execFileSync("git", ["-C", repositoryRoot, ...args], {
       encoding: "utf8",
+      env: options.credentialFree
+        ? {
+            ...process.env,
+            GIT_ASKPASS: "/bin/false",
+            GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o IdentitiesOnly=yes -o IdentityFile=/dev/null",
+            GIT_TERMINAL_PROMPT: "0",
+            SSH_ASKPASS: "/bin/false",
+          }
+        : process.env,
       maxBuffer: MAX_GIT_EVIDENCE_OUTPUT_BYTES,
       stdio: ["ignore", "pipe", "ignore"],
     })
@@ -22,6 +39,69 @@ export function resolveGitCommit(repositoryRoot: string, ref: string): string | 
 /** Resolves the immutable commit checked out at repository HEAD. */
 export function currentHeadCommit(repositoryRoot: string): string | undefined {
   return resolveGitCommit(repositoryRoot, "HEAD")
+}
+
+/** Resolves the immutable first parent of a landed commit. */
+export function firstParentCommit(repositoryRoot: string, commit: string): string | undefined {
+  return resolveGitCommit(repositoryRoot, `${commit}^1`)
+}
+
+/** Lists paths changed by one exact parent-to-commit comparison. */
+export function listChangedFilesBetween(
+  repositoryRoot: string,
+  parentCommit: string,
+  subjectCommit: string
+): string[] | undefined {
+  const output = gitOutput(repositoryRoot, [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMRTUXB",
+    parentCommit,
+    subjectCommit,
+    "--",
+  ])
+
+  return output?.split("\n").filter(Boolean)
+}
+
+function credentialFreeOriginUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "https:" && url.username === "" && url.password === ""
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Refreshes the public main tracking ref with prompts, helpers, and SSH identities disabled.
+ */
+export function refreshPublicOriginMain(repositoryRoot: string): string | undefined {
+  const originUrl = gitOutput(repositoryRoot, ["remote", "get-url", "origin"])?.trim()
+  if (originUrl === undefined || !credentialFreeOriginUrl(originUrl)) {
+    return undefined
+  }
+
+  const fetched = gitOutput(
+    repositoryRoot,
+    [
+      "-c",
+      "credential.helper=",
+      "-c",
+      "credential.interactive=never",
+      "-c",
+      "http.extraHeader=",
+      "-c",
+      `http.${originUrl}.extraHeader=`,
+      "fetch",
+      "--no-tags",
+      originUrl,
+      "+refs/heads/main:refs/remotes/origin/main",
+    ],
+    { credentialFree: true }
+  )
+
+  return fetched === undefined ? undefined : resolveGitCommit(repositoryRoot, "origin/main")
 }
 
 /** Reads a tracked file at a resolved Git commit without consulting the worktree. */

--- a/scripts/db-quality-gate/landed-static-diff.ts
+++ b/scripts/db-quality-gate/landed-static-diff.ts
@@ -1,0 +1,41 @@
+import {
+  currentHeadCommit,
+  firstParentCommit,
+  listChangedFilesBetween,
+  resolveGitCommit,
+} from "./git-evidence"
+
+export type TrustedStaticDiff = {
+  baseRef: string
+  changedFiles: string[]
+  unavailable: boolean
+}
+
+/** Binds a landed commit to its exact first parent before exposing changed paths. */
+export function resolveLandedStaticDiff(input: {
+  landedParentCommit: string
+  repositoryRoot: string
+  subjectCommit: string
+}): TrustedStaticDiff {
+  const headCommit = currentHeadCommit(input.repositoryRoot)
+  const resolvedSubject = resolveGitCommit(input.repositoryRoot, input.subjectCommit)
+  const resolvedParent = resolveGitCommit(input.repositoryRoot, input.landedParentCommit)
+  const actualParent =
+    headCommit === undefined ? undefined : firstParentCommit(input.repositoryRoot, headCommit)
+  const commitsBound =
+    headCommit !== undefined &&
+    resolvedSubject === headCommit &&
+    input.subjectCommit === headCommit &&
+    resolvedParent === actualParent &&
+    input.landedParentCommit === actualParent
+  const changedFiles =
+    commitsBound && actualParent !== undefined
+      ? listChangedFilesBetween(input.repositoryRoot, actualParent, headCommit)
+      : undefined
+
+  return {
+    baseRef: actualParent ?? input.landedParentCommit,
+    changedFiles: changedFiles ?? [],
+    unavailable: !commitsBound || changedFiles === undefined,
+  }
+}

--- a/scripts/db-quality-gate/oracle-evidence-store.ts
+++ b/scripts/db-quality-gate/oracle-evidence-store.ts
@@ -1,0 +1,115 @@
+import path from "node:path"
+
+import type { OracleExecutorResult } from "./dynamic-lane-types"
+import { oracleErrorResult, oracleStatePath } from "./oracle-remote-client"
+import type { OracleRemoteClient } from "./oracle-remote-client"
+import { shellQuote, validRunId } from "./oracle-remote-contract"
+import type { OracleRemoteExecutorConfig } from "./oracle-remote-contract"
+
+/** Canonical immutable report artifact name within an Oracle evidence run. */
+export const ORACLE_REPORT_ARTIFACT = "report.json"
+
+type OracleArtifactInput = {
+  artifactName: string
+  runId: string
+}
+
+type PersistOracleArtifactInput = OracleArtifactInput & {
+  content: string
+}
+
+export type OracleEvidenceStore = {
+  persistArtifact: (
+    input: PersistOracleArtifactInput
+  ) => OracleExecutorResult<{ evidenceId: string }>
+  readArtifact: (input: OracleArtifactInput) => OracleExecutorResult<string>
+  readBaselineState: () => OracleExecutorResult<string>
+}
+
+type OracleEvidenceStoreInput = {
+  client: Pick<OracleRemoteClient, "remote">
+  config: OracleRemoteExecutorConfig
+}
+
+function validArtifactName(value: string): boolean {
+  return (
+    /^[a-z0-9][a-z0-9._-]*\.json$/u.test(value) &&
+    !value.includes("..") &&
+    path.posix.basename(value) === value
+  )
+}
+
+function evidencePath(evidenceDirectory: string, input: OracleArtifactInput): string | undefined {
+  if (!validRunId(input.runId) || !validArtifactName(input.artifactName)) {
+    return undefined
+  }
+
+  return `${evidenceDirectory}/${input.runId}/${input.artifactName}`
+}
+
+/** Creates an injected immutable Oracle artifact store for reports and later evidence types. */
+export function createOracleEvidenceStore(input: OracleEvidenceStoreInput): OracleEvidenceStore {
+  const evidenceDirectory = input.config.evidenceDirectory
+
+  return {
+    persistArtifact(artifact) {
+      const filePath = evidencePath(evidenceDirectory, artifact)
+      if (filePath === undefined) {
+        return oracleErrorResult("unavailable", "Invalid immutable Oracle evidence path")
+      }
+      const directory = path.posix.dirname(filePath)
+      const temporaryPath = `${directory}/.${artifact.artifactName}.tmp`
+      const result = input.client.remote(
+        `set -eu
+umask 077
+evidence_root=${shellQuote(evidenceDirectory)}
+directory=${shellQuote(directory)}
+artifact_path=${shellQuote(filePath)}
+temporary_path=${shellQuote(temporaryPath)}
+published=0
+cleanup() {
+  rm -f "$temporary_path"
+  if [ "$published" -eq 0 ]; then
+    rmdir "$directory" 2>/dev/null || true
+  fi
+}
+trap cleanup 0 HUP INT TERM
+mkdir -p "$evidence_root"
+mkdir "$directory"
+cat > "$temporary_path"
+chmod 400 "$temporary_path"
+ln "$temporary_path" "$artifact_path"
+published=1
+rm -f "$temporary_path"
+chmod 500 "$directory"
+trap - 0 HUP INT TERM`,
+        artifact.content,
+        "unavailable"
+      )
+
+      return result.status === "ok"
+        ? {
+            status: "ok",
+            value: { evidenceId: `oracle:${artifact.runId}/${artifact.artifactName}` },
+          }
+        : result
+    },
+
+    readArtifact(artifact) {
+      const filePath = evidencePath(evidenceDirectory, artifact)
+      if (filePath === undefined) {
+        return oracleErrorResult("unavailable", "Invalid immutable Oracle evidence path")
+      }
+
+      return input.client.remote(`cat ${shellQuote(filePath)}`, undefined, "unavailable")
+    },
+
+    readBaselineState() {
+      return input.client.remote(
+        `cat ${shellQuote(oracleStatePath(input.config))}`,
+        undefined,
+        "unavailable"
+      )
+    },
+  }
+}

--- a/scripts/db-quality-gate/pre-live-inputs.ts
+++ b/scripts/db-quality-gate/pre-live-inputs.ts
@@ -1,0 +1,24 @@
+import {
+  dynamicImmutableInputHashes,
+  type DynamicImmutableInputHashes,
+} from "./dynamic-input-hashes"
+import { readDynamicInputArtifacts } from "./dynamic-lane-inputs"
+import { createDynamicRunState } from "./dynamic-lane-report"
+
+/** Recomputes baseline-forward repository hashes from the immutable landed commit. */
+export function recomputeBaselineForwardInputHashes(input: {
+  repositoryRoot: string
+  subjectCommit: string
+}): DynamicImmutableInputHashes | undefined {
+  const state = createDynamicRunState()
+  const artifacts = readDynamicInputArtifacts(input, state)
+  if (artifacts === undefined || state.incomplete) {
+    return undefined
+  }
+
+  return dynamicImmutableInputHashes({
+    invariants: artifacts.invariants,
+    migrationIdentities: artifacts.migrationIdentities,
+    sqlTestRegistry: artifacts.sqlTestRegistry,
+  })
+}

--- a/scripts/db-quality-gate/pre-live-live-state.ts
+++ b/scripts/db-quality-gate/pre-live-live-state.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs"
+
+import { z } from "zod"
+
+import { stableJsonSha256 } from "./serialization"
+import type { BaselineState } from "./baseline-state"
+import type { AppliedMigrationLock } from "./registries"
+
+const LIVE_PROJECT_REF = "cdthersvldpnlbvpufrr"
+const MAXIMUM_AGE_MILLISECONDS = 15 * 60 * 1000
+const MAXIMUM_FUTURE_SKEW_MILLISECONDS = 2 * 60 * 1000
+const MIGRATION_PATH_PATTERN = /^supabase\/migrations\/(\d{14})_(.+)\.sql$/u
+
+const liveMigrationObservationSchema = z
+  .object({
+    capturedAt: z.string().datetime({ offset: true }),
+    migrations: z.array(
+      z
+        .object({
+          name: z.string().min(1),
+          version: z.string().regex(/^\d{14}$/u),
+        })
+        .strict()
+    ),
+    projectRef: z.literal(LIVE_PROJECT_REF),
+    schemaVersion: z.literal(1),
+    source: z.literal("supabase-mcp"),
+  })
+  .strict()
+
+export type LiveMigrationObservation = z.infer<typeof liveMigrationObservationSchema>
+
+export type ParsedLiveMigrationObservation = LiveMigrationObservation & {
+  inputHash: string
+}
+
+export type LiveMigrationStateEvaluation =
+  | {
+      inputHash: string
+      liveMigrationHighWater: string
+      status: "baseline-behind" | "valid"
+    }
+  | {
+      reason: string
+      status: "invalid"
+    }
+
+function versionsStrictlyAscending(observation: LiveMigrationObservation): boolean {
+  return observation.migrations.every(
+    (migration, index) =>
+      index === 0 || migration.version > observation.migrations[index - 1].version
+  )
+}
+
+/** Parses a fresh, project-bound observation produced by a read-only Supabase MCP session. */
+export function parseLiveMigrationObservation(
+  value: unknown,
+  createdAt: string
+): ParsedLiveMigrationObservation | undefined {
+  const result = liveMigrationObservationSchema.safeParse(value)
+  const createdAtMilliseconds = Date.parse(createdAt)
+  if (!result.success || !Number.isFinite(createdAtMilliseconds)) {
+    return undefined
+  }
+
+  const capturedAtMilliseconds = Date.parse(result.data.capturedAt)
+  const ageMilliseconds = createdAtMilliseconds - capturedAtMilliseconds
+  if (
+    !Number.isFinite(capturedAtMilliseconds) ||
+    ageMilliseconds > MAXIMUM_AGE_MILLISECONDS ||
+    ageMilliseconds < -MAXIMUM_FUTURE_SKEW_MILLISECONDS ||
+    !versionsStrictlyAscending(result.data)
+  ) {
+    return undefined
+  }
+
+  return {
+    ...result.data,
+    inputHash: stableJsonSha256(result.data),
+  }
+}
+
+/** Reads an operator-exported observation without opening any live database connection. */
+export function readLiveMigrationObservationFile(filePath: string): unknown | undefined {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function appliedEntryIdentity(
+  entry: AppliedMigrationLock["applied"][number]
+): { name: string; version: string } | undefined {
+  const match = MIGRATION_PATH_PATTERN.exec(entry.path)
+  return match === null ? undefined : { name: match[2], version: match[1] }
+}
+
+/** Compares committed applied-lock intent and Oracle baseline high-water with live read-only evidence. */
+export function evaluateLiveMigrationState(input: {
+  appliedLock: AppliedMigrationLock | undefined
+  baselineState: BaselineState
+  observation: ParsedLiveMigrationObservation | undefined
+}): LiveMigrationStateEvaluation {
+  if (input.appliedLock === undefined || input.observation === undefined) {
+    return {
+      reason: "Live observation or committed applied lock is unavailable",
+      status: "invalid",
+    }
+  }
+
+  const liveByVersion = new Map(
+    input.observation.migrations.map((migration) => [migration.version, migration.name])
+  )
+  for (const entry of input.appliedLock.applied) {
+    const identity = appliedEntryIdentity(entry)
+    if (identity === undefined || liveByVersion.get(identity.version) !== identity.name) {
+      return {
+        reason: "Committed applied-lock entries do not exactly match live migration evidence",
+        status: "invalid",
+      }
+    }
+  }
+
+  const liveMigrationHighWater = input.observation.migrations.at(-1)?.version ?? "unavailable"
+  if (liveMigrationHighWater > input.baselineState.migrationHighWater) {
+    return {
+      inputHash: input.observation.inputHash,
+      liveMigrationHighWater,
+      status: "baseline-behind",
+    }
+  }
+  if (liveMigrationHighWater !== input.baselineState.migrationHighWater) {
+    return {
+      reason: "Published Oracle baseline high-water does not match live migration evidence",
+      status: "invalid",
+    }
+  }
+
+  return {
+    inputHash: input.observation.inputHash,
+    liveMigrationHighWater,
+    status: "valid",
+  }
+}

--- a/scripts/db-quality-gate/pre-live-report.ts
+++ b/scripts/db-quality-gate/pre-live-report.ts
@@ -1,0 +1,195 @@
+import {
+  aggregateOutcome,
+  createFindingFingerprint,
+  finalizeReport,
+  reportDigest,
+} from "./contract"
+import { GATE_SCHEMA_VERSION } from "./types"
+import type {
+  FindingClassification,
+  GateFinding,
+  GateLane,
+  GateOutcome,
+  GateReport,
+  MigrationIdentity,
+} from "./types"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string")
+}
+
+function isFindingClassification(value: unknown): value is FindingClassification {
+  return value === "WARNING" || value === "DANGEROUS" || value === "BLOCKING"
+}
+
+function isGateLane(value: unknown): value is GateLane {
+  return (
+    value === "static" ||
+    value === "baseline-forward" ||
+    value === "pre-live" ||
+    value === "reconciliation"
+  )
+}
+
+function isGateOutcome(value: unknown): value is GateOutcome {
+  return value === "PASS" || value === "FAILED" || value === "INCOMPLETE"
+}
+
+function isMigrationIdentity(value: unknown): value is MigrationIdentity {
+  return isRecord(value) && typeof value.path === "string" && typeof value.sha256 === "string"
+}
+
+function isGateFinding(value: unknown): value is GateFinding {
+  if (
+    !isRecord(value) ||
+    !isFindingClassification(value.classification) ||
+    typeof value.fingerprint !== "string" ||
+    typeof value.ruleId !== "string"
+  ) {
+    return false
+  }
+  if (
+    value.evidence !== undefined &&
+    (!isRecord(value.evidence) ||
+      !Object.values(value.evidence).every(
+        (entry) => typeof entry === "number" || typeof entry === "string"
+      ))
+  ) {
+    return false
+  }
+  return (
+    value.approval === undefined ||
+    (isRecord(value.approval) &&
+      typeof value.approval.acceptedForAggregate === "boolean" &&
+      typeof value.approval.id === "string")
+  )
+}
+
+/** Parses persisted gate evidence without trusting its JSON shape. */
+export function parseGateReport(value: unknown): GateReport | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.baselineMigrationHighWater !== "string" ||
+    typeof value.createdAt !== "string" ||
+    typeof value.digest !== "string" ||
+    !isStringRecord(value.executorEnvironment) ||
+    !Array.isArray(value.findings) ||
+    !value.findings.every(isGateFinding) ||
+    !isStringRecord(value.inputHashes) ||
+    !isGateLane(value.lane) ||
+    !Array.isArray(value.migrationIdentities) ||
+    !value.migrationIdentities.every(isMigrationIdentity) ||
+    !isGateOutcome(value.outcome) ||
+    typeof value.runId !== "string" ||
+    value.schemaVersion !== GATE_SCHEMA_VERSION ||
+    typeof value.subjectCommit !== "string"
+  ) {
+    return undefined
+  }
+  if (
+    (value.evidenceAvailable !== undefined && typeof value.evidenceAvailable !== "boolean") ||
+    (value.requiredChecksComplete !== undefined &&
+      typeof value.requiredChecksComplete !== "boolean")
+  ) {
+    return undefined
+  }
+
+  return value as GateReport
+}
+
+/** Creates a deterministic pre-live finding bound to the landed subject commit. */
+export function preLiveFinding(
+  classification: FindingClassification,
+  ruleId: string,
+  subject: string,
+  evidence: Record<string, number | string>
+): GateFinding {
+  return {
+    classification,
+    evidence,
+    fingerprint: createFindingFingerprint({ evidence, ruleId, subject }),
+    ruleId,
+  }
+}
+
+/** Finalizes one deterministic report for the read-only pre-live lane. */
+export function preLiveReport(input: {
+  baselineMigrationHighWater?: string
+  createdAt: string
+  evidenceAvailable: boolean
+  findings: GateFinding[]
+  inputHashes?: Record<string, string>
+  migrationIdentities?: MigrationIdentity[]
+  outcome: GateOutcome
+  runId: string
+  subjectCommit: string
+}): GateReport {
+  const complete = input.outcome !== "INCOMPLETE"
+  return finalizeReport({
+    baselineMigrationHighWater: input.baselineMigrationHighWater ?? "unavailable",
+    createdAt: input.createdAt,
+    digest: "",
+    evidenceAvailable: input.evidenceAvailable,
+    executorEnvironment: { execution: "pre-live-local-oracle-evidence" },
+    findings: input.findings,
+    inputHashes: input.inputHashes ?? {},
+    lane: "pre-live",
+    migrationIdentities: input.migrationIdentities ?? [],
+    outcome: input.outcome,
+    requiredChecksComplete: complete,
+    runId: input.runId,
+    schemaVersion: GATE_SCHEMA_VERSION,
+    subjectCommit: input.subjectCommit,
+  })
+}
+
+/** Creates a fail-closed pre-live report for unavailable or invalid evidence. */
+export function incompleteReport(
+  input: { runId: string },
+  createdAt: string,
+  subjectCommit: string,
+  ruleId: string,
+  reason: string
+): GateReport {
+  return preLiveReport({
+    createdAt,
+    evidenceAvailable: false,
+    findings: [preLiveFinding("BLOCKING", ruleId, subjectCommit, { reason })],
+    outcome: "INCOMPLETE",
+    runId: input.runId,
+    subjectCommit,
+  })
+}
+
+/** Verifies that persisted evidence is a complete PASS with an intact deterministic digest. */
+export function validReusableReport(
+  report: GateReport,
+  expected: {
+    digest: string
+    lane: GateLane
+    runId: string
+    subjectCommit: string
+  }
+): boolean {
+  const recomputedOutcome = aggregateOutcome({
+    evidenceAvailable: report.evidenceAvailable === true,
+    findings: report.findings,
+    requiredChecksComplete: report.requiredChecksComplete === true,
+  })
+
+  return (
+    report.runId === expected.runId &&
+    report.lane === expected.lane &&
+    report.outcome === "PASS" &&
+    report.outcome === recomputedOutcome &&
+    report.requiredChecksComplete === true &&
+    report.evidenceAvailable === true &&
+    report.subjectCommit === expected.subjectCommit &&
+    report.digest === expected.digest &&
+    report.digest === reportDigest(report)
+  )
+}

--- a/scripts/db-quality-gate/pre-live.ts
+++ b/scripts/db-quality-gate/pre-live.ts
@@ -1,0 +1,340 @@
+import { isBaselineForwardEvidenceReusable, parseBaselineState } from "./baseline-state"
+import { finalizeReport, serializeReport } from "./contract"
+import {
+  currentHeadCommit,
+  firstParentCommit,
+  readFileAtCommit,
+  refreshPublicOriginMain,
+  resolveGitCommit,
+} from "./git-evidence"
+import { ORACLE_REPORT_ARTIFACT, type OracleEvidenceStore } from "./oracle-evidence-store"
+import {
+  evaluateLiveMigrationState,
+  parseLiveMigrationObservation,
+  readLiveMigrationObservationFile,
+} from "./pre-live-live-state"
+import { recomputeBaselineForwardInputHashes as recomputeBaselineForwardInputHashesFromCommit } from "./pre-live-inputs"
+import {
+  incompleteReport,
+  parseGateReport,
+  preLiveFinding,
+  preLiveReport,
+  validReusableReport,
+} from "./pre-live-report"
+import { parseAppliedMigrationLock } from "./registries"
+import { runStaticLaneForLandedCommit, type LandedStaticLaneInput } from "./static-lane"
+import type { GateReport } from "./types"
+import type { AppliedMigrationLock } from "./registries"
+
+const EVIDENCE_NOT_LANDED_RULE = "prelive/evidence-not-landed"
+const EVIDENCE_INVALID_RULE = "prelive/evidence-invalid"
+const BASELINE_BEHIND_LIVE_RULE = "prelive/baseline-behind-live"
+const EXPLICIT_PERMISSION_RULE = "prelive.permission.explicit-required"
+const APPLIED_LOCK_PATH = "supabase/applied-migrations.lock.json"
+const PRE_LIVE_INPUT_KEYS = new Set([
+  "baselineForwardDigest",
+  "baselineForwardRunId",
+  "liveObservationPath",
+  "repositoryRoot",
+  "runId",
+  "staticRunId",
+  "subjectCommit",
+])
+export type PreLiveEvidenceInput = {
+  baselineForwardDigest: string
+  baselineForwardRunId: string
+  liveObservationPath: string
+  repositoryRoot: string
+  runId: string
+  staticRunId: string
+  subjectCommit: string
+}
+
+type LandedStaticRunner = (input: LandedStaticLaneInput) => GateReport
+type BaselineForwardInputHashReader = typeof recomputeBaselineForwardInputHashesFromCommit
+type AppliedMigrationLockReader = (
+  repositoryRoot: string,
+  subjectCommit: string
+) => AppliedMigrationLock | undefined
+
+export type PreLiveEvidenceDependencies = {
+  clock: () => string
+  evidenceStore: OracleEvidenceStore
+  readAppliedMigrationLock?: AppliedMigrationLockReader
+  readLiveObservation?: (filePath: string) => unknown | undefined
+  recomputeBaselineForwardInputHashes?: BaselineForwardInputHashReader
+  refreshOriginMain?: (repositoryRoot: string) => string | undefined
+  runStatic?: LandedStaticRunner
+}
+
+function readAppliedMigrationLockAtCommit(
+  repositoryRoot: string,
+  subjectCommit: string
+): AppliedMigrationLock | undefined {
+  const content = readFileAtCommit(repositoryRoot, subjectCommit, APPLIED_LOCK_PATH)
+  if (content === undefined) {
+    return undefined
+  }
+  try {
+    return parseAppliedMigrationLock(JSON.parse(content) as unknown)
+  } catch {
+    return undefined
+  }
+}
+
+function validPreLiveInput(input: PreLiveEvidenceInput): boolean {
+  const entries = Object.entries(input)
+  return (
+    entries.length === PRE_LIVE_INPUT_KEYS.size &&
+    entries.every(([key, value]) => PRE_LIVE_INPUT_KEYS.has(key) && typeof value === "string")
+  )
+}
+
+/** Verifies exact landed static and baseline-forward evidence without performing a live write. */
+export function runPreLiveEvidenceCheck(
+  input: PreLiveEvidenceInput,
+  dependencies: PreLiveEvidenceDependencies
+): GateReport {
+  const createdAt = dependencies.clock()
+  if (!validPreLiveInput(input)) {
+    return incompleteReport(
+      input,
+      createdAt,
+      "unavailable",
+      EVIDENCE_INVALID_RULE,
+      "Pre-live input contains unknown or malformed properties"
+    )
+  }
+
+  const resolvedSubject = resolveGitCommit(input.repositoryRoot, input.subjectCommit)
+  const headCommit = currentHeadCommit(input.repositoryRoot)
+  const refreshedOriginMain = (dependencies.refreshOriginMain ?? refreshPublicOriginMain)(
+    input.repositoryRoot
+  )
+  const landed =
+    resolvedSubject !== undefined &&
+    resolvedSubject === input.subjectCommit &&
+    headCommit === resolvedSubject &&
+    refreshedOriginMain === resolvedSubject
+  if (!landed) {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject ?? headCommit ?? "unavailable",
+      EVIDENCE_NOT_LANDED_RULE,
+      "subjectCommit, HEAD, and refreshed origin/main must identify the same landed commit"
+    )
+  }
+
+  const landedParentCommit = firstParentCommit(input.repositoryRoot, resolvedSubject)
+  if (landedParentCommit === undefined) {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_NOT_LANDED_RULE,
+      "The landed commit first parent is unavailable"
+    )
+  }
+
+  const staticReport = finalizeReport(
+    (dependencies.runStatic ?? runStaticLaneForLandedCommit)({
+      createdAt,
+      landedParentCommit,
+      repositoryRoot: input.repositoryRoot,
+      runId: input.staticRunId,
+      subjectCommit: resolvedSubject,
+    })
+  )
+  if (
+    !validReusableReport(staticReport, {
+      digest: staticReport.digest,
+      lane: "static",
+      runId: input.staticRunId,
+      subjectCommit: resolvedSubject,
+    })
+  ) {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Fresh landed static evidence is incomplete or non-PASS"
+    )
+  }
+
+  const persistedStatic = dependencies.evidenceStore.persistArtifact({
+    artifactName: ORACLE_REPORT_ARTIFACT,
+    content: serializeReport(staticReport),
+    runId: input.staticRunId,
+  })
+  if (persistedStatic.status === "error") {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Fresh landed static evidence could not be persisted to Oracle"
+    )
+  }
+
+  const baselineStateArtifact = dependencies.evidenceStore.readBaselineState()
+  if (baselineStateArtifact.status === "error") {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Published Oracle baseline state is unavailable"
+    )
+  }
+  let baselineState
+  try {
+    baselineState = parseBaselineState(JSON.parse(baselineStateArtifact.value) as unknown)
+  } catch {
+    baselineState = undefined
+  }
+  if (baselineState === undefined) {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Published Oracle baseline state is malformed"
+    )
+  }
+
+  const baselineArtifact = dependencies.evidenceStore.readArtifact({
+    artifactName: ORACLE_REPORT_ARTIFACT,
+    runId: input.baselineForwardRunId,
+  })
+  if (baselineArtifact.status === "error") {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Baseline-forward Oracle evidence is unavailable"
+    )
+  }
+
+  let baselineReport: GateReport | undefined
+  try {
+    baselineReport = parseGateReport(JSON.parse(baselineArtifact.value) as unknown)
+  } catch {
+    baselineReport = undefined
+  }
+  if (
+    baselineReport === undefined ||
+    !validReusableReport(baselineReport, {
+      digest: input.baselineForwardDigest,
+      lane: "baseline-forward",
+      runId: input.baselineForwardRunId,
+      subjectCommit: resolvedSubject,
+    })
+  ) {
+    const ruleId =
+      baselineReport?.subjectCommit !== undefined &&
+      baselineReport.subjectCommit !== resolvedSubject
+        ? EVIDENCE_NOT_LANDED_RULE
+        : EVIDENCE_INVALID_RULE
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      ruleId,
+      "Baseline-forward Oracle evidence does not exactly match the landed commit"
+    )
+  }
+
+  const baselineStateMatches = isBaselineForwardEvidenceReusable(
+    {
+      baselineMigrationHighWater: baselineReport.baselineMigrationHighWater,
+      inputHashes: baselineReport.inputHashes,
+      outcome: "PASS",
+    },
+    baselineState
+  )
+  const expectedBaselineForwardHashes = (
+    dependencies.recomputeBaselineForwardInputHashes ??
+    recomputeBaselineForwardInputHashesFromCommit
+  )({
+    repositoryRoot: input.repositoryRoot,
+    subjectCommit: resolvedSubject,
+  })
+  const baselineForwardInputsMatch =
+    expectedBaselineForwardHashes !== undefined &&
+    Object.entries(expectedBaselineForwardHashes).every(
+      ([key, expectedHash]) => baselineReport.inputHashes[key] === expectedHash
+    )
+  if (!baselineStateMatches || !baselineForwardInputsMatch) {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      "Baseline-forward immutable inputs no longer match current Oracle and HEAD evidence"
+    )
+  }
+
+  const rawLiveObservation = (dependencies.readLiveObservation ?? readLiveMigrationObservationFile)(
+    input.liveObservationPath
+  )
+  const liveObservation = parseLiveMigrationObservation(rawLiveObservation, createdAt)
+  const appliedLock = (dependencies.readAppliedMigrationLock ?? readAppliedMigrationLockAtCommit)(
+    input.repositoryRoot,
+    resolvedSubject
+  )
+  const liveState = evaluateLiveMigrationState({
+    appliedLock,
+    baselineState,
+    observation: liveObservation,
+  })
+  if (liveState.status === "invalid") {
+    return incompleteReport(
+      input,
+      createdAt,
+      resolvedSubject,
+      EVIDENCE_INVALID_RULE,
+      liveState.reason
+    )
+  }
+
+  const inputHashes = {
+    baselineForwardReport: baselineReport.digest,
+    liveObservation: liveState.inputHash,
+    staticReport: staticReport.digest,
+  }
+  if (liveState.status === "baseline-behind") {
+    const finding = preLiveFinding("BLOCKING", BASELINE_BEHIND_LIVE_RULE, resolvedSubject, {
+      baselineMigrationHighWater: baselineState.migrationHighWater,
+      liveMigrationHighWater: liveState.liveMigrationHighWater,
+    })
+    return preLiveReport({
+      baselineMigrationHighWater: baselineReport.baselineMigrationHighWater,
+      createdAt,
+      evidenceAvailable: true,
+      findings: [finding],
+      inputHashes,
+      migrationIdentities: staticReport.migrationIdentities,
+      outcome: "FAILED",
+      runId: input.runId,
+      subjectCommit: resolvedSubject,
+    })
+  }
+
+  const permissionFinding = preLiveFinding("WARNING", EXPLICIT_PERMISSION_RULE, resolvedSubject, {
+    nextAction: "request-explicit-permission",
+  })
+  return preLiveReport({
+    baselineMigrationHighWater: baselineReport.baselineMigrationHighWater,
+    createdAt,
+    evidenceAvailable: true,
+    findings: [permissionFinding],
+    inputHashes,
+    migrationIdentities: staticReport.migrationIdentities,
+    outcome: "PASS",
+    runId: input.runId,
+    subjectCommit: resolvedSubject,
+  })
+}

--- a/scripts/db-quality-gate/static-changed-files.ts
+++ b/scripts/db-quality-gate/static-changed-files.ts
@@ -1,0 +1,32 @@
+import { collectChangedFiles } from "../changed-files"
+import { isCanonicalMigrationPath } from "./migration-source"
+import { INVARIANTS_PATH, SQL_TESTS_PATH } from "./static-lane-expected-state"
+
+/** Default comparison ref for ordinary diff-aware static gate runs. */
+export const DEFAULT_STATIC_BASE_REF = "origin/main"
+/** Canonical repository directory containing forward migration sources. */
+export const DEFAULT_MIGRATION_ROOT = "supabase/migrations"
+/** Append-only registry of migrations verified as applied to live. */
+export const APPLIED_LOCK_PATH = "supabase/applied-migrations.lock.json"
+/** Baseline registry used for no-new-regression static policy checks. */
+export const BASELINE_PATH = "supabase/db-quality-gate-baseline.json"
+/** Exact-bound approval registry for dangerous migration findings. */
+export const WAIVERS_PATH = "supabase/db-quality-gate-waivers.json"
+
+/** Narrows a repository diff to canonical migrations and static-gate metadata. */
+export function staticChangedFiles(changedFiles: string[]): string[] {
+  return changedFiles.filter(
+    (filePath: string) =>
+      isCanonicalMigrationPath(filePath) ||
+      filePath === APPLIED_LOCK_PATH ||
+      filePath === BASELINE_PATH ||
+      filePath === INVARIANTS_PATH ||
+      filePath === SQL_TESTS_PATH ||
+      filePath === WAIVERS_PATH
+  )
+}
+
+/** Collects the ordinary static-lane diff using the production default base ref. */
+export function collectStaticChangedFiles(baseRef = DEFAULT_STATIC_BASE_REF): string[] {
+  return staticChangedFiles(collectChangedFiles(baseRef))
+}

--- a/scripts/db-quality-gate/static-lane-types.ts
+++ b/scripts/db-quality-gate/static-lane-types.ts
@@ -1,0 +1,12 @@
+export type StaticLaneInput = {
+  baseRef?: string
+  changedFiles?: string[]
+  createdAt: string
+  repositoryRoot: string
+  runId: string
+  subjectCommit: string
+}
+
+export type LandedStaticLaneInput = Omit<StaticLaneInput, "baseRef" | "changedFiles"> & {
+  landedParentCommit: string
+}

--- a/scripts/db-quality-gate/static-lane.ts
+++ b/scripts/db-quality-gate/static-lane.ts
@@ -1,12 +1,11 @@
-import { collectChangedFiles } from "../changed-files"
 import { compareFindingBaseline, parseIdentityBaseline } from "./baseline"
 import {
   inspectCanonicalMigrationSource,
   inspectCanonicalMigrationSourceAtCommit,
-  isCanonicalMigrationPath,
 } from "./migration-source"
 import { inspectMigrationRepository } from "./migration-repository"
 import { currentHeadCommit } from "./git-evidence"
+import { resolveLandedStaticDiff, type TrustedStaticDiff } from "./landed-static-diff"
 import { attachDangerousApprovals } from "./static-approvals"
 import {
   hasTrustedIdentityBaseline,
@@ -39,42 +38,27 @@ import {
   INVARIANTS_PATH,
   SQL_TESTS_PATH,
 } from "./static-lane-expected-state"
+import {
+  APPLIED_LOCK_PATH,
+  BASELINE_PATH,
+  collectStaticChangedFiles,
+  DEFAULT_MIGRATION_ROOT,
+  DEFAULT_STATIC_BASE_REF,
+  staticChangedFiles,
+  WAIVERS_PATH,
+} from "./static-changed-files"
 import { finalizeStaticLaneReport } from "./static-lane-report"
+import type { LandedStaticLaneInput, StaticLaneInput } from "./static-lane-types"
 import type { GateReport } from "./types"
 
-type StaticLaneInput = {
-  baseRef?: string
-  changedFiles?: string[]
-  createdAt: string
-  repositoryRoot: string
-  runId: string
-  subjectCommit: string
-}
-
-const DEFAULT_BASE_REF = "origin/main"
-const DEFAULT_MIGRATION_ROOT = "supabase/migrations"
-const APPLIED_LOCK_PATH = "supabase/applied-migrations.lock.json"
-const BASELINE_PATH = "supabase/db-quality-gate-baseline.json"
-const WAIVERS_PATH = "supabase/db-quality-gate-waivers.json"
-
-/** Reuses the repository diff helper and narrows it to canonical migrations plus static-gate metadata. */
-export function collectStaticChangedFiles(baseRef = DEFAULT_BASE_REF): string[] {
-  return collectChangedFiles(baseRef).filter(
-    (filePath: string) =>
-      isCanonicalMigrationPath(filePath) ||
-      filePath === APPLIED_LOCK_PATH ||
-      filePath === BASELINE_PATH ||
-      filePath === INVARIANTS_PATH ||
-      filePath === SQL_TESTS_PATH ||
-      filePath === WAIVERS_PATH
-  )
-}
-
-/** Runs deterministic local-only static checks for the current repository state. */
-export function runStaticLane(input: StaticLaneInput): GateReport {
-  const testOverridesAllowed = process.env.NODE_ENV === "test"
+function runStaticLaneInternal(
+  input: StaticLaneInput,
+  trustedDiff?: TrustedStaticDiff
+): GateReport {
+  const testOverridesAllowed = trustedDiff === undefined && process.env.NODE_ENV === "test"
   const baseRef =
-    testOverridesAllowed && input.baseRef !== undefined ? input.baseRef : DEFAULT_BASE_REF
+    trustedDiff?.baseRef ??
+    (testOverridesAllowed && input.baseRef !== undefined ? input.baseRef : DEFAULT_STATIC_BASE_REF)
   const headCommit = currentHeadCommit(input.repositoryRoot)
   const subjectCommit = headCommit ?? "unavailable"
   const subjectEvidenceUnavailable = headCommit === undefined || input.subjectCommit !== headCommit
@@ -97,9 +81,14 @@ export function runStaticLane(input: StaticLaneInput): GateReport {
       sourceInspection.migrationIdentities,
       sourceAtHead.migrationIdentities
     )
-  let changedFileDiscoveryUnavailable = false
-  let changedFiles = testOverridesAllowed ? input.changedFiles : undefined
-  if (!testOverridesAllowed && (input.baseRef !== undefined || input.changedFiles !== undefined)) {
+  let changedFileDiscoveryUnavailable = trustedDiff?.unavailable ?? false
+  let changedFiles =
+    trustedDiff?.changedFiles ?? (testOverridesAllowed ? input.changedFiles : undefined)
+  if (
+    trustedDiff === undefined &&
+    !testOverridesAllowed &&
+    (input.baseRef !== undefined || input.changedFiles !== undefined)
+  ) {
     changedFileDiscoveryUnavailable = true
   }
   if (changedFiles === undefined) {
@@ -325,3 +314,31 @@ export function runStaticLane(input: StaticLaneInput): GateReport {
     subjectCommit,
   })
 }
+
+/** Runs deterministic local-only static checks with ordinary production defaults unchanged. */
+export function runStaticLane(input: StaticLaneInput): GateReport {
+  return runStaticLaneInternal(input)
+}
+
+/**
+ * Runs static checks over the exact landed first-parent diff after independently binding both SHAs.
+ */
+export function runStaticLaneForLandedCommit(input: LandedStaticLaneInput): GateReport {
+  const trustedDiff = resolveLandedStaticDiff(input)
+
+  return runStaticLaneInternal(
+    {
+      createdAt: input.createdAt,
+      repositoryRoot: input.repositoryRoot,
+      runId: input.runId,
+      subjectCommit: input.subjectCommit,
+    },
+    {
+      ...trustedDiff,
+      changedFiles: staticChangedFiles(trustedDiff.changedFiles),
+    }
+  )
+}
+
+export { collectStaticChangedFiles }
+export type { LandedStaticLaneInput }


### PR DESCRIPTION
## Summary
- implement exact landed-SHA static and immutable Oracle baseline-forward evidence checks
- add strict read-only Supabase MCP live observation reconciliation and fail-closed CLI wiring
- emit explicit-permission warning and document the MCP live-apply handoff
- complete OpenSpec Phase 6 tasks 6.1-6.4 and test matrix rows 1-7

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- verify:ts-docstrings
- typecheck
- focused pre-live tests: 54 passed
- all database quality gate tests: 234 passed
- React Doctor: 100/100
- openspec validate add-database-quality-gate --strict

Part of #931

No migration SQL, registry content, ruleset, live database, or Oracle baseline state was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Phase 6 “pre-live” quality gate checkpoint to verify exact landed evidence and enforce an explicit-permission boundary before any live write. Previously a PASS could rely on PR-head evidence; now pre-live requires PASS reports for the exact landed SHA plus a read-only Supabase MCP observation, and it never performs writes.

- Implements a `pre-live` lane in the CLI that:
  - Requires `--run-id`, `--subject-commit`, `--static-run-id`, `--baseline-forward-run-id`, `--baseline-forward-digest`, and `--live-observation`.
  - Rejects `--created-at` (uses a trusted internal clock) and any unknown inputs; fails closed on unavailable evidence.
  - Produces PASS with a warning `prelive.permission.explicit-required` when static, baseline-forward, baseline state, and live observation all reconcile; produces FAILED when live high-water exceeds Oracle; otherwise INCOMPLETE.
- Adds an immutable Oracle evidence store:
  - Safe artifact publication using restrictive temp files; no clobber on duplicates; strict run ID and artifact name validation; baseline state reader.
- Binds static evidence to the exact landed diff:
  - New `runStaticLaneForLandedCommit` uses the first parent of the landed commit and exact changed paths; normal `static` defaults unchanged.
- Strengthens Git and evidence validation:
  - Credential-free HTTPS-only refresh of `origin/main`; local or credentialed remotes are rejected.
  - Parses and validates persisted reports (lane, outcome, digest, runId, subjectCommit) and recomputes baseline-forward input hashes from the landed commit.
- Validates live state without opening a DB connection:
  - Strict parsing of Supabase MCP observation (project-bound, time-bounded, ordered, deduped) and exact matching against `applied-migrations.lock` and Oracle baseline.
- Updates docs with the explicit-permission MCP handoff; marks OpenSpec tasks 6.1–6.4 complete. No SQL, registries, rulesets, live DB, or Oracle baseline state changed.

- Review/usage notes:
  - To run pre-live, first produce and persist static and baseline-forward reports at the landed SHA, then invoke the CLI with the exact run IDs and baseline-forward digest and provide the MCP live observation JSON path.
  - Operators must request explicit permission bound to the exact `landedSha` and verified evidence IDs/digests; apply only via Supabase MCP; capture and persist the post-apply observation as documented.

<sup>Written for commit 48e92e52841576124e14ee89dc5ffebf9b4dfdc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

